### PR TITLE
Expose DFA creation and Lexer's internal DFA to external classes

### DIFF
--- a/src/log_surgeon/Lexer.hpp
+++ b/src/log_surgeon/Lexer.hpp
@@ -149,7 +149,7 @@ public:
      * @param finite_automata::RegexNFA<NFAStateType> nfa
      * @return std::unique_ptr<finite_automata::RegexDFA<DFAStateType>>
      */
-    auto nfa_to_dfa(finite_automata::RegexNFA<NFAStateType>& nfa)
+    static auto nfa_to_dfa(finite_automata::RegexNFA<NFAStateType>& nfa)
             -> std::unique_ptr<finite_automata::RegexDFA<DFAStateType>>;
 
     std::unordered_map<std::string, uint32_t> m_symbol_id;
@@ -166,7 +166,7 @@ private:
      * Return epsilon_closure over m_epsilon_transitions
      * @return
      */
-    auto epsilon_closure(NFAStateType const* state_ptr) -> std::set<NFAStateType const*>;
+    static auto epsilon_closure(NFAStateType const* state_ptr) -> std::set<NFAStateType const*>;
 
     uint32_t m_match_pos{0};
     uint32_t m_start_pos{0};

--- a/src/log_surgeon/Lexer.hpp
+++ b/src/log_surgeon/Lexer.hpp
@@ -139,6 +139,19 @@ public:
         return m_is_first_char[byte];
     }
 
+    [[nodiscard]] auto get_dfa() const
+            -> std::unique_ptr<finite_automata::RegexDFA<DFAStateType>> const& {
+        return m_dfa;
+    }
+
+    /**
+     * Generate a DFA from an NFA
+     * @param finite_automata::RegexNFA<NFAStateType> nfa
+     * @return std::unique_ptr<finite_automata::RegexDFA<DFAStateType>>
+     */
+    auto nfa_to_dfa(finite_automata::RegexNFA<NFAStateType>& nfa)
+            -> std::unique_ptr<finite_automata::RegexDFA<DFAStateType>>;
+
     std::unordered_map<std::string, uint32_t> m_symbol_id;
     std::unordered_map<uint32_t, std::string> m_id_symbol;
 
@@ -155,13 +168,6 @@ private:
      */
     auto epsilon_closure(NFAStateType const* state_ptr) -> std::set<NFAStateType const*>;
 
-    /**
-     * Generate a DFA from the NFA
-     * @param finite_automata::RegexNFA<NFAStateType> nfa
-     * @return std::unique_ptr<finite_automata::RegexDFA<DFAStateType>>
-     */
-    auto nfa_to_dfa(finite_automata::RegexNFA<NFAStateType>& nfa)
-            -> std::unique_ptr<finite_automata::RegexDFA<DFAStateType>>;
     uint32_t m_match_pos{0};
     uint32_t m_start_pos{0};
     uint32_t m_match_line{0};

--- a/src/log_surgeon/Lexer.hpp
+++ b/src/log_surgeon/Lexer.hpp
@@ -46,6 +46,14 @@ public:
     };
 
     /**
+     * Generate a DFA from an NFA
+     * @param finite_automata::RegexNFA<NFAStateType> nfa
+     * @return std::unique_ptr<finite_automata::RegexDFA<DFAStateType>>
+     */
+    static auto nfa_to_dfa(finite_automata::RegexNFA<NFAStateType>& nfa)
+            -> std::unique_ptr<finite_automata::RegexDFA<DFAStateType>>;
+
+    /**
      * Add a delimiters line from the schema to the lexer
      * @param delimiters
      */
@@ -144,29 +152,21 @@ public:
         return m_dfa;
     }
 
-    /**
-     * Generate a DFA from an NFA
-     * @param finite_automata::RegexNFA<NFAStateType> nfa
-     * @return std::unique_ptr<finite_automata::RegexDFA<DFAStateType>>
-     */
-    static auto nfa_to_dfa(finite_automata::RegexNFA<NFAStateType>& nfa)
-            -> std::unique_ptr<finite_automata::RegexDFA<DFAStateType>>;
-
     std::unordered_map<std::string, uint32_t> m_symbol_id;
     std::unordered_map<uint32_t, std::string> m_id_symbol;
 
 private:
     /**
-     * Get next character from the input buffer
-     * @return unsigned char
-     */
-    auto get_next_character() -> unsigned char;
-
-    /**
      * Return epsilon_closure over m_epsilon_transitions
      * @return
      */
     static auto epsilon_closure(NFAStateType const* state_ptr) -> std::set<NFAStateType const*>;
+
+    /**
+     * Get next character from the input buffer
+     * @return unsigned char
+     */
+    auto get_next_character() -> unsigned char;
 
     uint32_t m_match_pos{0};
     uint32_t m_start_pos{0};


### PR DESCRIPTION
# Description
- Create additional DFAs that are not stored inside the Lexer
- Allow external classes to get access to the Lexer's internal DFA 

# Validation performed
- Ran reader-parser and buffer-parser with correct output
