### PR TITLE
Add LogEventView as a member within LogParser  

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,9 @@ optional<uint32_t> loglevel_id{parser.get_variable_id("loglevel")};
 // <Omitted validation of loglevel_id>
 
 // Create a LogEventView (similar to a string_view)
-LogEventView event{&parser.get_log_parser()};
+LogEventView const& event = parser.get_log_parser().get_log_event_view();
 while (false == parser.done()) {
-    // Parse the next event
-    auto err = parser.get_next_event_view(event);
-    if (ErrorCode::Success != err) {
+    if (ErrorCode err{parser.parse_next_event()}; ErrorCode::Success != err) {
         throw runtime_error("Parsing Failed");
     }
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ optional<uint32_t> loglevel_id{parser.get_variable_id("loglevel")};
 // <Omitted validation of loglevel_id>
 
 // Create a LogEventView (similar to a string_view)
-LogEventView const& event = parser.get_log_parser().get_log_event_view();
 while (false == parser.done()) {
     if (ErrorCode err{parser.parse_next_event()}; ErrorCode::Success != err) {
         throw runtime_error("Parsing Failed");
@@ -71,6 +70,7 @@ while (false == parser.done()) {
     // Other analysis...
 
     // Print the entire event
+    LogEventView const& event = parser.get_log_parser().get_log_event_view();
     cout << event->to_string() << endl;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ parser.reset_and_set_reader(reader);
 optional<uint32_t> loglevel_id{parser.get_variable_id("loglevel")};
 // <Omitted validation of loglevel_id>
 
-// Create a LogEventView (similar to a string_view)
 while (false == parser.done()) {
     if (ErrorCode err{parser.parse_next_event()}; ErrorCode::Success != err) {
         throw runtime_error("Parsing Failed");

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 # files.
 # For example, if log-surgeon was installed to ~/.local:
 # set(log_surgeon_DIR "~/.local/lib/cmake/log_surgeon/")
-find_package(log_surgeon REQUIRED)
+add_subdirectory(.. log-surgeon-build EXCLUDE_FROM_ALL)
 
 function(add_to_target target libraries)
     target_link_libraries(${target} ${libraries})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,13 +7,6 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Choose the type of build." FORCE)
 endif()
 
-# To use log-surgeon in your own project, replace the line below as follows:
-# - If log-surgeon was NOT installed to the system library path, set
-#   log_surgeon_DIR to the installed location containing the CMake configuration
-#   files. For example, if log-surgeon was installed to ~/.local:
-#   set(log_surgeon_DIR "~/.local/lib/cmake/log_surgeon/")
-# - Add the following find_package call:
-#   find_package(log_surgeon REQUIRED)
 add_subdirectory(.. log-surgeon-build EXCLUDE_FROM_ALL)
 
 function(add_to_target target libraries)

--- a/examples/buffer-parser.cpp
+++ b/examples/buffer-parser.cpp
@@ -41,7 +41,6 @@ auto process_logs(string& schema_path, string const& input_path) -> void {
 
     vector<LogEvent> multiline_logs;
     size_t offset{0};
-    LogEventView const& event = parser.get_log_parser().get_log_event_view();
     while (false == parser.done()) {
         if (ErrorCode err{parser.parse_next_event(buf.data(), valid_size, offset, input_done)};
             ErrorCode::Success != err)
@@ -76,6 +75,7 @@ auto process_logs(string& schema_path, string const& input_path) -> void {
             continue;
         }
 
+        LogEventView const& event = parser.get_log_parser().get_log_event_view();
         cout << "log: " << event.to_string() << endl;
         print_timestamp_loglevel(event, *loglevel_id);
         cout << "logtype: " << event.get_logtype() << endl;

--- a/examples/buffer-parser.cpp
+++ b/examples/buffer-parser.cpp
@@ -35,6 +35,7 @@ auto process_logs(string& schema_path, string const& input_path) -> void {
     if (infs.eof()) {
         input_done = true;
     }
+    parser.reset();
 
     cout << "# Parsing timestamp and loglevel for each log event in " << input_path << ":" << endl;
 
@@ -82,7 +83,6 @@ auto process_logs(string& schema_path, string const& input_path) -> void {
             multiline_logs.emplace_back(event);
         }
     }
-    parser.reset();
 
     cout << endl << "# Printing multiline logs:" << endl;
     for (auto const& log : multiline_logs) {

--- a/examples/buffer-parser.cpp
+++ b/examples/buffer-parser.cpp
@@ -27,7 +27,7 @@ auto process_logs(string& schema_path, string const& input_path) -> void {
         return;
     }
 
-    constexpr ssize_t const cSize{4096L * 8}; // 8 pages
+    constexpr ssize_t const cSize{4096L * 8};  // 8 pages
     vector<char> buf(cSize);
     infs.read(buf.data(), cSize);
     ssize_t valid_size{infs.gcount()};
@@ -40,11 +40,11 @@ auto process_logs(string& schema_path, string const& input_path) -> void {
 
     vector<LogEvent> multiline_logs;
     size_t offset{0};
-    LogEventView event{&parser.get_log_parser()};
+    LogEventView const& event = parser.get_log_parser().get_log_event_view();
     while (false == parser.done()) {
-        if (ErrorCode err{
-                    parser.get_next_event_view(buf.data(), valid_size, offset, event, input_done)};
-            ErrorCode::Success != err) {
+        if (ErrorCode err{parser.parse_next_event(buf.data(), valid_size, offset, input_done)};
+            ErrorCode::Success != err)
+        {
             // The only expected error is the parser has read to the bound
             // of the buffer.
             if (ErrorCode::BufferOutOfBounds != err) {

--- a/examples/reader-parser.cpp
+++ b/examples/reader-parser.cpp
@@ -39,9 +39,9 @@ auto process_logs(string& schema_path, string const& input_path) -> void {
     cout << "# Parsing timestamp and loglevel for each log event in " << input_path << ":" << endl;
 
     vector<LogEvent> multiline_logs;
-    LogEventView event{&parser.get_log_parser()};
+    LogEventView const& event = parser.get_log_parser().get_log_event_view();
     while (false == parser.done()) {
-        if (ErrorCode err{parser.get_next_event_view(event)}; ErrorCode::Success != err) {
+        if (ErrorCode err{parser.parse_next_event()}; ErrorCode::Success != err) {
             throw runtime_error("Parsing Failed");
         }
 

--- a/examples/reader-parser.cpp
+++ b/examples/reader-parser.cpp
@@ -39,12 +39,12 @@ auto process_logs(string& schema_path, string const& input_path) -> void {
     cout << "# Parsing timestamp and loglevel for each log event in " << input_path << ":" << endl;
 
     vector<LogEvent> multiline_logs;
-    LogEventView const& event = parser.get_log_parser().get_log_event_view();
     while (false == parser.done()) {
         if (ErrorCode err{parser.parse_next_event()}; ErrorCode::Success != err) {
             throw runtime_error("Parsing Failed");
         }
 
+        LogEventView const& event = parser.get_log_parser().get_log_event_view();
         cout << "log: " << event.to_string() << endl;
         print_timestamp_loglevel(event, *loglevel_id);
         cout << "logtype: " << event.get_logtype() << endl;

--- a/src/log_surgeon/BufferParser.cpp
+++ b/src/log_surgeon/BufferParser.cpp
@@ -17,23 +17,26 @@ auto BufferParser::reset() -> void {
     m_done = false;
 }
 
-auto BufferParser::get_next_event_view(
+auto BufferParser::parse_next_event(
         char* buf,
         size_t size,
         size_t& offset,
-        LogEventView& event_view,
         bool finished_reading_input
 ) -> ErrorCode {
-    event_view.reset();
+    m_log_parser.reset_log_event_view();
     // TODO in order to allow logs/tokens to wrap user buffers this function
     // will need more parameters or the input buffer may need to be exposed to
     // the user
     m_log_parser.set_input_buffer(buf, size, offset, finished_reading_input);
     LogParser::ParsingAction parsing_action{LogParser::ParsingAction::None};
-    ErrorCode error_code = m_log_parser.parse(event_view.m_log_output_buffer, parsing_action);
+    ErrorCode error_code = m_log_parser.parse(
+            parsing_action
+    );
     if (ErrorCode::Success != error_code) {
-        if (0 != event_view.m_log_output_buffer->pos()) {
-            offset = event_view.m_log_output_buffer->get_token(0).m_start_pos;
+        if (0 != m_log_parser.get_log_event_view().m_log_output_buffer->pos()) {
+            offset = m_log_parser.get_log_event_view()
+                             .m_log_output_buffer->get_token(0)
+                             .m_start_pos;
         }
         reset();
         return error_code;
@@ -42,27 +45,7 @@ auto BufferParser::get_next_event_view(
         m_done = true;
     }
     offset = m_log_parser.get_input_pos();
-
-    uint32_t start = 0;
-    if (false == event_view.m_log_output_buffer->has_timestamp()) {
-        start = 1;
-    }
-    uint32_t first_newline_pos{0};
-    for (uint32_t i = start; i < event_view.m_log_output_buffer->pos(); i++) {
-        Token* token = &event_view.m_log_output_buffer->get_mutable_token(i);
-        event_view.add_token(token->m_type_ids_ptr->at(0), token);
-        if (token->m_type_ids_ptr->at(0) == (int)SymbolID::TokenNewlineId && first_newline_pos == 0)
-        {
-            first_newline_pos = i;
-        }
-    }
-    // To be a multiline log there must be at least one token between the
-    // newline token and the last token in the output buffer.
-    if (event_view.m_log_output_buffer->has_timestamp() && 0 < first_newline_pos
-        && first_newline_pos + 1 < event_view.m_log_output_buffer->pos())
-    {
-        event_view.set_multiline(true);
-    }
+    m_log_parser.generate_log_event_view_metadata();
     return ErrorCode::Success;
 }
 }  // namespace log_surgeon

--- a/src/log_surgeon/BufferParser.cpp
+++ b/src/log_surgeon/BufferParser.cpp
@@ -29,9 +29,7 @@ auto BufferParser::parse_next_event(
     // the user
     m_log_parser.set_input_buffer(buf, size, offset, finished_reading_input);
     LogParser::ParsingAction parsing_action{LogParser::ParsingAction::None};
-    ErrorCode error_code = m_log_parser.parse(
-            parsing_action
-    );
+    ErrorCode error_code = m_log_parser.parse(parsing_action);
     if (ErrorCode::Success != error_code) {
         if (0 != m_log_parser.get_log_event_view().m_log_output_buffer->pos()) {
             offset = m_log_parser.get_log_event_view()

--- a/src/log_surgeon/BufferParser.cpp
+++ b/src/log_surgeon/BufferParser.cpp
@@ -29,7 +29,7 @@ auto BufferParser::parse_next_event(
     // the user
     m_log_parser.set_input_buffer(buf, size, offset, finished_reading_input);
     LogParser::ParsingAction parsing_action{LogParser::ParsingAction::None};
-    ErrorCode error_code = m_log_parser.parse(parsing_action);
+    ErrorCode error_code = m_log_parser.parse_and_generate_metadata(parsing_action);
     if (ErrorCode::Success != error_code) {
         if (0 != m_log_parser.get_log_event_view().m_log_output_buffer->pos()) {
             offset = m_log_parser.get_log_event_view()
@@ -43,7 +43,6 @@ auto BufferParser::parse_next_event(
         m_done = true;
     }
     offset = m_log_parser.get_input_pos();
-    m_log_parser.generate_log_event_view_metadata();
     return ErrorCode::Success;
 }
 }  // namespace log_surgeon

--- a/src/log_surgeon/BufferParser.hpp
+++ b/src/log_surgeon/BufferParser.hpp
@@ -66,12 +66,9 @@ public:
      * internally before this method returns.
      * @return ErrorCode from LogParser::parse.
      */
-    auto parse_next_event(
-            char* buf,
-            size_t size,
-            size_t& offset,
-            bool finished_reading_input = false
-    ) -> ErrorCode;
+    auto
+    parse_next_event(char* buf, size_t size, size_t& offset, bool finished_reading_input = false)
+            -> ErrorCode;
 
     /**
      * @return The underlying LogParser.

--- a/src/log_surgeon/BufferParser.hpp
+++ b/src/log_surgeon/BufferParser.hpp
@@ -36,7 +36,7 @@ public:
 
     /**
      * Clears the internal state of the log parser (lexer and input buffer) so
-     * that the next call to get_next_event_view will begin parsing from
+     * that the next call to parse_next_event will begin parsing from
      * scratch. This is an alternative to constructing a new Parser that would
      * require rebuilding the LogParser (generating a new lexer and input
      * buffer). This should be called whenever you mutate the input buffer, but
@@ -50,14 +50,13 @@ public:
      * bytes between offset and size may contain a partial log event. It is the
      * user's responsibility to preserve these bytes when mutating the buffer
      * to contain more of the log event before the next call of
-     * get_next_log_view.
+     * get_next_log_view. The result is stored in m_log_parser.log_event_view,
+     * and only valid if ErrorCode::Success is returned.
      * @param buf The byte buffer containing raw log events to be parsed.
      * @param size The size of the buffer.
      * @param offset The starting position in the buffer of the current log
      * event to be parsed. Updated to be the starting position of the next
      * unparsed log event. If no log event is parsed it remains unchanged.
-     * @param event_view Populated with the log event view parsed from the
-     * buffer. Only valid if ErrorCode::Success is returned.
      * @param finished_reading_input Indicates if the end of the buffer is the
      * end of input and therefore the end of the final log event.
      * @return ErrorCode::Success if a log event is successfully parsed as a
@@ -67,11 +66,10 @@ public:
      * internally before this method returns.
      * @return ErrorCode from LogParser::parse.
      */
-    auto get_next_event_view(
+    auto parse_next_event(
             char* buf,
             size_t size,
             size_t& offset,
-            LogEventView& event_view,
             bool finished_reading_input = false
     ) -> ErrorCode;
 
@@ -93,7 +91,7 @@ public:
     /**
      * @return true when the BufferParser has completed parsing all of the
      * provided input. This can only occur if finished_reading_input was set to
-     * true in get_next_event_view. Otherwise, the BufferParser will always
+     * true in parse_next_event. Otherwise, the BufferParser will always
      * assume more input can be read.
      */
     auto done() const -> bool { return m_done; }

--- a/src/log_surgeon/BufferParser.hpp
+++ b/src/log_surgeon/BufferParser.hpp
@@ -50,8 +50,8 @@ public:
      * bytes between offset and size may contain a partial log event. It is the
      * user's responsibility to preserve these bytes when mutating the buffer
      * to contain more of the log event before the next call of
-     * get_next_log_view. The result is stored in m_log_parser.log_event_view,
-     * and only valid if ErrorCode::Success is returned.
+     * get_next_log_view. The result is stored internally and is only valid if
+     * ErrorCode::Success is returned.
      * @param buf The byte buffer containing raw log events to be parsed.
      * @param size The size of the buffer.
      * @param offset The starting position in the buffer of the current log

--- a/src/log_surgeon/LogEvent.cpp
+++ b/src/log_surgeon/LogEvent.cpp
@@ -10,10 +10,13 @@
 #include <log_surgeon/Token.hpp>
 
 namespace log_surgeon {
-LogEventView::LogEventView(LogParser const* log_parser)
-        : m_log_parser{log_parser},
-          m_log_var_occurrences{log_parser->m_lexer.m_id_symbol.size()} {
+LogEventView::LogEventView() : m_log_parser{nullptr}, m_log_var_occurrences{0} {
     m_log_output_buffer = std::make_unique<LogParserOutputBuffer>();
+}
+
+auto LogEventView::init(LogParser const* log_parser) -> void {
+    m_log_parser = log_parser;
+    m_log_var_occurrences.resize(log_parser->m_lexer.m_id_symbol.size());
 }
 
 auto LogEventView::deep_copy() const -> LogEvent {
@@ -48,7 +51,7 @@ auto LogEventView::reset() -> void {
     return raw_log;
 }
 
-auto LogEventView::get_logtype() -> std::string {
+auto LogEventView::get_logtype() const -> std::string {
     std::string logtype;
     for (uint32_t i = 1; i < m_log_output_buffer->pos(); i++) {
         Token& token = m_log_output_buffer->get_mutable_token(i);
@@ -64,7 +67,8 @@ auto LogEventView::get_logtype() -> std::string {
     return logtype;
 }
 
-LogEvent::LogEvent(LogEventView const& src) : LogEventView{src.get_log_parser()} {
+LogEvent::LogEvent(LogEventView const& src) : LogEventView{} {
+    init(src.get_log_parser());
     set_multiline(src.is_multiline());
     m_log_output_buffer->set_has_timestamp(src.m_log_output_buffer->has_timestamp());
     m_log_output_buffer->set_has_delimiters(src.m_log_output_buffer->has_delimiters());

--- a/src/log_surgeon/LogEvent.cpp
+++ b/src/log_surgeon/LogEvent.cpp
@@ -57,6 +57,10 @@ auto LogEventView::get_logtype() const -> std::string {
         Token& token = m_log_output_buffer->get_mutable_token(i);
         if (token.m_type_ids_ptr->at(0) == (int)log_surgeon::SymbolID::TokenUncaughtStringID) {
             logtype += token.to_string_view();
+        } else if (token.m_type_ids_ptr->at(0) == (int)log_surgeon::SymbolID::TokenNewlineId) {
+            logtype += "<";
+            logtype += m_log_parser->get_id_symbol(token.m_type_ids_ptr->at(0));
+            logtype += ">";
         } else {
             logtype += token.get_delimiter();
             logtype += "<";

--- a/src/log_surgeon/LogEvent.cpp
+++ b/src/log_surgeon/LogEvent.cpp
@@ -10,9 +10,9 @@
 #include <log_surgeon/Token.hpp>
 
 namespace log_surgeon {
-LogEventView::LogEventView(LogParser const* log_parser)
+LogEventView::LogEventView(LogParser const& log_parser)
         : m_log_parser{log_parser},
-          m_log_var_occurrences{log_parser->m_lexer.m_id_symbol.size()} {
+          m_log_var_occurrences{log_parser.m_lexer.m_id_symbol.size()} {
     m_log_output_buffer = std::make_unique<LogParserOutputBuffer>();
 }
 
@@ -56,12 +56,12 @@ auto LogEventView::get_logtype() const -> std::string {
             logtype += token.to_string_view();
         } else if (token.m_type_ids_ptr->at(0) == (int)log_surgeon::SymbolID::TokenNewlineId) {
             logtype += "<";
-            logtype += m_log_parser->get_id_symbol(token.m_type_ids_ptr->at(0));
+            logtype += m_log_parser.get_id_symbol(token.m_type_ids_ptr->at(0));
             logtype += ">";
         } else {
             logtype += token.get_delimiter();
             logtype += "<";
-            logtype += m_log_parser->get_id_symbol(token.m_type_ids_ptr->at(0));
+            logtype += m_log_parser.get_id_symbol(token.m_type_ids_ptr->at(0));
             logtype += ">";
         }
     }

--- a/src/log_surgeon/LogEvent.cpp
+++ b/src/log_surgeon/LogEvent.cpp
@@ -54,12 +54,10 @@ auto LogEventView::get_logtype() const -> std::string {
         Token& token = m_log_output_buffer->get_mutable_token(i);
         if (token.m_type_ids_ptr->at(0) == (int)log_surgeon::SymbolID::TokenUncaughtStringID) {
             logtype += token.to_string_view();
-        } else if (token.m_type_ids_ptr->at(0) == (int)log_surgeon::SymbolID::TokenNewlineId) {
-            logtype += "<";
-            logtype += m_log_parser.get_id_symbol(token.m_type_ids_ptr->at(0));
-            logtype += ">";
         } else {
-            logtype += token.get_delimiter();
+            if ((int)log_surgeon::SymbolID::TokenNewlineId != token.m_type_ids_ptr->at(0)) {
+                logtype += token.get_delimiter();
+            }
             logtype += "<";
             logtype += m_log_parser.get_id_symbol(token.m_type_ids_ptr->at(0));
             logtype += ">";

--- a/src/log_surgeon/LogEvent.cpp
+++ b/src/log_surgeon/LogEvent.cpp
@@ -10,7 +10,7 @@
 #include <log_surgeon/Token.hpp>
 
 namespace log_surgeon {
-LogEventView::LogEventView() : m_log_parser{nullptr}, m_log_var_occurrences{0} {
+LogEventView::LogEventView() {
     m_log_output_buffer = std::make_unique<LogParserOutputBuffer>();
 }
 

--- a/src/log_surgeon/LogEvent.cpp
+++ b/src/log_surgeon/LogEvent.cpp
@@ -10,13 +10,10 @@
 #include <log_surgeon/Token.hpp>
 
 namespace log_surgeon {
-LogEventView::LogEventView() {
+LogEventView::LogEventView(LogParser const* log_parser)
+        : m_log_parser{log_parser},
+          m_log_var_occurrences{log_parser->m_lexer.m_id_symbol.size()} {
     m_log_output_buffer = std::make_unique<LogParserOutputBuffer>();
-}
-
-auto LogEventView::init(LogParser const* log_parser) -> void {
-    m_log_parser = log_parser;
-    m_log_var_occurrences.resize(log_parser->m_lexer.m_id_symbol.size());
 }
 
 auto LogEventView::deep_copy() const -> LogEvent {
@@ -71,8 +68,7 @@ auto LogEventView::get_logtype() const -> std::string {
     return logtype;
 }
 
-LogEvent::LogEvent(LogEventView const& src) : LogEventView{} {
-    init(src.get_log_parser());
+LogEvent::LogEvent(LogEventView const& src) : LogEventView{src.get_log_parser()} {
     set_multiline(src.is_multiline());
     m_log_output_buffer->set_has_timestamp(src.m_log_output_buffer->has_timestamp());
     m_log_output_buffer->set_has_delimiters(src.m_log_output_buffer->has_delimiters());

--- a/src/log_surgeon/LogEvent.hpp
+++ b/src/log_surgeon/LogEvent.hpp
@@ -5,11 +5,11 @@
 #include <string>
 #include <vector>
 
-#include <log_surgeon/LogParser.hpp>
 #include <log_surgeon/LogParserOutputBuffer.hpp>
 #include <log_surgeon/Token.hpp>
 
 namespace log_surgeon {
+class LogParser;
 class LogEvent;
 
 /**
@@ -24,10 +24,17 @@ class LogEventView {
 public:
     /**
      * Constructs an empty LogEventView
+     */
+    explicit LogEventView();
+
+    /**
+     * Initialize log event view after the parser containing it has already 
+     * been constructed, therefore this cannot be done in its own constructor
      * @param log_parser The LogParser whose input buffer the view will
      * reference
      */
-    explicit LogEventView(LogParser const* log_parser);
+    auto init(LogParser const* log_parser) -> void;
+        
 
     /**
      * Copies the tokens representing a log event from the source buffer. This
@@ -99,7 +106,7 @@ public:
      * events from the same logging source code may have the same logtype.
      * @return The logtype of the log.
      */
-    auto get_logtype() -> std::string;
+    auto get_logtype() const -> std::string;
 
     /**
      * Adds a Token to the array of tokens of a particular token type.

--- a/src/log_surgeon/LogEvent.hpp
+++ b/src/log_surgeon/LogEvent.hpp
@@ -24,16 +24,10 @@ class LogEventView {
 public:
     /**
      * Constructs an empty LogEventView
-     */
-    explicit LogEventView();
-
-    /**
-     * Initialize log event view after the parser containing it has already
-     * been constructed, therefore this cannot be done in its own constructor
      * @param log_parser The LogParser whose input buffer the view will
      * reference
      */
-    auto init(LogParser const* log_parser) -> void;
+    explicit LogEventView(LogParser const* log_parser);
 
     /**
      * Copies the tokens representing a log event from the source buffer. This

--- a/src/log_surgeon/LogEvent.hpp
+++ b/src/log_surgeon/LogEvent.hpp
@@ -127,8 +127,8 @@ public:
 
 private:
     bool m_multiline{false};
-    LogParser const* m_log_parser;
-    std::vector<std::vector<Token*>> m_log_var_occurrences;
+    LogParser const* m_log_parser{nullptr};
+    std::vector<std::vector<Token*>> m_log_var_occurrences{};
 };
 
 /**

--- a/src/log_surgeon/LogEvent.hpp
+++ b/src/log_surgeon/LogEvent.hpp
@@ -28,13 +28,12 @@ public:
     explicit LogEventView();
 
     /**
-     * Initialize log event view after the parser containing it has already 
+     * Initialize log event view after the parser containing it has already
      * been constructed, therefore this cannot be done in its own constructor
      * @param log_parser The LogParser whose input buffer the view will
      * reference
      */
     auto init(LogParser const* log_parser) -> void;
-        
 
     /**
      * Copies the tokens representing a log event from the source buffer. This

--- a/src/log_surgeon/LogEvent.hpp
+++ b/src/log_surgeon/LogEvent.hpp
@@ -27,7 +27,7 @@ public:
      * @param log_parser The LogParser whose input buffer the view will
      * reference
      */
-    explicit LogEventView(LogParser const* log_parser);
+    explicit LogEventView(LogParser const& log_parser);
 
     /**
      * Copies the tokens representing a log event from the source buffer. This
@@ -57,7 +57,7 @@ public:
     /**
      * @return The LogParser whose input buffer this LogEventView references
      */
-    [[nodiscard]] auto get_log_parser() const -> LogParser const* { return m_log_parser; }
+    [[nodiscard]] auto get_log_parser() const -> LogParser const& { return m_log_parser; }
 
     /**
      * @return The LogParserOutputBuffer containing the tokens that make up the
@@ -121,7 +121,7 @@ public:
 
 private:
     bool m_multiline{false};
-    LogParser const* m_log_parser{nullptr};
+    LogParser const& m_log_parser;
     std::vector<std::vector<Token*>> m_log_var_occurrences{};
 };
 

--- a/src/log_surgeon/LogParser.cpp
+++ b/src/log_surgeon/LogParser.cpp
@@ -33,7 +33,7 @@ LogParser::LogParser(string const& schema_file_path)
 LogParser::LogParser(SchemaAST const* schema_ast) {
     add_rules(schema_ast);
     m_lexer.generate();
-    m_log_event_view = make_unique<LogEventView>(this);
+    m_log_event_view = make_unique<LogEventView>(*this);
 }
 
 auto LogParser::add_delimiters(unique_ptr<ParserAST> const& delimiters) -> void {

--- a/src/log_surgeon/LogParser.cpp
+++ b/src/log_surgeon/LogParser.cpp
@@ -30,9 +30,10 @@ using finite_automata::RegexNFAByteState;
 LogParser::LogParser(string const& schema_file_path)
         : LogParser::LogParser(SchemaParser::try_schema_file(schema_file_path).get()) {}
 
-LogParser::LogParser(SchemaAST const* schema_ast) : m_has_start_of_log(false) {
+LogParser::LogParser(SchemaAST const* schema_ast) : m_has_start_of_log(false), m_log_event_view{} {
     add_rules(schema_ast);
     m_lexer.generate();
+    m_log_event_view.init(this);
 }
 
 auto LogParser::add_delimiters(unique_ptr<ParserAST> const& delimiters) -> void {
@@ -157,10 +158,8 @@ auto LogParser::reset() -> void {
 // TODO: if the first text is a variable in the no timestamp case you lose the
 // first character to static text since it has no leading delim
 // TODO: switching between timestamped and non-timestamped logs
-auto LogParser::parse(
-        std::unique_ptr<LogParserOutputBuffer>& output_buffer,
-        LogParser::ParsingAction& parsing_action
-) -> ErrorCode {
+auto LogParser::parse(LogParser::ParsingAction& parsing_action) -> ErrorCode {
+    std::unique_ptr<LogParserOutputBuffer>& output_buffer = m_log_event_view.m_log_output_buffer;
     if (0 == output_buffer->pos()) {
         output_buffer->set_has_delimiters(m_lexer.get_has_delimiters());
         Token next_token;
@@ -277,5 +276,28 @@ auto LogParser::get_symbol_id(std::string const& symbol) const -> std::optional<
 
 auto LogParser::get_next_symbol(Token& token) -> ErrorCode {
     return m_lexer.scan(m_input_buffer, token);
+}
+
+auto LogParser::generate_log_event_view_metadata() -> void {
+    uint32_t start = 0;
+    if (false == m_log_event_view.m_log_output_buffer->has_timestamp()) {
+        start = 1;
+    }
+    uint32_t first_newline_pos{0};
+    for (uint32_t i = start; i < m_log_event_view.m_log_output_buffer->pos(); i++) {
+        Token* token = &m_log_event_view.m_log_output_buffer->get_mutable_token(i);
+        m_log_event_view.add_token(token->m_type_ids_ptr->at(0), token);
+        if (token->m_type_ids_ptr->at(0) == (int)SymbolID::TokenNewlineId && first_newline_pos == 0)
+        {
+            first_newline_pos = i;
+        }
+    }
+    // To be a multiline log there must be at least one token between the
+    // newline token and the last token in the output buffer.
+    if (m_log_event_view.m_log_output_buffer->has_timestamp() && 0 < first_newline_pos
+        && first_newline_pos + 1 < m_log_event_view.m_log_output_buffer->pos())
+    {
+        m_log_event_view.set_multiline(true);
+    }
 }
 }  // namespace log_surgeon

--- a/src/log_surgeon/LogParser.cpp
+++ b/src/log_surgeon/LogParser.cpp
@@ -155,6 +155,14 @@ auto LogParser::reset() -> void {
     m_lexer.prepend_start_of_file_char(m_input_buffer);
 }
 
+auto LogParser::parse_and_generate_metadata(LogParser::ParsingAction& parsing_action) -> ErrorCode {
+    ErrorCode error_code = parse(parsing_action);
+    if (ErrorCode::Success == error_code) {
+        generate_log_event_view_metadata();
+    }
+    return error_code;
+}
+
 // TODO: if the first text is a variable in the no timestamp case you lose the
 // first character to static text since it has no leading delim
 // TODO: switching between timestamped and non-timestamped logs

--- a/src/log_surgeon/LogParser.cpp
+++ b/src/log_surgeon/LogParser.cpp
@@ -163,7 +163,6 @@ auto LogParser::parse_and_generate_metadata(LogParser::ParsingAction& parsing_ac
     return error_code;
 }
 
-// TODO: switching between timestamped and non-timestamped logs
 auto LogParser::parse(LogParser::ParsingAction& parsing_action) -> ErrorCode {
     std::unique_ptr<LogParserOutputBuffer>& output_buffer = m_log_event_view->m_log_output_buffer;
     if (0 == output_buffer->pos()) {

--- a/src/log_surgeon/LogParser.cpp
+++ b/src/log_surgeon/LogParser.cpp
@@ -295,8 +295,7 @@ auto LogParser::generate_log_event_view_metadata() -> void {
     for (uint32_t i = start; i < m_log_event_view->m_log_output_buffer->pos(); i++) {
         Token* token = &m_log_event_view->m_log_output_buffer->get_mutable_token(i);
         m_log_event_view->add_token(token->m_type_ids_ptr->at(0), token);
-        if (token->m_type_ids_ptr->at(0) == (int)SymbolID::TokenNewlineId && first_newline_pos == 0)
-        {
+        if (token->get_delimiter() == "\n" && first_newline_pos == 0) {
             first_newline_pos = i;
         }
     }

--- a/src/log_surgeon/LogParser.cpp
+++ b/src/log_surgeon/LogParser.cpp
@@ -163,8 +163,6 @@ auto LogParser::parse_and_generate_metadata(LogParser::ParsingAction& parsing_ac
     return error_code;
 }
 
-// TODO: if the first text is a variable in the no timestamp case you lose the
-// first character to static text since it has no leading delim
 // TODO: switching between timestamped and non-timestamped logs
 auto LogParser::parse(LogParser::ParsingAction& parsing_action) -> ErrorCode {
     std::unique_ptr<LogParserOutputBuffer>& output_buffer = m_log_event_view->m_log_output_buffer;

--- a/src/log_surgeon/LogParser.hpp
+++ b/src/log_surgeon/LogParser.hpp
@@ -112,12 +112,12 @@ public:
     /**
      * Resets the log event view to prepare for the next parse
      */
-    auto reset_log_event_view() -> void { m_log_event_view.reset(); }
+    auto reset_log_event_view() -> void { m_log_event_view->reset(); }
 
     /**
      * @return the log event view based on the last parse
      */
-    auto get_log_event_view() const -> LogEventView const& { return m_log_event_view; }
+    auto get_log_event_view() const -> LogEventView const& { return *m_log_event_view; }
 
 private:
     /**
@@ -162,9 +162,9 @@ private:
 
     // TODO: move ownership of the buffer to the lexer
     ParserInputBuffer m_input_buffer;
-    bool m_has_start_of_log;
+    bool m_has_start_of_log{false};
     Token m_start_of_log_message{};
-    LogEventView m_log_event_view;
+    std::unique_ptr<LogEventView> m_log_event_view{nullptr};
 };
 }  // namespace log_surgeon
 

--- a/src/log_surgeon/LogParser.hpp
+++ b/src/log_surgeon/LogParser.hpp
@@ -7,6 +7,7 @@
 
 #include <log_surgeon/Constants.hpp>
 #include <log_surgeon/LALR1Parser.hpp>
+#include <log_surgeon/LogEvent.hpp>
 #include <log_surgeon/LogParserOutputBuffer.hpp>
 #include <log_surgeon/Parser.hpp>
 #include <log_surgeon/ParserInputBuffer.hpp>
@@ -49,14 +50,12 @@ public:
     /**
      * Parses the input buffer until a complete log event has been parsed and
      * its tokens are stored into output_buffer.
-     * @param output_buffer Buffer to write Token objects to as they are parsed.
      * @param parsing_action Returns the action for CLP to take by reference.
      * @return ErrorCode::Success if successfully parsed to the start of a new
      * log event.
      * @return ErrorCode from LogParser::get_next_symbol.
      */
-    auto parse(std::unique_ptr<LogParserOutputBuffer>& output_buffer, ParsingAction& parsing_action)
-            -> ErrorCode;
+    auto parse(ParsingAction& parsing_action) -> ErrorCode;
 
     // TODO protect against invalid id (use optional)
     /**
@@ -111,6 +110,22 @@ public:
      */
     auto increase_capacity() -> void { m_lexer.increase_buffer_capacity(m_input_buffer); }
 
+    /**
+     * Reset the log event view to prepare for the next parse
+     */
+    auto reset_log_event_view() -> void { m_log_event_view.reset(); }
+
+    /**
+     * Run after parsing to fill m_var_occurrences field for fast variable
+     * search and m_multiline in log event view
+     */
+    auto generate_log_event_view_metadata() -> void;
+
+    /**
+     * @return the log event view based on the last parse
+     */
+    auto get_log_event_view() const -> LogEventView const& { return m_log_event_view; }
+
 private:
     /**
      * Requests the next token from the lexer.
@@ -140,6 +155,7 @@ private:
     ParserInputBuffer m_input_buffer;
     bool m_has_start_of_log;
     Token m_start_of_log_message{};
+    LogEventView m_log_event_view;
 };
 }  // namespace log_surgeon
 

--- a/src/log_surgeon/LogParser.hpp
+++ b/src/log_surgeon/LogParser.hpp
@@ -48,14 +48,13 @@ public:
     auto reset() -> void;
 
     /**
-     * Parses the input buffer until a complete log event has been parsed and
-     * its tokens are stored into output_buffer.
+     * Parses and generates metadata if parse was successful.
      * @param parsing_action Returns the action for CLP to take by reference.
      * @return ErrorCode::Success if successfully parsed to the start of a new
      * log event.
-     * @return ErrorCode from LogParser::get_next_symbol.
+     * @return ErrorCode from LogParser::parse.
      */
-    auto parse(ParsingAction& parsing_action) -> ErrorCode;
+    auto parse_and_generate_metadata(ParsingAction& parsing_action) -> ErrorCode;
 
     // TODO protect against invalid id (use optional)
     /**
@@ -116,17 +115,27 @@ public:
     auto reset_log_event_view() -> void { m_log_event_view.reset(); }
 
     /**
-     * Run after parsing to fill m_var_occurrences field for fast variable
-     * search and m_multiline in log event view
-     */
-    auto generate_log_event_view_metadata() -> void;
-
-    /**
      * @return the log event view based on the last parse
      */
     auto get_log_event_view() const -> LogEventView const& { return m_log_event_view; }
 
 private:
+    /**
+     * Parses the input buffer until a complete log event has been parsed and
+     * its tokens are stored into output_buffer.
+     * @param parsing_action Returns the action for CLP to take by reference.
+     * @return ErrorCode::Success if successfully parsed to the start of a new
+     * log event.
+     * @return ErrorCode from LogParser::get_next_symbol.
+     */
+    auto parse(ParsingAction& parsing_action) -> ErrorCode;
+
+    /**
+     * Generates metadata for last parsed log event indicating occurrences of
+     * each variable and if the log event is multiline
+     */
+    auto generate_log_event_view_metadata() -> void;
+
     /**
      * Requests the next token from the lexer.
      * @param token is populated with the next token found by the parser.

--- a/src/log_surgeon/LogParser.hpp
+++ b/src/log_surgeon/LogParser.hpp
@@ -111,7 +111,7 @@ public:
     auto increase_capacity() -> void { m_lexer.increase_buffer_capacity(m_input_buffer); }
 
     /**
-     * Reset the log event view to prepare for the next parse
+     * Resets the log event view to prepare for the next parse
      */
     auto reset_log_event_view() -> void { m_log_event_view.reset(); }
 

--- a/src/log_surgeon/LogParser.hpp
+++ b/src/log_surgeon/LogParser.hpp
@@ -122,7 +122,7 @@ public:
 private:
     /**
      * Parses the input buffer until a complete log event has been parsed and
-     * its tokens are stored into output_buffer.
+     * its tokens are stored into m_log_event_view.
      * @param parsing_action Returns the action for CLP to take by reference.
      * @return ErrorCode::Success if successfully parsed to the start of a new
      * log event.

--- a/src/log_surgeon/ReaderParser.cpp
+++ b/src/log_surgeon/ReaderParser.cpp
@@ -26,9 +26,7 @@ auto ReaderParser::parse_next_event() -> ErrorCode {
     }
     while (true) {
         LogParser::ParsingAction parsing_action{LogParser::ParsingAction::None};
-        ErrorCode parse_error = m_log_parser.parse(
-                parsing_action
-        );
+        ErrorCode parse_error = m_log_parser.parse(parsing_action);
         if (ErrorCode::Success == parse_error) {
             if (LogParser::ParsingAction::CompressAndFinish == parsing_action) {
                 m_done = true;

--- a/src/log_surgeon/ReaderParser.cpp
+++ b/src/log_surgeon/ReaderParser.cpp
@@ -17,8 +17,8 @@ auto ReaderParser::reset_and_set_reader(Reader& reader) -> void {
     m_reader = reader;
 }
 
-auto ReaderParser::get_next_event_view(LogEventView& event_view) -> ErrorCode {
-    event_view.reset();
+auto ReaderParser::parse_next_event() -> ErrorCode {
+    m_log_parser.reset_log_event_view();
     if (ErrorCode err = m_log_parser.read_into_input(m_reader);
         ErrorCode::Success != err && ErrorCode::EndOfFile != err)
     {
@@ -26,7 +26,9 @@ auto ReaderParser::get_next_event_view(LogEventView& event_view) -> ErrorCode {
     }
     while (true) {
         LogParser::ParsingAction parsing_action{LogParser::ParsingAction::None};
-        ErrorCode parse_error = m_log_parser.parse(event_view.m_log_output_buffer, parsing_action);
+        ErrorCode parse_error = m_log_parser.parse(
+                parsing_action
+        );
         if (ErrorCode::Success == parse_error) {
             if (LogParser::ParsingAction::CompressAndFinish == parsing_action) {
                 m_done = true;
@@ -44,26 +46,7 @@ auto ReaderParser::get_next_event_view(LogEventView& event_view) -> ErrorCode {
             return parse_error;
         }
     }
-    uint32_t start = 0;
-    if (false == event_view.m_log_output_buffer->has_timestamp()) {
-        start = 1;
-    }
-    uint32_t first_newline_pos{0};
-    for (uint32_t i = start; i < event_view.m_log_output_buffer->pos(); i++) {
-        Token* token = &event_view.m_log_output_buffer->get_mutable_token(i);
-        event_view.add_token(token->m_type_ids_ptr->at(0), token);
-        if (token->m_type_ids_ptr->at(0) == (int)SymbolID::TokenNewlineId && first_newline_pos == 0)
-        {
-            first_newline_pos = i;
-        }
-    }
-    // To be a multiline log there must be at least one token between the
-    // newline token and the last token in the output buffer.
-    if (event_view.m_log_output_buffer->has_timestamp() && 0 < first_newline_pos
-        && first_newline_pos + 1 < event_view.m_log_output_buffer->pos())
-    {
-        event_view.set_multiline(true);
-    }
+    m_log_parser.generate_log_event_view_metadata();
     return ErrorCode::Success;
 }
 }  // namespace log_surgeon

--- a/src/log_surgeon/ReaderParser.cpp
+++ b/src/log_surgeon/ReaderParser.cpp
@@ -26,7 +26,7 @@ auto ReaderParser::parse_next_event() -> ErrorCode {
     }
     while (true) {
         LogParser::ParsingAction parsing_action{LogParser::ParsingAction::None};
-        ErrorCode parse_error = m_log_parser.parse(parsing_action);
+        ErrorCode parse_error = m_log_parser.parse_and_generate_metadata(parsing_action);
         if (ErrorCode::Success == parse_error) {
             if (LogParser::ParsingAction::CompressAndFinish == parsing_action) {
                 m_done = true;
@@ -44,7 +44,6 @@ auto ReaderParser::parse_next_event() -> ErrorCode {
             return parse_error;
         }
     }
-    m_log_parser.generate_log_event_view_metadata();
     return ErrorCode::Success;
 }
 }  // namespace log_surgeon

--- a/src/log_surgeon/ReaderParser.hpp
+++ b/src/log_surgeon/ReaderParser.hpp
@@ -36,7 +36,7 @@ public:
     /**
      * Clears the internal state of the log parser (lexer and input buffer),
      * and sets the reader containing the logs to be parsed. The next call to
-     * get_next_event_view will begin parsing from scratch. This is an
+     * parse_next_event will begin parsing from scratch. This is an
      * alternative to constructing a new Parser that would require rebuilding
      * the LogParser (generating a new lexer and input buffer). This should be
      * called whenever new input is needed.
@@ -47,16 +47,16 @@ public:
     /**
      * Attempts to parse the next log event from the internal `Reader`. Users
      * should add their own error handling and tracking logic to Reader::read,
-     * in order to retrieve IO errors.
-     * @param event_view Populated with the LogEventView parsed from the reader.
-     * Only valid if ErrorCode::Success is returned.
+     * in order to retrieve IO errors. The result is stored in
+     * m_log_parser.log_event_view, and only valid if ErrorCode::Success is
+     * returned.
      * @return ErrorCode::Success if a log event is successfully parsed as a
      * LogEventView.
      * @return ErrorCode from LogParser::parse.
      * @return ErrorCode from the user defined Reader::read.
      * @throw std::bad_alloc if a log event is large enough to exhaust memory.
      */
-    auto get_next_event_view(LogEventView& event_view) -> ErrorCode;
+    auto parse_next_event() -> ErrorCode;
 
     /**
      * @return The underlying LogParser.

--- a/src/log_surgeon/ReaderParser.hpp
+++ b/src/log_surgeon/ReaderParser.hpp
@@ -47,8 +47,8 @@ public:
     /**
      * Attempts to parse the next log event from the internal `Reader`. Users
      * should add their own error handling and tracking logic to Reader::read,
-     * in order to retrieve IO errors. The result is stored in internally and
-     * is only valid if ErrorCode::Success is returned.
+     * in order to retrieve IO errors. The result is stored internally and is
+     * only valid if ErrorCode::Success is returned.
      * @return ErrorCode::Success if a log event is successfully parsed as a
      * LogEventView.
      * @return ErrorCode from LogParser::parse.

--- a/src/log_surgeon/ReaderParser.hpp
+++ b/src/log_surgeon/ReaderParser.hpp
@@ -47,9 +47,8 @@ public:
     /**
      * Attempts to parse the next log event from the internal `Reader`. Users
      * should add their own error handling and tracking logic to Reader::read,
-     * in order to retrieve IO errors. The result is stored in
-     * m_log_parser.log_event_view, and only valid if ErrorCode::Success is
-     * returned.
+     * in order to retrieve IO errors. The result is stored in internally and
+     * is only valid if ErrorCode::Success is returned.
      * @return ErrorCode::Success if a log event is successfully parsed as a
      * LogEventView.
      * @return ErrorCode from LogParser::parse.


### PR DESCRIPTION
# References
Fix needed to remove static instantiation of LogEventView in https://github.com/y-scope/clp/pull/131

# Description
Added LogEventView as member of LogParser
Fixed bug in buffer-parser example

# Validation performed
Ran reader-parser and buffer-parser examples on test log
