### PR TITLE
Add map of special regex characters; Move non-static functions to private

### DIFF
--- a/src/log_surgeon/SchemaParser.cpp
+++ b/src/log_surgeon/SchemaParser.cpp
@@ -575,7 +575,7 @@ void SchemaParser::add_productions() {
     add_production("Literal", {"Tilde"}, regex_literal_rule);
     add_production("Literal", {"Lparen", "Regex", "Rparen"}, regex_middle_identity_rule);
     for (auto const& [special_regex_name, special_regex_char] : m_special_regex_characters) {
-        (void)special_regex_char;
+        std::ignore = special_regex_char;
         add_production("Literal", {"Backslash", special_regex_name}, regex_cancel_literal_rule);
     }
     add_production("Integer", {"Integer", "Numeric"}, regex_existing_integer_rule);

--- a/src/log_surgeon/SchemaParser.cpp
+++ b/src/log_surgeon/SchemaParser.cpp
@@ -389,7 +389,7 @@ static auto new_delimiter_string_rule(NonTerminal* m) -> unique_ptr<ParserAST> {
 
 void SchemaParser::add_lexical_rules() {
     for (auto special_char : m_special_regex_characters) {
-        add_token(special_char.m_name, special_char.m_character);
+        add_token(special_char.first, special_char.second);
     }
     add_token("Tab", '\t');  // 9
     add_token("NewLine", '\n');  // 10
@@ -575,7 +575,7 @@ void SchemaParser::add_productions() {
     add_production("Literal", {"Tilde"}, regex_literal_rule);
     add_production("Literal", {"Lparen", "Regex", "Rparen"}, regex_middle_identity_rule);
     for (auto special_char : m_special_regex_characters) {
-        add_production("Literal", {"Backslash", special_char.m_name}, regex_cancel_literal_rule);
+        add_production("Literal", {"Backslash", special_char.first}, regex_cancel_literal_rule);
     }
     add_production("Integer", {"Integer", "Numeric"}, regex_existing_integer_rule);
     add_production("Integer", {"Numeric"}, regex_new_integer_rule);

--- a/src/log_surgeon/SchemaParser.cpp
+++ b/src/log_surgeon/SchemaParser.cpp
@@ -574,8 +574,8 @@ void SchemaParser::add_productions() {
     add_production("Literal", {"Backslash", "Rbrace"}, regex_cancel_literal_rule);
     add_production("Literal", {"Tilde"}, regex_literal_rule);
     add_production("Literal", {"Lparen", "Regex", "Rparen"}, regex_middle_identity_rule);
-    for (const auto& [special_regex_name, special_regex_char] : m_special_regex_characters) {
-        (void) special_regex_char;
+    for (auto const& [special_regex_name, special_regex_char] : m_special_regex_characters) {
+        (void)special_regex_char;
         add_production("Literal", {"Backslash", special_regex_name}, regex_cancel_literal_rule);
     }
     add_production("Integer", {"Integer", "Numeric"}, regex_existing_integer_rule);

--- a/src/log_surgeon/SchemaParser.cpp
+++ b/src/log_surgeon/SchemaParser.cpp
@@ -575,6 +575,7 @@ void SchemaParser::add_productions() {
     add_production("Literal", {"Tilde"}, regex_literal_rule);
     add_production("Literal", {"Lparen", "Regex", "Rparen"}, regex_middle_identity_rule);
     for (const auto& [special_regex_name, special_regex_char] : m_special_regex_characters) {
+        (void) special_regex_char;
         add_production("Literal", {"Backslash", special_regex_name}, regex_cancel_literal_rule);
     }
     add_production("Integer", {"Integer", "Numeric"}, regex_existing_integer_rule);

--- a/src/log_surgeon/SchemaParser.cpp
+++ b/src/log_surgeon/SchemaParser.cpp
@@ -388,6 +388,9 @@ static auto new_delimiter_string_rule(NonTerminal* m) -> unique_ptr<ParserAST> {
 }
 
 void SchemaParser::add_lexical_rules() {
+    for (auto special_char : m_special_regex_characters) {
+        add_token(special_char.m_name, special_char.m_character);
+    }
     add_token("Tab", '\t');  // 9
     add_token("NewLine", '\n');  // 10
     add_token("VerticalTab", '\v');  // 11
@@ -401,13 +404,7 @@ void SchemaParser::add_lexical_rules() {
     add_token("Percent", '%');
     add_token("Ampersand", '&');
     add_token("Apostrophe", '\'');
-    add_token("Lparen", '(');
-    add_token("Rparen", ')');
-    add_token("Star", '*');
-    add_token("Plus", '+');
     add_token("Comma", ',');
-    add_token("Dash", '-');
-    add_token("Dot", '.');
     add_token("ForwardSlash", '/');
     add_token_group("Numeric", make_unique<RegexASTGroupByte>('0', '9'));
     add_token("Colon", ':');
@@ -420,15 +417,8 @@ void SchemaParser::add_lexical_rules() {
     add_token_group("AlphaNumeric", make_unique<RegexASTGroupByte>('a', 'z'));
     add_token_group("AlphaNumeric", make_unique<RegexASTGroupByte>('A', 'Z'));
     add_token_group("AlphaNumeric", make_unique<RegexASTGroupByte>('0', '9'));
-    add_token("Lbracket", '[');
-    add_token("Backslash", '\\');
-    add_token("Rbracket", ']');
-    add_token("Hat", '^');
     add_token("Underscore", '_');
     add_token("Backtick", '`');
-    add_token("Lbrace", '{');
-    add_token("Vbar", '|');
-    add_token("Rbrace", '}');
     add_token("Tilde", '~');
     add_token("d", 'd');
     add_token("s", 's');
@@ -584,6 +574,9 @@ void SchemaParser::add_productions() {
     add_production("Literal", {"Backslash", "Rbrace"}, regex_cancel_literal_rule);
     add_production("Literal", {"Tilde"}, regex_literal_rule);
     add_production("Literal", {"Lparen", "Regex", "Rparen"}, regex_middle_identity_rule);
+    for (auto special_char : m_special_regex_characters) {
+        add_production("Literal", {"Backslash", special_char.m_name}, regex_cancel_literal_rule);
+    }
     add_production("Integer", {"Integer", "Numeric"}, regex_existing_integer_rule);
     add_production("Integer", {"Numeric"}, regex_new_integer_rule);
     add_production("Digit", {"Backslash", "d"}, regex_digit_rule);

--- a/src/log_surgeon/SchemaParser.cpp
+++ b/src/log_surgeon/SchemaParser.cpp
@@ -388,8 +388,8 @@ static auto new_delimiter_string_rule(NonTerminal* m) -> unique_ptr<ParserAST> {
 }
 
 void SchemaParser::add_lexical_rules() {
-    for (auto special_char : m_special_regex_characters) {
-        add_token(special_char.first, special_char.second);
+    for (auto const& [special_regex_name, special_regex_char] : m_special_regex_characters) {
+        add_token(special_regex_name, special_regex_char);
     }
     add_token("Tab", '\t');  // 9
     add_token("NewLine", '\n');  // 10
@@ -574,8 +574,8 @@ void SchemaParser::add_productions() {
     add_production("Literal", {"Backslash", "Rbrace"}, regex_cancel_literal_rule);
     add_production("Literal", {"Tilde"}, regex_literal_rule);
     add_production("Literal", {"Lparen", "Regex", "Rparen"}, regex_middle_identity_rule);
-    for (auto special_char : m_special_regex_characters) {
-        add_production("Literal", {"Backslash", special_char.first}, regex_cancel_literal_rule);
+    for (const auto& [special_regex_name, special_regex_char] : m_special_regex_characters) {
+        add_production("Literal", {"Backslash", special_regex_name}, regex_cancel_literal_rule);
     }
     add_production("Integer", {"Integer", "Numeric"}, regex_existing_integer_rule);
     add_production("Integer", {"Numeric"}, regex_new_integer_rule);

--- a/src/log_surgeon/SchemaParser.hpp
+++ b/src/log_surgeon/SchemaParser.hpp
@@ -6,6 +6,17 @@
 #include <log_surgeon/LALR1Parser.hpp>
 
 namespace log_surgeon {
+// Represents a non-literal character used to specify regex
+class SpecialRegexCharacter {
+public:
+    SpecialRegexCharacter(std::string name, char character)
+            : m_name(name),
+              m_character(character) {}
+
+    std::string m_name;
+    char m_character;
+};
+
 // ASTs used in SchemaParser AST
 class SchemaAST : public ParserAST {
 public:
@@ -71,16 +82,6 @@ class SchemaParser : public LALR1Parser<
                              finite_automata::RegexNFAByteState,
                              finite_automata::RegexDFAByteState> {
 public:
-    // Constructor
-    SchemaParser();
-
-    /**
-     * A semantic rule that needs access to soft_reset()
-     * @param m
-     * @return std::unique_ptr<SchemaAST>
-     */
-    auto existing_schema_rule(NonTerminal* m) -> std::unique_ptr<SchemaAST>;
-
     /**
      * File wrapper around generate_schema_ast()
      * @param schema_file_path
@@ -95,7 +96,21 @@ public:
      */
     static auto try_schema_string(std::string const& schema_string) -> std::unique_ptr<SchemaAST>;
 
+    static auto get_special_regex_characters() -> std::vector<SpecialRegexCharacter> const& {
+        return m_special_regex_characters;
+    }
+
 private:
+    // Constructor
+    SchemaParser();
+
+    /**
+     * A semantic rule that needs access to soft_reset()
+     * @param m
+     * @return std::unique_ptr<SchemaAST>
+     */
+    auto existing_schema_rule(NonTerminal* m) -> std::unique_ptr<SchemaAST>;
+
     /**
      * After lexing half of the buffer, reads into that half of the buffer and
      * changes variables accordingly
@@ -120,6 +135,21 @@ private:
      * @return std::unique_ptr<SchemaAST>
      */
     auto generate_schema_ast(Reader& reader) -> std::unique_ptr<SchemaAST>;
+
+    static inline std::vector<SpecialRegexCharacter> const m_special_regex_characters = {
+            SpecialRegexCharacter("Lparen", '{'),
+            SpecialRegexCharacter("Rparen", '}'),
+            SpecialRegexCharacter("Star", '*'),
+            SpecialRegexCharacter("Plus", '+'),
+            SpecialRegexCharacter("Dash", '-'),
+            SpecialRegexCharacter("Dot", '.'),
+            SpecialRegexCharacter("Lbracket", '['),
+            SpecialRegexCharacter("Rbracket", ']'),
+            SpecialRegexCharacter("Backslash", '\\'),
+            SpecialRegexCharacter("Hat", '^'),
+            SpecialRegexCharacter("Lbrace", '{'),
+            SpecialRegexCharacter("Rbrace", '}'),
+            SpecialRegexCharacter("VBar", '|')};
 };
 }  // namespace log_surgeon
 

--- a/src/log_surgeon/SchemaParser.hpp
+++ b/src/log_surgeon/SchemaParser.hpp
@@ -85,7 +85,7 @@ public:
      */
     static auto try_schema_string(std::string const& schema_string) -> std::unique_ptr<SchemaAST>;
 
-    static auto get_special_regex_characters() -> std::unordered_map<std::string,char> const& {
+    static auto get_special_regex_characters() -> std::unordered_map<std::string, char> const& {
         return m_special_regex_characters;
     }
 

--- a/src/log_surgeon/SchemaParser.hpp
+++ b/src/log_surgeon/SchemaParser.hpp
@@ -137,8 +137,8 @@ private:
     auto generate_schema_ast(Reader& reader) -> std::unique_ptr<SchemaAST>;
 
     static inline std::vector<SpecialRegexCharacter> const m_special_regex_characters = {
-            SpecialRegexCharacter("Lparen", '{'),
-            SpecialRegexCharacter("Rparen", '}'),
+            SpecialRegexCharacter("Lparen", '('),
+            SpecialRegexCharacter("Rparen", ')'),
             SpecialRegexCharacter("Star", '*'),
             SpecialRegexCharacter("Plus", '+'),
             SpecialRegexCharacter("Dash", '-'),
@@ -149,7 +149,7 @@ private:
             SpecialRegexCharacter("Hat", '^'),
             SpecialRegexCharacter("Lbrace", '{'),
             SpecialRegexCharacter("Rbrace", '}'),
-            SpecialRegexCharacter("VBar", '|')};
+            SpecialRegexCharacter("Vbar", '|')};
 };
 }  // namespace log_surgeon
 

--- a/src/log_surgeon/SchemaParser.hpp
+++ b/src/log_surgeon/SchemaParser.hpp
@@ -6,10 +6,9 @@
 #include <log_surgeon/LALR1Parser.hpp>
 
 namespace log_surgeon {
-// Represents a non-literal character used to specify regex
-class RegexCharacter {
+class NamedCharacter {
 public:
-    RegexCharacter(std::string name, char character)
+    NamedCharacter(std::string name, char character)
             : m_name(name),
               m_character(character) {}
 
@@ -96,7 +95,7 @@ public:
      */
     static auto try_schema_string(std::string const& schema_string) -> std::unique_ptr<SchemaAST>;
 
-    static auto get_special_regex_characters() -> std::vector<RegexCharacter> const& {
+    static auto get_special_regex_characters() -> std::vector<NamedCharacter> const& {
         return m_special_regex_characters;
     }
 
@@ -136,20 +135,20 @@ private:
      */
     auto generate_schema_ast(Reader& reader) -> std::unique_ptr<SchemaAST>;
 
-    static inline std::vector<RegexCharacter> const m_special_regex_characters = {
-            RegexCharacter("Lparen", '('),
-            RegexCharacter("Rparen", ')'),
-            RegexCharacter("Star", '*'),
-            RegexCharacter("Plus", '+'),
-            RegexCharacter("Dash", '-'),
-            RegexCharacter("Dot", '.'),
-            RegexCharacter("Lbracket", '['),
-            RegexCharacter("Rbracket", ']'),
-            RegexCharacter("Backslash", '\\'),
-            RegexCharacter("Hat", '^'),
-            RegexCharacter("Lbrace", '{'),
-            RegexCharacter("Rbrace", '}'),
-            RegexCharacter("Vbar", '|')};
+    static inline std::vector<NamedCharacter> const m_special_regex_characters = {
+            NamedCharacter("Lparen", '('),
+            NamedCharacter("Rparen", ')'),
+            NamedCharacter("Star", '*'),
+            NamedCharacter("Plus", '+'),
+            NamedCharacter("Dash", '-'),
+            NamedCharacter("Dot", '.'),
+            NamedCharacter("Lbracket", '['),
+            NamedCharacter("Rbracket", ']'),
+            NamedCharacter("Backslash", '\\'),
+            NamedCharacter("Hat", '^'),
+            NamedCharacter("Lbrace", '{'),
+            NamedCharacter("Rbrace", '}'),
+            NamedCharacter("Vbar", '|')};
 };
 }  // namespace log_surgeon
 

--- a/src/log_surgeon/SchemaParser.hpp
+++ b/src/log_surgeon/SchemaParser.hpp
@@ -7,9 +7,9 @@
 
 namespace log_surgeon {
 // Represents a non-literal character used to specify regex
-class SpecialRegexCharacter {
+class RegexCharacter {
 public:
-    SpecialRegexCharacter(std::string name, char character)
+    RegexCharacter(std::string name, char character)
             : m_name(name),
               m_character(character) {}
 
@@ -96,7 +96,7 @@ public:
      */
     static auto try_schema_string(std::string const& schema_string) -> std::unique_ptr<SchemaAST>;
 
-    static auto get_special_regex_characters() -> std::vector<SpecialRegexCharacter> const& {
+    static auto get_special_regex_characters() -> std::vector<RegexCharacter> const& {
         return m_special_regex_characters;
     }
 
@@ -136,20 +136,20 @@ private:
      */
     auto generate_schema_ast(Reader& reader) -> std::unique_ptr<SchemaAST>;
 
-    static inline std::vector<SpecialRegexCharacter> const m_special_regex_characters = {
-            SpecialRegexCharacter("Lparen", '('),
-            SpecialRegexCharacter("Rparen", ')'),
-            SpecialRegexCharacter("Star", '*'),
-            SpecialRegexCharacter("Plus", '+'),
-            SpecialRegexCharacter("Dash", '-'),
-            SpecialRegexCharacter("Dot", '.'),
-            SpecialRegexCharacter("Lbracket", '['),
-            SpecialRegexCharacter("Rbracket", ']'),
-            SpecialRegexCharacter("Backslash", '\\'),
-            SpecialRegexCharacter("Hat", '^'),
-            SpecialRegexCharacter("Lbrace", '{'),
-            SpecialRegexCharacter("Rbrace", '}'),
-            SpecialRegexCharacter("Vbar", '|')};
+    static inline std::vector<RegexCharacter> const m_special_regex_characters = {
+            RegexCharacter("Lparen", '('),
+            RegexCharacter("Rparen", ')'),
+            RegexCharacter("Star", '*'),
+            RegexCharacter("Plus", '+'),
+            RegexCharacter("Dash", '-'),
+            RegexCharacter("Dot", '.'),
+            RegexCharacter("Lbracket", '['),
+            RegexCharacter("Rbracket", ']'),
+            RegexCharacter("Backslash", '\\'),
+            RegexCharacter("Hat", '^'),
+            RegexCharacter("Lbrace", '{'),
+            RegexCharacter("Rbrace", '}'),
+            RegexCharacter("Vbar", '|')};
 };
 }  // namespace log_surgeon
 

--- a/src/log_surgeon/SchemaParser.hpp
+++ b/src/log_surgeon/SchemaParser.hpp
@@ -6,16 +6,6 @@
 #include <log_surgeon/LALR1Parser.hpp>
 
 namespace log_surgeon {
-class NamedCharacter {
-public:
-    NamedCharacter(std::string name, char character)
-            : m_name(name),
-              m_character(character) {}
-
-    std::string m_name;
-    char m_character;
-};
-
 // ASTs used in SchemaParser AST
 class SchemaAST : public ParserAST {
 public:
@@ -95,7 +85,7 @@ public:
      */
     static auto try_schema_string(std::string const& schema_string) -> std::unique_ptr<SchemaAST>;
 
-    static auto get_special_regex_characters() -> std::vector<NamedCharacter> const& {
+    static auto get_special_regex_characters() -> std::unordered_map<std::string,char> const& {
         return m_special_regex_characters;
     }
 
@@ -135,20 +125,20 @@ private:
      */
     auto generate_schema_ast(Reader& reader) -> std::unique_ptr<SchemaAST>;
 
-    static inline std::vector<NamedCharacter> const m_special_regex_characters = {
-            NamedCharacter("Lparen", '('),
-            NamedCharacter("Rparen", ')'),
-            NamedCharacter("Star", '*'),
-            NamedCharacter("Plus", '+'),
-            NamedCharacter("Dash", '-'),
-            NamedCharacter("Dot", '.'),
-            NamedCharacter("Lbracket", '['),
-            NamedCharacter("Rbracket", ']'),
-            NamedCharacter("Backslash", '\\'),
-            NamedCharacter("Hat", '^'),
-            NamedCharacter("Lbrace", '{'),
-            NamedCharacter("Rbrace", '}'),
-            NamedCharacter("Vbar", '|')};
+    static inline std::unordered_map<std::string, char> const m_special_regex_characters{
+            {"Lparen", '('},
+            {"Rparen", ')'},
+            {"Star", '*'},
+            {"Plus", '+'},
+            {"Dash", '-'},
+            {"Dot", '.'},
+            {"Lbracket", '['},
+            {"Rbracket", ']'},
+            {"Backslash", '\\'},
+            {"Hat", '^'},
+            {"Lbrace", '{'},
+            {"Rbrace", '}'},
+            {"Vbar", '|'}};
 };
 }  // namespace log_surgeon
 


### PR DESCRIPTION
# Description
Add a map of all special characters used in the regex language supported by log-surgeon.
- Use this map in the SchemaParser class when adding schema tokens of special regex characters to its lexer.
- Use this map in the SchemaParser class adding productions to escape the literal counterparts of the special characters.
- Provide access to the map of special characters to anything using the SchemaParser class.

Move non-static functions to private as these are not suppose to be used directly.

# Validation performed
Ran reader-parser example and buffer-parser example executables successfully
