### PR TITLE
Cleaner includes when using repo as submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,10 +66,10 @@ add_library(log_surgeon ${SOURCE_FILES})
 add_library(log_surgeon::log_surgeon ALIAS log_surgeon)
 target_include_directories(log_surgeon
     PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/log_surgeon>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/log_surgeon
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
     )
 
 target_compile_features(log_surgeon


### PR DESCRIPTION
# Description
Changed CMakeLists such that projects using log_surgeon can include headers with #include<log_surgeon/header.hpp

