### PR TITLE
get_logtype() now has correct output; changes to examples to demonstrate get_logtype() behavior

### DIFF
--- a/examples/buffer-parser.cpp
+++ b/examples/buffer-parser.cpp
@@ -75,7 +75,9 @@ auto process_logs(string& schema_path, string const& input_path) -> void {
             continue;
         }
 
+        cout << "log: " << event.to_string() << endl;
         print_timestamp_loglevel(event, *loglevel_id);
+        cout << "logtype: " << event.get_logtype() << endl;
         if (event.is_multiline()) {
             multiline_logs.emplace_back(event);
         }

--- a/examples/reader-parser.cpp
+++ b/examples/reader-parser.cpp
@@ -45,7 +45,9 @@ auto process_logs(string& schema_path, string const& input_path) -> void {
             throw runtime_error("Parsing Failed");
         }
 
+        cout << "log: " << event.to_string() << endl;
         print_timestamp_loglevel(event, *loglevel_id);
+        cout << "logtype: " << event.get_logtype() << endl;
         if (event.is_multiline()) {
             multiline_logs.emplace_back(event);
         }

--- a/src/log_surgeon/LogEvent.cpp
+++ b/src/log_surgeon/LogEvent.cpp
@@ -50,9 +50,16 @@ auto LogEventView::reset() -> void {
 
 auto LogEventView::get_logtype() -> std::string {
     std::string logtype;
-    auto static_text_id = (uint32_t)log_surgeon::SymbolID::TokenUncaughtStringID;
-    for (Token* token_ptr : m_log_var_occurrences[static_text_id]) {
-        logtype += token_ptr->to_string();
+    for (uint32_t i = 1; i < m_log_output_buffer->pos(); i++) {
+        Token& token = m_log_output_buffer->get_mutable_token(i);
+        if (token.m_type_ids_ptr->at(0) == (int)log_surgeon::SymbolID::TokenUncaughtStringID) {
+            logtype += token.to_string_view();
+        } else {
+            logtype += token.get_delimiter();
+            logtype += "<";
+            logtype += m_log_parser->get_id_symbol(token.m_type_ids_ptr->at(0));
+            logtype += ">";
+        }
     }
     return logtype;
 }

--- a/src/log_surgeon/LogEvent.hpp
+++ b/src/log_surgeon/LogEvent.hpp
@@ -95,8 +95,8 @@ public:
     /**
      * Constructs a user friendly/readable representation of the log event's
      * logtype. A logtype is essentially the static text of a log event with the
-     * variable components replaced with their name/id. Therefore, two separate
-     * log events from the same logging source code may have the same logtype.
+     * variable components replaced with their name. Therefore, two separate log
+     * events from the same logging source code may have the same logtype.
      * @return The logtype of the log.
      */
     auto get_logtype() -> std::string;

--- a/src/log_surgeon/LogParser.hpp
+++ b/src/log_surgeon/LogParser.hpp
@@ -58,13 +58,13 @@ public:
     auto parse(std::unique_ptr<LogParserOutputBuffer>& output_buffer, ParsingAction& parsing_action)
             -> ErrorCode;
 
-    // TODO protect against invalid id (use optional) and make const
+    // TODO protect against invalid id (use optional)
     /**
      * @param id The integer ID of the symbol from the schema.
      * @return the name of the variable type / symbol from the schema using its
      * integer ID.
      */
-    auto get_id_symbol(uint32_t id) -> std::string { return m_lexer.m_id_symbol[id]; }
+    auto get_id_symbol(uint32_t id) const -> std::string { return m_lexer.m_id_symbol.at(id); }
 
     /**
      * @param symbol name of the variable type from the schema.


### PR DESCRIPTION
Changed get_id_symbol to be const
Changed get_logtype() to also contain the var_names;
Changed get_logtype() docstring
Changed get_logtype() to output delims correctly and to not output timestamp var
Changed examples to print log + timestamp + logtype for every line

