### PR TITLE
Fix empty schema objects

### DIFF
--- a/src/log_surgeon/Schema.cpp
+++ b/src/log_surgeon/Schema.cpp
@@ -3,6 +3,10 @@
 #include <string>
 
 namespace log_surgeon {
+Schema::Schema() {
+    m_schema_ast = std::make_unique<SchemaAST>();
+}
+
 Schema::Schema(std::string const& schema_file_path)
         : m_schema_ast{SchemaParser::try_schema_file(schema_file_path)} {}
 

--- a/src/log_surgeon/Schema.hpp
+++ b/src/log_surgeon/Schema.hpp
@@ -14,7 +14,7 @@ namespace log_surgeon {
  */
 class Schema {
 public:
-    Schema() = default;
+    Schema();
 
     explicit Schema(std::string const& schema_file_path);
 


### PR DESCRIPTION
# Description
Fix bug when creating and trying to use empty schema objects by  creating a SchemaAST unique pointer when constructing an empty schema object.

# Validation performed
Ran reader-buffer and parser-buffer with correct output.

