### PR TITLE
Added vars to schema object; fixed 2 timestamp bugs; fixed 1 buffer bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ target_include_directories(log_surgeon
     )
 
 target_compile_features(log_surgeon
-    PRIVATE cxx_std_17
+    PRIVATE cxx_std_20
     )
 
 target_compile_options(log_surgeon PRIVATE

--- a/src/log_surgeon/LALR1Parser.tpp
+++ b/src/log_surgeon/LALR1Parser.tpp
@@ -227,7 +227,7 @@ void LALR1Parser<NFAStateType, DFAStateType>::generate_lr0_closure(ItemSet* item
             assert(false);
         }
         for (Production* const p : m_non_terminals.at(next_symbol)) {  // S -> a
-            q.emplace_back(p, 0, cNullSymbol);                         // {S -> (dot) a, ""}
+            q.emplace_back(p, 0, cNullSymbol);  // {S -> (dot) a, ""}
         }
     }
 }

--- a/src/log_surgeon/LALR1Parser.tpp
+++ b/src/log_surgeon/LALR1Parser.tpp
@@ -227,7 +227,7 @@ void LALR1Parser<NFAStateType, DFAStateType>::generate_lr0_closure(ItemSet* item
             assert(false);
         }
         for (Production* const p : m_non_terminals.at(next_symbol)) {  // S -> a
-            q.emplace_back(p, 0, cNullSymbol);  // {S -> (dot) a, ""}
+            q.emplace_back(p, 0, cNullSymbol);                         // {S -> (dot) a, ""}
         }
     }
 }

--- a/src/log_surgeon/Lexer.hpp
+++ b/src/log_surgeon/Lexer.hpp
@@ -113,6 +113,17 @@ public:
     auto scan_with_wildcard(ParserInputBuffer& input_buffer, char wildcard, Token& token)
             -> ErrorCode;
 
+    /**
+     * Grows the capacity of the passed in input buffer if it is not large 
+     * enough to store the contents of an entire LogEvent. Then, adjusts any
+     * values being tracked in the lexer related to the input buffer if needed.
+     * @param parser_input_buffer Buffer which size needs to be checked.
+     * @return ErrorCode::Success
+     * @throw It is possible for std::bad_alloc to be thrown in the case
+     * allocation of the new buffer fails.
+     */
+    auto increase_buffer_capacity(ParserInputBuffer& input_buffer);
+
     [[nodiscard]] auto get_has_delimiters() const -> bool const& { return m_has_delimiters; }
 
     [[nodiscard]] auto is_delimiter(uint8_t byte) const -> bool const& {

--- a/src/log_surgeon/Lexer.hpp
+++ b/src/log_surgeon/Lexer.hpp
@@ -114,7 +114,7 @@ public:
             -> ErrorCode;
 
     /**
-     * Grows the capacity of the passed in input buffer if it is not large 
+     * Grows the capacity of the passed in input buffer if it is not large
      * enough to store the contents of an entire LogEvent. Then, adjusts any
      * values being tracked in the lexer related to the input buffer if needed.
      * @param parser_input_buffer Buffer which size needs to be checked.

--- a/src/log_surgeon/Lexer.hpp
+++ b/src/log_surgeon/Lexer.hpp
@@ -118,11 +118,8 @@ public:
      * enough to store the contents of an entire LogEvent. Then, adjusts any
      * values being tracked in the lexer related to the input buffer if needed.
      * @param parser_input_buffer Buffer which size needs to be checked.
-     * @return ErrorCode::Success
-     * @throw It is possible for std::bad_alloc to be thrown in the case
-     * allocation of the new buffer fails.
      */
-    auto increase_buffer_capacity(ParserInputBuffer& input_buffer);
+    auto increase_buffer_capacity(ParserInputBuffer& input_buffer) -> void;
 
     [[nodiscard]] auto get_has_delimiters() const -> bool const& { return m_has_delimiters; }
 

--- a/src/log_surgeon/Lexer.tpp
+++ b/src/log_surgeon/Lexer.tpp
@@ -299,6 +299,26 @@ auto Lexer<NFAStateType, DFAStateType>::scan_with_wildcard(
 }
 
 template <typename NFAStateType, typename DFAStateType>
+auto Lexer<NFAStateType, DFAStateType>::increase_buffer_capacity(ParserInputBuffer& input_buffer) {
+    uint32_t old_storage_size{0};
+    bool flipped_static_buffer{false};
+    if (ErrorCode err = input_buffer.increase_capacity(old_storage_size, flipped_static_buffer);
+        ErrorCode::Success != err) {
+        return err;
+    }
+    if (old_storage_size < input_buffer.storage().size()) {
+        if (flipped_static_buffer) {
+            flip_states(old_storage_size);
+        }
+        if (0 == m_last_match_pos) {
+            m_last_match_pos = old_storage_size;
+            m_start_pos = old_storage_size;
+        }
+    }
+    return ErrorCode::Success;
+}
+
+template <typename NFAStateType, typename DFAStateType>
 void Lexer<NFAStateType, DFAStateType>::reset() {
     m_last_match_pos = 0;
     m_match = false;

--- a/src/log_surgeon/Lexer.tpp
+++ b/src/log_surgeon/Lexer.tpp
@@ -299,14 +299,11 @@ auto Lexer<NFAStateType, DFAStateType>::scan_with_wildcard(
 }
 
 template <typename NFAStateType, typename DFAStateType>
-auto Lexer<NFAStateType, DFAStateType>::increase_buffer_capacity(ParserInputBuffer& input_buffer) {
+auto Lexer<NFAStateType, DFAStateType>::increase_buffer_capacity(ParserInputBuffer& input_buffer)
+        -> void {
     uint32_t old_storage_size{0};
     bool flipped_static_buffer{false};
-    if (ErrorCode err = input_buffer.increase_capacity(old_storage_size, flipped_static_buffer);
-        ErrorCode::Success != err)
-    {
-        return err;
-    }
+    input_buffer.increase_capacity(old_storage_size, flipped_static_buffer);
     if (old_storage_size < input_buffer.storage().size()) {
         if (flipped_static_buffer) {
             flip_states(old_storage_size);
@@ -316,7 +313,6 @@ auto Lexer<NFAStateType, DFAStateType>::increase_buffer_capacity(ParserInputBuff
             m_start_pos = old_storage_size;
         }
     }
-    return ErrorCode::Success;
 }
 
 template <typename NFAStateType, typename DFAStateType>

--- a/src/log_surgeon/Lexer.tpp
+++ b/src/log_surgeon/Lexer.tpp
@@ -303,7 +303,8 @@ auto Lexer<NFAStateType, DFAStateType>::increase_buffer_capacity(ParserInputBuff
     uint32_t old_storage_size{0};
     bool flipped_static_buffer{false};
     if (ErrorCode err = input_buffer.increase_capacity(old_storage_size, flipped_static_buffer);
-        ErrorCode::Success != err) {
+        ErrorCode::Success != err)
+    {
         return err;
     }
     if (old_storage_size < input_buffer.storage().size()) {

--- a/src/log_surgeon/LogParser.cpp
+++ b/src/log_surgeon/LogParser.cpp
@@ -163,8 +163,10 @@ auto LogParser::parse(
             if(false == output_buffer->has_timestamp() &&
                 next_token.m_type_ids_ptr->at(0) == (int)SymbolID::TokenNewlineTimestampId) 
             {
-                /// TODO: combine with found_start_of_next_message into 1 function
-                // increment by 1 because the '\n' character is not part of the next log message
+                // TODO: combine with found_start_of_next_message into 1
+                //  function
+                // increment by 1 because the '\n' character is not part of the
+                // next log message
                 m_start_of_log_message = next_token;
                 if (m_start_of_log_message.m_start_pos == m_start_of_log_message.m_buffer_size - 1) {
                     m_start_of_log_message.m_start_pos = 0;

--- a/src/log_surgeon/LogParser.cpp
+++ b/src/log_surgeon/LogParser.cpp
@@ -160,23 +160,24 @@ auto LogParser::parse(
             if (ErrorCode err = get_next_symbol(next_token); ErrorCode::Success != err) {
                 return err;
             }
-            if(false == output_buffer->has_timestamp() &&
-                next_token.m_type_ids_ptr->at(0) == (int)SymbolID::TokenNewlineTimestampId) 
+            if (false == output_buffer->has_timestamp()
+                && next_token.m_type_ids_ptr->at(0) == (int)SymbolID::TokenNewlineTimestampId)
             {
                 // TODO: combine with found_start_of_next_message into 1
                 //  function
                 // increment by 1 because the '\n' character is not part of the
                 // next log message
                 m_start_of_log_message = next_token;
-                if (m_start_of_log_message.m_start_pos == m_start_of_log_message.m_buffer_size - 1) {
+                if (m_start_of_log_message.m_start_pos == m_start_of_log_message.m_buffer_size - 1)
+                {
                     m_start_of_log_message.m_start_pos = 0;
                 } else {
                     m_start_of_log_message.m_start_pos++;
                 }
                 // make a message with just the '\n' character
                 next_token.m_end_pos = next_token.m_start_pos + 1;
-                next_token.m_type_ids_ptr =
-                        &Lexer<RegexNFAByteState, RegexDFAByteState>::cTokenUncaughtStringTypes;
+                next_token.m_type_ids_ptr
+                        = &Lexer<RegexNFAByteState, RegexDFAByteState>::cTokenUncaughtStringTypes;
                 output_buffer->set_token(1, next_token);
                 output_buffer->set_pos(2);
                 m_input_buffer.set_consumed_pos(next_token.m_start_pos);

--- a/src/log_surgeon/LogParser.cpp
+++ b/src/log_surgeon/LogParser.cpp
@@ -160,6 +160,28 @@ auto LogParser::parse(
             if (ErrorCode err = get_next_symbol(next_token); ErrorCode::Success != err) {
                 return err;
             }
+            if(false == output_buffer->has_timestamp() &&
+                next_token.m_type_ids_ptr->at(0) == (int)SymbolID::TokenNewlineTimestampId) 
+            {
+                /// TODO: combine with found_start_of_next_message into 1 function
+                // increment by 1 because the '\n' character is not part of the next log message
+                m_start_of_log_message = next_token;
+                if (m_start_of_log_message.m_start_pos == m_start_of_log_message.m_buffer_size - 1) {
+                    m_start_of_log_message.m_start_pos = 0;
+                } else {
+                    m_start_of_log_message.m_start_pos++;
+                }
+                // make a message with just the '\n' character
+                next_token.m_end_pos = next_token.m_start_pos + 1;
+                next_token.m_type_ids_ptr =
+                        &Lexer<RegexNFAByteState, RegexDFAByteState>::cTokenUncaughtStringTypes;
+                output_buffer->set_token(1, next_token);
+                output_buffer->set_pos(2);
+                m_input_buffer.set_consumed_pos(next_token.m_start_pos);
+                m_has_start_of_log = true;
+                parsing_action = ParsingAction::Compress;
+                return ErrorCode::Success;
+            }
         }
         if (next_token.m_type_ids_ptr->at(0) == (int)SymbolID::TokenEndID) {
             output_buffer->set_token(0, next_token);

--- a/src/log_surgeon/LogParser.cpp
+++ b/src/log_surgeon/LogParser.cpp
@@ -165,9 +165,9 @@ auto LogParser::parse(
             if (false == output_buffer->has_timestamp()
                 && next_token.m_type_ids_ptr->at(0) == (int)SymbolID::TokenNewlineTimestampId)
             {
-                // TODO: combine with found_start_of_next_message into 1
-                //  function
-                // increment by 1 because the '\n' character is not part of the
+                // TODO: combine the below with found_start_of_next_message
+                // into 1 function
+                // Increment by 1 because the '\n' character is not part of the
                 // next log message
                 m_start_of_log_message = next_token;
                 if (m_start_of_log_message.m_start_pos == m_start_of_log_message.m_buffer_size - 1)

--- a/src/log_surgeon/LogParser.cpp
+++ b/src/log_surgeon/LogParser.cpp
@@ -35,7 +35,9 @@ LogParser::LogParser(string const& schema_file_path) : m_has_start_of_log(false)
 }
 
 LogParser::LogParser(SchemaAST const* schema_ast) : m_has_start_of_log(false) {
-    add_delimiters(schema_ast->m_delimiters);
+    for (auto const& delimiters : schema_ast->m_delimiters) {
+        add_delimiters(delimiters);
+    }
     add_rules(schema_ast);
     m_lexer.generate();
 }

--- a/src/log_surgeon/LogParser.hpp
+++ b/src/log_surgeon/LogParser.hpp
@@ -13,7 +13,7 @@
 #include <log_surgeon/SchemaParser.hpp>
 
 namespace log_surgeon {
-/// TODO: Compare c-array vs. vectors (its underlying array) for buffers
+// TODO: Compare c-array vs. vectors (its underlying array) for buffers
 class LogParser
         : public Parser<finite_automata::RegexNFAByteState, finite_automata::RegexDFAByteState> {
 public:
@@ -141,7 +141,7 @@ private:
      */
     auto add_rules(SchemaAST const* schema_ast) -> void;
 
-    /// TODO: move ownership of the buffer to the lexer
+    // TODO: move ownership of the buffer to the lexer
     ParserInputBuffer m_input_buffer;
     bool m_has_start_of_log;
     Token m_start_of_log_message{};

--- a/src/log_surgeon/LogParser.hpp
+++ b/src/log_surgeon/LogParser.hpp
@@ -108,13 +108,8 @@ public:
     /**
      * Grows the capacity of the input buffer if it is not large enough to store
      * the contents of an entire LogEvent.
-     * @return ErrorCode::Success
-     * @throw It is possible for std::bad_alloc to be thrown in the case
-     * allocation of the new buffer fails.
      */
-    auto increase_capacity() -> ErrorCode {
-        return m_lexer.increase_buffer_capacity(m_input_buffer);
-    }
+    auto increase_capacity() -> void { m_lexer.increase_buffer_capacity(m_input_buffer); }
 
 private:
     /**

--- a/src/log_surgeon/LogParser.hpp
+++ b/src/log_surgeon/LogParser.hpp
@@ -141,7 +141,7 @@ private:
      */
     auto add_rules(SchemaAST const* schema_ast) -> void;
 
-    /// TODO: lexer should own the buffer, not the parser
+    /// TODO: move ownership of the buffer to the lexer
     ParserInputBuffer m_input_buffer;
     bool m_has_start_of_log;
     Token m_start_of_log_message{};

--- a/src/log_surgeon/LogParser.hpp
+++ b/src/log_surgeon/LogParser.hpp
@@ -113,7 +113,6 @@ public:
      * allocation of the new buffer fails.
      */
     auto increase_capacity() -> ErrorCode {
-        /// TODO: is the lexer suppose to own the buffer and not the parser?
         return m_lexer.increase_buffer_capacity(m_input_buffer);
     }
 
@@ -142,6 +141,7 @@ private:
      */
     auto add_rules(SchemaAST const* schema_ast) -> void;
 
+    /// TODO: lexer should own the buffer, not the parser
     ParserInputBuffer m_input_buffer;
     bool m_has_start_of_log;
     Token m_start_of_log_message{};

--- a/src/log_surgeon/LogParser.hpp
+++ b/src/log_surgeon/LogParser.hpp
@@ -58,15 +58,6 @@ public:
     auto parse(std::unique_ptr<LogParserOutputBuffer>& output_buffer, ParsingAction& parsing_action)
             -> ErrorCode;
 
-    /**
-     * Flips the lexer states to match the static buffer flipping.
-     * @param old_storage_size The previous buffer size used to calculate the
-     * new states inside the flipped buffer.
-     */
-    auto flip_lexer_states(uint32_t old_storage_size) -> void {
-        m_lexer.flip_states(old_storage_size);
-    }
-
     // TODO protect against invalid id (use optional) and make const
     /**
      * @param id The integer ID of the symbol from the schema.
@@ -117,18 +108,13 @@ public:
     /**
      * Grows the capacity of the input buffer if it is not large enough to store
      * the contents of an entire LogEvent.
-     * @param old_storage_size Populated with the previous size of the input
-     * buffer.
-     * @param flipped_static_buffer Populated with whether the buffer needed to
-     * be flipped while copying. If true then the second half of the old buffer
-     * contained data preceeding the first half of the old buffer. The order of
-     * data in the new buffer will be sequential.
      * @return ErrorCode::Success
      * @throw It is possible for std::bad_alloc to be thrown in the case
      * allocation of the new buffer fails.
      */
-    auto increase_capacity(uint32_t& old_storage_size, bool& flipped_static_buffer) -> ErrorCode {
-        return m_input_buffer.increase_capacity(old_storage_size, flipped_static_buffer);
+    auto increase_capacity() -> ErrorCode {
+        /// TODO: is the lexer suppose to own the buffer and not the parser?
+        return m_lexer.increase_buffer_capacity(m_input_buffer);
     }
 
 private:

--- a/src/log_surgeon/ParserInputBuffer.cpp
+++ b/src/log_surgeon/ParserInputBuffer.cpp
@@ -62,7 +62,7 @@ auto ParserInputBuffer::read(Reader& reader) -> ErrorCode {
 }
 
 auto ParserInputBuffer::increase_capacity(uint32_t& old_storage_size, bool& flipped_static_buffer)
-        -> ErrorCode {
+        -> void {
     old_storage_size = m_storage.size();
     uint32_t new_storage_size = old_storage_size * 2;
     flipped_static_buffer = false;
@@ -81,7 +81,6 @@ auto ParserInputBuffer::increase_capacity(uint32_t& old_storage_size, bool& flip
     m_last_read_first_half = true;
     m_pos_last_read_char = new_storage_size - old_storage_size;
     m_storage.set_pos(old_storage_size);
-    return ErrorCode::Success;
 }
 
 auto ParserInputBuffer::get_next_character(unsigned char& next_char) -> ErrorCode {

--- a/src/log_surgeon/ParserInputBuffer.hpp
+++ b/src/log_surgeon/ParserInputBuffer.hpp
@@ -53,9 +53,9 @@ public:
      * content stored in the second half precedes the content stored in the
      * first half in the original log.
      * @param old_storage_size
-     * @return if old buffer was flipped when creating new buffer
+     * @param flipped_static_buffer
      */
-    auto increase_capacity(uint32_t& old_storage_size, bool& flipped_static_buffer) -> ErrorCode;
+    auto increase_capacity(uint32_t& old_storage_size, bool& flipped_static_buffer) -> void;
 
     /**
      * Attempt to get the next character from the input buffer.

--- a/src/log_surgeon/ReaderParser.cpp
+++ b/src/log_surgeon/ReaderParser.cpp
@@ -34,9 +34,7 @@ auto ReaderParser::get_next_event_view(LogEventView& event_view) -> ErrorCode {
             break;
         }
         if (ErrorCode::BufferOutOfBounds == parse_error) {
-            if (ErrorCode err = m_log_parser.increase_capacity(); ErrorCode::Success != err) {
-                return err;
-            }
+            m_log_parser.increase_capacity();
             if (ErrorCode err = m_log_parser.read_into_input(m_reader);
                 ErrorCode::Success != err && ErrorCode::EndOfFile != err)
             {

--- a/src/log_surgeon/ReaderParser.cpp
+++ b/src/log_surgeon/ReaderParser.cpp
@@ -34,16 +34,8 @@ auto ReaderParser::get_next_event_view(LogEventView& event_view) -> ErrorCode {
             break;
         }
         if (ErrorCode::BufferOutOfBounds == parse_error) {
-            uint32_t old_storage_size{0};
-            bool flipped_static_buffer{false};
-            if (ErrorCode err
-                = m_log_parser.increase_capacity(old_storage_size, flipped_static_buffer);
-                ErrorCode::Success != err)
-            {
+            if (ErrorCode err = m_log_parser.increase_capacity(); ErrorCode::Success != err) {
                 return err;
-            }
-            if (flipped_static_buffer) {
-                m_log_parser.flip_lexer_states(old_storage_size);
             }
             if (ErrorCode err = m_log_parser.read_into_input(m_reader);
                 ErrorCode::Success != err && ErrorCode::EndOfFile != err)

--- a/src/log_surgeon/Schema.cpp
+++ b/src/log_surgeon/Schema.cpp
@@ -6,8 +6,8 @@ namespace log_surgeon {
 Schema::Schema(std::string const& schema_file_path)
         : m_schema_ast{SchemaParser::try_schema_file(schema_file_path)} {}
 
-auto Schema::add_variable (const std::string& var_name, const std::string& regex, 
-                           int priority) -> void {
+auto Schema::add_variable(const std::string& var_name, const std::string& regex, int priority)
+        -> void {
     std::string unparsed_string = var_name + ":" + regex;
     std::unique_ptr<SchemaAST> schema_ast = SchemaParser::try_schema_string(unparsed_string);
     m_schema_ast->add_schema_var(std::move(schema_ast->m_schema_vars[0]), priority);

--- a/src/log_surgeon/Schema.cpp
+++ b/src/log_surgeon/Schema.cpp
@@ -6,7 +6,7 @@ namespace log_surgeon {
 Schema::Schema(std::string const& schema_file_path)
         : m_schema_ast{SchemaParser::try_schema_file(schema_file_path)} {}
 
-auto Schema::add_variable(const std::string& var_name, const std::string& regex, int priority)
+auto Schema::add_variable(std::string const& var_name, std::string const& regex, int priority)
         -> void {
     std::string unparsed_string = var_name + ":" + regex;
     std::unique_ptr<SchemaAST> schema_ast = SchemaParser::try_schema_string(unparsed_string);

--- a/src/log_surgeon/Schema.cpp
+++ b/src/log_surgeon/Schema.cpp
@@ -5,4 +5,11 @@
 namespace log_surgeon {
 Schema::Schema(std::string const& schema_file_path)
         : m_schema_ast{SchemaParser::try_schema_file(schema_file_path)} {}
+
+auto Schema::add_variable (const std::string& var_name, const std::string& regex, 
+                           int priority) -> void {
+    std::string unparsed_string = var_name + ":" + regex;
+    std::unique_ptr<SchemaAST> schema_ast = SchemaParser::try_schema_string(unparsed_string);
+    m_schema_ast->add_schema_var(std::move(schema_ast->m_schema_vars[0]), priority);
+}
 }  // namespace log_surgeon

--- a/src/log_surgeon/Schema.hpp
+++ b/src/log_surgeon/Schema.hpp
@@ -18,16 +18,15 @@ public:
 
     explicit Schema(std::string const& schema_file_path);
 
-    /** 
+    /**
      * Parses var_name+":"+regex as if it were its own entire schema file. Then extracts the
-     * SchemaVarAST from the resulting SchemaAST and adds it to m_schema_vars in m_schema_ast. 
+     * SchemaVarAST from the resulting SchemaAST and adds it to m_schema_vars in m_schema_ast.
      * Position in m_schema_vars is determined by the priority (priority == -1 to set to lowest).
-     * @param var_name 
-     * @param regex 
+     * @param var_name
+     * @param regex
      * @param priority
      */
-    auto add_variable (const std::string& var_name, const std::string& regex, 
-                       int priority) -> void;
+    auto add_variable(const std::string& var_name, const std::string& regex, int priority) -> void;
 
     /* Work in progress API to modify a schema object
 

--- a/src/log_surgeon/Schema.hpp
+++ b/src/log_surgeon/Schema.hpp
@@ -26,7 +26,7 @@ public:
      * @param regex
      * @param priority
      */
-    auto add_variable(const std::string& var_name, const std::string& regex, int priority) -> void;
+    auto add_variable(std::string const& var_name, std::string const& regex, int priority) -> void;
 
     /* Work in progress API to modify a schema object
 

--- a/src/log_surgeon/Schema.hpp
+++ b/src/log_surgeon/Schema.hpp
@@ -18,9 +18,18 @@ public:
 
     explicit Schema(std::string const& schema_file_path);
 
-    /* Work in progress API to modify a schema object
+    /** 
+     * Parses var_name+":"+regex as if it were its own entire schema file. Then extracts the
+     * SchemaVarAST from the resulting SchemaAST and adds it to m_schema_vars in m_schema_ast. 
+     * Position in m_schema_vars is determined by the priority (priority == -1 to set to lowest).
+     * @param var_name 
+     * @param regex 
+     * @param priority
+     */
+    auto add_variable (const std::string& var_name, const std::string& regex, 
+                       int priority) -> void;
 
-    auto add_variable (std::string& var_name, std::string& regex) -> void;
+    /* Work in progress API to modify a schema object
 
     auto remove_variable (std::string var_name) -> void;
 

--- a/src/log_surgeon/SchemaParser.cpp
+++ b/src/log_surgeon/SchemaParser.cpp
@@ -128,7 +128,7 @@ static auto new_schema_rule_with_var(NonTerminal* m) -> unique_ptr<SchemaAST> {
 static auto new_schema_rule_with_delimiters(NonTerminal* m) -> unique_ptr<SchemaAST> {
     unique_ptr<ParserAST>& r1 = m->non_terminal_cast(2)->get_parser_ast();
     unique_ptr<SchemaAST> schema_ast = make_unique<SchemaAST>();
-    schema_ast->set_delimiters(std::move(r1));
+    schema_ast->add_delimiters(std::move(r1));
     return schema_ast;
 }
 
@@ -136,7 +136,7 @@ static auto existing_schema_rule_with_delimiter(NonTerminal* m) -> unique_ptr<Sc
     unique_ptr<ParserAST>& r1 = m->non_terminal_cast(0)->get_parser_ast();
     std::unique_ptr<SchemaAST> schema_ast(dynamic_cast<SchemaAST*>(r1.release()));
     unique_ptr<ParserAST>& r5 = m->non_terminal_cast(4)->get_parser_ast();
-    schema_ast->set_delimiters(std::move(r5));
+    schema_ast->add_delimiters(std::move(r5));
     return schema_ast;
 }
 

--- a/src/log_surgeon/SchemaParser.cpp
+++ b/src/log_surgeon/SchemaParser.cpp
@@ -83,7 +83,7 @@ auto SchemaParser::try_schema_string(string const& schema_string) -> unique_ptr<
              return ErrorCode::EndOfFile;
         }
         for(uint32_t i = 0; i < count; i++) {
-            *(buf + i) = schema_string[unparsed_string_pos + i];
+            buf[i] = schema_string[unparsed_string_pos + i];
         }
         unparsed_string_pos += count;
         return ErrorCode::Success;

--- a/src/log_surgeon/SchemaParser.cpp
+++ b/src/log_surgeon/SchemaParser.cpp
@@ -77,14 +77,14 @@ auto SchemaParser::try_schema_string(string const& schema_string) -> unique_ptr<
     Reader reader{[&](char* dst_buf, size_t count, size_t& read_to) -> ErrorCode {
         uint32_t unparsed_string_pos = 0;
         std::span<char> const buf{dst_buf, count};
-        if(unparsed_string_pos + count > schema_string.length()) {
+        if (unparsed_string_pos + count > schema_string.length()) {
             count = schema_string.length() - unparsed_string_pos;
         }
         read_to = count;
-        if(read_to == 0) {
-             return ErrorCode::EndOfFile;
+        if (read_to == 0) {
+            return ErrorCode::EndOfFile;
         }
-        for(uint32_t i = 0; i < count; i++) {
+        for (uint32_t i = 0; i < count; i++) {
             buf[i] = schema_string[unparsed_string_pos + i];
         }
         unparsed_string_pos += count;
@@ -388,10 +388,10 @@ static auto new_delimiter_string_rule(NonTerminal* m) -> unique_ptr<ParserAST> {
 }
 
 void SchemaParser::add_lexical_rules() {
-    add_token("Tab", '\t');  // 9
-    add_token("NewLine", '\n');  // 10
-    add_token("VerticalTab", '\v');  // 11
-    add_token("FormFeed", '\f');  // 12
+    add_token("Tab", '\t');             // 9
+    add_token("NewLine", '\n');         // 10
+    add_token("VerticalTab", '\v');     // 11
+    add_token("FormFeed", '\f');        // 12
     add_token("CarriageReturn", '\r');  // 13
     add_token("Space", ' ');
     add_token("Bang", '!');

--- a/src/log_surgeon/SchemaParser.cpp
+++ b/src/log_surgeon/SchemaParser.cpp
@@ -388,10 +388,10 @@ static auto new_delimiter_string_rule(NonTerminal* m) -> unique_ptr<ParserAST> {
 }
 
 void SchemaParser::add_lexical_rules() {
-    add_token("Tab", '\t');             // 9
-    add_token("NewLine", '\n');         // 10
-    add_token("VerticalTab", '\v');     // 11
-    add_token("FormFeed", '\f');        // 12
+    add_token("Tab", '\t');  // 9
+    add_token("NewLine", '\n');  // 10
+    add_token("VerticalTab", '\v');  // 11
+    add_token("FormFeed", '\f');  // 12
     add_token("CarriageReturn", '\r');  // 13
     add_token("Space", ' ');
     add_token("Bang", '!');

--- a/src/log_surgeon/SchemaParser.cpp
+++ b/src/log_surgeon/SchemaParser.cpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <memory>
+#include <span>
 #include <stdexcept>
 
 #include <log_surgeon/Constants.hpp>
@@ -73,8 +74,9 @@ auto SchemaParser::try_schema_file(string const& schema_file_path) -> unique_ptr
 }
 
 auto SchemaParser::try_schema_string(string const& schema_string) -> unique_ptr<SchemaAST> {
-    uint32_t unparsed_string_pos = 0;
-    Reader reader{[&](char* buf, size_t count, size_t& read_to) -> ErrorCode {
+    Reader reader{[&](char* dst_buf, size_t count, size_t& read_to) -> ErrorCode {
+        uint32_t unparsed_string_pos = 0;
+        std::span<char> const buf{dst_buf, count};
         if(unparsed_string_pos + count > schema_string.length()) {
             count = schema_string.length() - unparsed_string_pos;
         }

--- a/src/log_surgeon/SchemaParser.hpp
+++ b/src/log_surgeon/SchemaParser.hpp
@@ -17,8 +17,12 @@ public:
         m_delimiters = std::move(delimiters_in);
     }
 
-    auto add_schema_var(std::unique_ptr<ParserAST> schema_var) -> void {
-        m_schema_vars.push_back(std::move(schema_var));
+    auto add_schema_var(std::unique_ptr<ParserAST> schema_var, int32_t pos = -1) -> void {
+        if(pos == -1) {
+            m_schema_vars.push_back(std::move(schema_var));
+        } else {
+            m_schema_vars.insert(m_schema_vars.begin() + pos, std::move(schema_var));
+        }
     }
 
     std::vector<std::unique_ptr<ParserAST>> m_schema_vars;
@@ -79,11 +83,18 @@ public:
     auto existing_schema_rule(NonTerminal* m) -> std::unique_ptr<SchemaAST>;
 
     /**
-     * Wrapper around generate_schema_ast()
+     * File wrapper around generate_schema_ast()
      * @param schema_file_path
      * @return std::unique_ptr<SchemaAST>
      */
     static auto try_schema_file(std::string const& schema_file_path) -> std::unique_ptr<SchemaAST>;
+
+    /**
+     * String wrapper around generate_schema_ast()
+     * @param schema_string
+     * @return std::unique_ptr<SchemaAST>
+     */
+    static auto try_schema_string(std::string const& schema_string) -> std::unique_ptr<SchemaAST>;
 
 private:
     /**

--- a/src/log_surgeon/SchemaParser.hpp
+++ b/src/log_surgeon/SchemaParser.hpp
@@ -12,7 +12,7 @@ public:
     // Constructor
     SchemaAST() = default;
 
-    /// TODO: shouldn't this add delimiters instead of setting it?
+    // TODO: shouldn't this add delimiters instead of setting it?
     auto set_delimiters(std::unique_ptr<ParserAST> delimiters_in) -> void {
         m_delimiters = std::move(delimiters_in);
     }

--- a/src/log_surgeon/SchemaParser.hpp
+++ b/src/log_surgeon/SchemaParser.hpp
@@ -12,9 +12,8 @@ public:
     // Constructor
     SchemaAST() = default;
 
-    // TODO: shouldn't this add delimiters instead of setting it?
-    auto set_delimiters(std::unique_ptr<ParserAST> delimiters_in) -> void {
-        m_delimiters = std::move(delimiters_in);
+    auto add_delimiters(std::unique_ptr<ParserAST> delimiters_in) -> void {
+        m_delimiters.push_back(std::move(delimiters_in));
     }
 
     auto add_schema_var(std::unique_ptr<ParserAST> schema_var, int32_t pos = -1) -> void {
@@ -26,7 +25,7 @@ public:
     }
 
     std::vector<std::unique_ptr<ParserAST>> m_schema_vars;
-    std::unique_ptr<ParserAST> m_delimiters;
+    std::vector<std::unique_ptr<ParserAST>> m_delimiters;
     std::string m_file_path;
 };
 

--- a/src/log_surgeon/SchemaParser.hpp
+++ b/src/log_surgeon/SchemaParser.hpp
@@ -18,7 +18,7 @@ public:
     }
 
     auto add_schema_var(std::unique_ptr<ParserAST> schema_var, int32_t pos = -1) -> void {
-        if(pos == -1) {
+        if (pos == -1) {
             m_schema_vars.push_back(std::move(schema_var));
         } else {
             m_schema_vars.insert(m_schema_vars.begin() + pos, std::move(schema_var));


### PR DESCRIPTION
Added vars to schema object
- try_schema_string function added for string schemas since generate_schema_ast is private
- Schema::add_variable() function added

Fixed 2 timestamp bugs
- Bug fixed, where if a newline preceeded the first newlineTimestamp, the first timestamp log would incorrectly contain a newline
- Similar to the above bug, fixed issue where if nontimestamped logs preceeded a timestamped log, the first timestamp log would incorrectly contain a newline

Fixed 1 buffer bug
- Moved all the functionality for increasing capacity into the log_parser class
- Lexer::increase_buffer_capacity() added
- Case where log ends at the buffer halfway/capacity now properly handled