### PR TITLE
Swap key and value in map of special regex characters

### DIFF
--- a/src/log_surgeon/SchemaParser.cpp
+++ b/src/log_surgeon/SchemaParser.cpp
@@ -388,7 +388,7 @@ static auto new_delimiter_string_rule(NonTerminal* m) -> unique_ptr<ParserAST> {
 }
 
 void SchemaParser::add_lexical_rules() {
-    for (auto const& [special_regex_name, special_regex_char] : m_special_regex_characters) {
+    for (auto const& [special_regex_char, special_regex_name] : m_special_regex_characters) {
         add_token(special_regex_name, special_regex_char);
     }
     add_token("Tab", '\t');  // 9
@@ -574,7 +574,7 @@ void SchemaParser::add_productions() {
     add_production("Literal", {"Backslash", "Rbrace"}, regex_cancel_literal_rule);
     add_production("Literal", {"Tilde"}, regex_literal_rule);
     add_production("Literal", {"Lparen", "Regex", "Rparen"}, regex_middle_identity_rule);
-    for (auto const& [special_regex_name, special_regex_char] : m_special_regex_characters) {
+    for (auto const& [special_regex_char, special_regex_name] : m_special_regex_characters) {
         std::ignore = special_regex_char;
         add_production("Literal", {"Backslash", special_regex_name}, regex_cancel_literal_rule);
     }

--- a/src/log_surgeon/SchemaParser.hpp
+++ b/src/log_surgeon/SchemaParser.hpp
@@ -85,7 +85,7 @@ public:
      */
     static auto try_schema_string(std::string const& schema_string) -> std::unique_ptr<SchemaAST>;
 
-    static auto get_special_regex_characters() -> std::unordered_map<std::string, char> const& {
+    static auto get_special_regex_characters() -> std::unordered_map<char, std::string> const& {
         return m_special_regex_characters;
     }
 
@@ -125,20 +125,20 @@ private:
      */
     auto generate_schema_ast(Reader& reader) -> std::unique_ptr<SchemaAST>;
 
-    static inline std::unordered_map<std::string, char> const m_special_regex_characters{
-            {"Lparen", '('},
-            {"Rparen", ')'},
-            {"Star", '*'},
-            {"Plus", '+'},
-            {"Dash", '-'},
-            {"Dot", '.'},
-            {"Lbracket", '['},
-            {"Rbracket", ']'},
-            {"Backslash", '\\'},
-            {"Hat", '^'},
-            {"Lbrace", '{'},
-            {"Rbrace", '}'},
-            {"Vbar", '|'}};
+    static inline std::unordered_map<char, std::string> const m_special_regex_characters{
+            {'(', "Lparen"},
+            {')', "Rparen"},
+            {'*', "Star"},
+            {'+', "Plus"},
+            {'-', "Dash"},
+            {'.', "Dot"},
+            {'[', "Lbracket"},
+            {']', "Rbracket"},
+            {'\\', "Backslash"},
+            {'^', "Hat"},
+            {'{', "Lbrace"},
+            {'}', "Rbrace"},
+            {'|', "Vbar"}};
 };
 }  // namespace log_surgeon
 


### PR DESCRIPTION
# Description
Set the character to be the key in the special regex characters map. A project including log-surgeon can then make use of this map only knowing the characters and not the assigned names.

# Validation performed
Ran reader-parser example and buffer-parser example executables successfully
