### PR TITLE
Add DFA intersection

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -28,3 +28,6 @@ add_to_target(buffer-parser "${libraries}")
 
 add_executable(reader-parser reader-parser.cpp)
 add_to_target(reader-parser "${libraries}")
+
+add_executable(intersect-test intersect-test.cpp)
+add_to_target(intersect-test "${libraries}")

--- a/examples/intersect-test.cpp
+++ b/examples/intersect-test.cpp
@@ -1,0 +1,114 @@
+#include <iostream>
+#include <string>
+
+#include <log_surgeon/Lexer.hpp>
+#include <log_surgeon/Schema.hpp>
+
+using log_surgeon::finite_automata::RegexDFA;
+using log_surgeon::finite_automata::RegexDFAByteState;
+using log_surgeon::finite_automata::RegexNFA;
+using log_surgeon::finite_automata::RegexNFAByteState;
+using log_surgeon::lexers::ByteLexer;
+using log_surgeon::ParserAST;
+using log_surgeon::SchemaVarAST;
+using std::string;
+using std::unique_ptr;
+
+auto get_intersect_for_query(ByteLexer& lexer, std::string const& search_string) -> void {
+    std::string processed_search_string;
+    // Replace all * with .*
+    for (char const& c : search_string) {
+        if (c == '*') {
+            processed_search_string.push_back('.');
+        }
+        processed_search_string.push_back(c);
+    }
+    log_surgeon::Schema schema2;
+    schema2.add_variable("search", processed_search_string, -1);
+    RegexNFA<RegexNFAByteState> nfa;
+    for (unique_ptr<ParserAST> const& parser_ast : schema2.get_schema_ast_ptr()->m_schema_vars) {
+        auto* schema_var_ast = dynamic_cast<SchemaVarAST*>(parser_ast.get());
+        ByteLexer::Rule rule(0, std::move(schema_var_ast->m_regex_ptr));
+        rule.add_ast(&nfa);
+    }
+    // TODO: this is obviously bad, but the code needs to be reorganized a lot
+    // to fix the fact that DFAs and NFAs can't be used without a lexer
+    std::unique_ptr<RegexDFA<RegexDFAByteState>> dfa2 = lexer.nfa_to_dfa(nfa);
+    [[maybe_unused]] std::unique_ptr<RegexDFA<RegexDFAByteState>> const& dfa1 = lexer.get_dfa();
+    std::set<uint32_t> schema_types = dfa1->get_intersect(dfa2);
+
+    std::cout << search_string << ":";
+    for (auto const& schema_type : schema_types) {
+        std::cout << lexer.m_id_symbol[schema_type] << ",";
+    }
+    std::cout << std::endl;
+}
+
+auto main() -> int {
+    {
+        std::cout << "--LEXER1--" << std::endl;
+        log_surgeon::Schema schema;
+        schema.add_variable("int", "\\-{0,1}[0-9]+", -1);
+        schema.add_variable("float", "\\-{0,1}[0-9]+\\.[0-9]+", -1);
+        schema.add_variable("hex", "[a-fA-F]+", -1);
+        schema.add_variable("hasNumber", ".*\\d.*", -1);
+        schema.add_variable("equals", ".*=.*[a-zA-Z0-9].*", -1);
+        schema.add_variable("logLevel", "(INFO)|(DEBUG)|(WARN)|(ERROR)|(TRACE)|(FATAL)", -1);
+
+        ByteLexer lexer;
+        for (unique_ptr<ParserAST> const& parser_ast : schema.get_schema_ast_ptr()->m_schema_vars) {
+            auto* rule = dynamic_cast<SchemaVarAST*>(parser_ast.get());
+            std::string& name = rule->m_name;
+            if (lexer.m_symbol_id.find(name) == lexer.m_symbol_id.end()) {
+                lexer.m_symbol_id[name] = lexer.m_symbol_id.size();
+                lexer.m_id_symbol[lexer.m_symbol_id[name]] = name;
+            }
+            lexer.add_rule(lexer.m_symbol_id[name], std::move(rule->m_regex_ptr));
+        }
+        lexer.generate();
+
+        get_intersect_for_query(lexer, "*1*");
+        get_intersect_for_query(lexer, "*a*");
+        get_intersect_for_query(lexer, "*a1*");
+        get_intersect_for_query(lexer, "*=*");
+        get_intersect_for_query(lexer, "abc123");
+        get_intersect_for_query(lexer, "=");
+        get_intersect_for_query(lexer, "1");
+        get_intersect_for_query(lexer, "a*1");
+        get_intersect_for_query(lexer, "a1");
+    }
+
+    {
+        std::cout << "--LEXER2--" << std::endl;
+        log_surgeon::Schema schema;
+        schema.add_variable("v1", "1", -1);
+        schema.add_variable("v2", "2", -1);
+        schema.add_variable("v3", "3", -1);
+        schema.add_variable("v4", "abc12", -1);
+        schema.add_variable("v5", "23def", -1);
+        schema.add_variable("v6", "123", -1);
+
+        ByteLexer lexer;
+        for (unique_ptr<ParserAST> const& parser_ast : schema.get_schema_ast_ptr()->m_schema_vars) {
+            auto* rule = dynamic_cast<SchemaVarAST*>(parser_ast.get());
+            std::string& name = rule->m_name;
+            if (lexer.m_symbol_id.find(name) == lexer.m_symbol_id.end()) {
+                lexer.m_symbol_id[name] = lexer.m_symbol_id.size();
+                lexer.m_id_symbol[lexer.m_symbol_id[name]] = name;
+            }
+            lexer.add_rule(lexer.m_symbol_id[name], std::move(rule->m_regex_ptr));
+        }
+        lexer.generate();
+
+        get_intersect_for_query(lexer, "*1*");
+        get_intersect_for_query(lexer, "*a*");
+        get_intersect_for_query(lexer, "*a1*");
+        get_intersect_for_query(lexer, "*=*");
+        get_intersect_for_query(lexer, "abc12");
+        get_intersect_for_query(lexer, "=");
+        get_intersect_for_query(lexer, "1");
+        get_intersect_for_query(lexer, "a*1");
+        get_intersect_for_query(lexer, "a1");
+    }
+    return 0;
+}

--- a/examples/intersect-test.cpp
+++ b/examples/intersect-test.cpp
@@ -14,7 +14,17 @@ using log_surgeon::SchemaVarAST;
 using std::string;
 using std::unique_ptr;
 
-auto get_intersect_for_query(ByteLexer& lexer, std::string const& search_string) -> void {
+auto get_intersect_for_query(log_surgeon::Schema& schema, std::string const& search_string)
+        -> void {
+    std::map<uint32_t, std::string> m_id_symbol;
+    RegexNFA<RegexNFAByteState> nfa1;
+    for (unique_ptr<ParserAST> const& parser_ast : schema.get_schema_ast_ptr()->m_schema_vars) {
+        auto* var_ast = dynamic_cast<SchemaVarAST*>(parser_ast.get());
+        ByteLexer::Rule rule(m_id_symbol.size(), std::move(var_ast->m_regex_ptr));
+        m_id_symbol[m_id_symbol.size()] = var_ast->m_name;
+        rule.add_ast(&nfa1);
+    }
+    std::unique_ptr<RegexDFA<RegexDFAByteState>> dfa1 = ByteLexer::nfa_to_dfa(nfa1);
     std::string processed_search_string;
     // Replace all * with .*
     for (char const& c : search_string) {
@@ -25,87 +35,50 @@ auto get_intersect_for_query(ByteLexer& lexer, std::string const& search_string)
     }
     log_surgeon::Schema schema2;
     schema2.add_variable("search", processed_search_string, -1);
-    RegexNFA<RegexNFAByteState> nfa;
+    RegexNFA<RegexNFAByteState> nfa2;
     for (unique_ptr<ParserAST> const& parser_ast : schema2.get_schema_ast_ptr()->m_schema_vars) {
         auto* schema_var_ast = dynamic_cast<SchemaVarAST*>(parser_ast.get());
         ByteLexer::Rule rule(0, std::move(schema_var_ast->m_regex_ptr));
-        rule.add_ast(&nfa);
+        rule.add_ast(&nfa2);
     }
-    std::unique_ptr<RegexDFA<RegexDFAByteState>> dfa2 = ByteLexer::nfa_to_dfa(nfa);
-    std::unique_ptr<RegexDFA<RegexDFAByteState>> const& dfa1 = lexer.get_dfa();
+    std::unique_ptr<RegexDFA<RegexDFAByteState>> dfa2 = ByteLexer::nfa_to_dfa(nfa2);
     std::set<uint32_t> schema_types = dfa1->get_intersect(dfa2);
     std::cout << search_string << ":";
     for (auto const& schema_type : schema_types) {
-        std::cout << lexer.m_id_symbol[schema_type] << ",";
+        std::cout << m_id_symbol[schema_type] << ",";
     }
     std::cout << std::endl;
 }
 
 auto main() -> int {
-    {
-        std::cout << "--LEXER1--" << std::endl;
+    for (int i = 0; i < 2; i++) {
         log_surgeon::Schema schema;
-        schema.add_variable("int", "\\-{0,1}[0-9]+", -1);
-        schema.add_variable("float", "\\-{0,1}[0-9]+\\.[0-9]+", -1);
-        schema.add_variable("hex", "[a-fA-F]+", -1);
-        schema.add_variable("hasNumber", ".*\\d.*", -1);
-        schema.add_variable("equals", ".*=.*[a-zA-Z0-9].*", -1);
-        schema.add_variable("logLevel", "(INFO)|(DEBUG)|(WARN)|(ERROR)|(TRACE)|(FATAL)", -1);
-
-        ByteLexer lexer;
-        for (unique_ptr<ParserAST> const& parser_ast : schema.get_schema_ast_ptr()->m_schema_vars) {
-            auto* rule = dynamic_cast<SchemaVarAST*>(parser_ast.get());
-            std::string& name = rule->m_name;
-            if (lexer.m_symbol_id.find(name) == lexer.m_symbol_id.end()) {
-                lexer.m_symbol_id[name] = lexer.m_symbol_id.size();
-                lexer.m_id_symbol[lexer.m_symbol_id[name]] = name;
-            }
-            lexer.add_rule(lexer.m_symbol_id[name], std::move(rule->m_regex_ptr));
+        if (0 == i) {
+            std::cout << "--LEXER1--" << std::endl;
+            schema.add_variable("int", "\\-{0,1}[0-9]+", -1);
+            schema.add_variable("float", "\\-{0,1}[0-9]+\\.[0-9]+", -1);
+            schema.add_variable("hex", "[a-fA-F]+", -1);
+            schema.add_variable("hasNumber", ".*\\d.*", -1);
+            schema.add_variable("equals", ".*=.*[a-zA-Z0-9].*", -1);
+            schema.add_variable("logLevel", "(INFO)|(DEBUG)|(WARN)|(ERROR)|(TRACE)|(FATAL)", -1);
+        } else {
+            std::cout << "--LEXER2--" << std::endl;
+            schema.add_variable("v1", "1", -1);
+            schema.add_variable("v2", "2", -1);
+            schema.add_variable("v3", "3", -1);
+            schema.add_variable("v4", "abc12", -1);
+            schema.add_variable("v5", "23def", -1);
+            schema.add_variable("v6", "123", -1);
         }
-        lexer.generate();
-
-        get_intersect_for_query(lexer, "*1*");
-        get_intersect_for_query(lexer, "*a*");
-        get_intersect_for_query(lexer, "*a1*");
-        get_intersect_for_query(lexer, "*=*");
-        get_intersect_for_query(lexer, "abc123");
-        get_intersect_for_query(lexer, "=");
-        get_intersect_for_query(lexer, "1");
-        get_intersect_for_query(lexer, "a*1");
-        get_intersect_for_query(lexer, "a1");
-    }
-
-    {
-        std::cout << "--LEXER2--" << std::endl;
-        log_surgeon::Schema schema;
-        schema.add_variable("v1", "1", -1);
-        schema.add_variable("v2", "2", -1);
-        schema.add_variable("v3", "3", -1);
-        schema.add_variable("v4", "abc12", -1);
-        schema.add_variable("v5", "23def", -1);
-        schema.add_variable("v6", "123", -1);
-
-        ByteLexer lexer;
-        for (unique_ptr<ParserAST> const& parser_ast : schema.get_schema_ast_ptr()->m_schema_vars) {
-            auto* rule = dynamic_cast<SchemaVarAST*>(parser_ast.get());
-            std::string& name = rule->m_name;
-            if (lexer.m_symbol_id.find(name) == lexer.m_symbol_id.end()) {
-                lexer.m_symbol_id[name] = lexer.m_symbol_id.size();
-                lexer.m_id_symbol[lexer.m_symbol_id[name]] = name;
-            }
-            lexer.add_rule(lexer.m_symbol_id[name], std::move(rule->m_regex_ptr));
-        }
-        lexer.generate();
-
-        get_intersect_for_query(lexer, "*1*");
-        get_intersect_for_query(lexer, "*a*");
-        get_intersect_for_query(lexer, "*a1*");
-        get_intersect_for_query(lexer, "*=*");
-        get_intersect_for_query(lexer, "abc12");
-        get_intersect_for_query(lexer, "=");
-        get_intersect_for_query(lexer, "1");
-        get_intersect_for_query(lexer, "a*1");
-        get_intersect_for_query(lexer, "a1");
+        get_intersect_for_query(schema, "*1*");
+        get_intersect_for_query(schema, "*a*");
+        get_intersect_for_query(schema, "*a1*");
+        get_intersect_for_query(schema, "*=*");
+        get_intersect_for_query(schema, "abc123");
+        get_intersect_for_query(schema, "=");
+        get_intersect_for_query(schema, "1");
+        get_intersect_for_query(schema, "a*1");
+        get_intersect_for_query(schema, "a1");
     }
     return 0;
 }

--- a/examples/intersect-test.cpp
+++ b/examples/intersect-test.cpp
@@ -54,7 +54,7 @@ auto main() -> int {
     for (int i = 0; i < 2; i++) {
         log_surgeon::Schema schema;
         if (0 == i) {
-            std::cout << "--LEXER1--" << std::endl;
+            std::cout << "--Schema1--" << std::endl;
             schema.add_variable("int", "\\-{0,1}[0-9]+", -1);
             schema.add_variable("float", "\\-{0,1}[0-9]+\\.[0-9]+", -1);
             schema.add_variable("hex", "[a-fA-F]+", -1);
@@ -62,7 +62,7 @@ auto main() -> int {
             schema.add_variable("equals", ".*=.*[a-zA-Z0-9].*", -1);
             schema.add_variable("logLevel", "(INFO)|(DEBUG)|(WARN)|(ERROR)|(TRACE)|(FATAL)", -1);
         } else {
-            std::cout << "--LEXER2--" << std::endl;
+            std::cout << "--Schema2--" << std::endl;
             schema.add_variable("v1", "1", -1);
             schema.add_variable("v2", "2", -1);
             schema.add_variable("v3", "3", -1);

--- a/examples/intersect-test.cpp
+++ b/examples/intersect-test.cpp
@@ -31,12 +31,9 @@ auto get_intersect_for_query(ByteLexer& lexer, std::string const& search_string)
         ByteLexer::Rule rule(0, std::move(schema_var_ast->m_regex_ptr));
         rule.add_ast(&nfa);
     }
-    // TODO: this is obviously bad, but the code needs to be reorganized a lot
-    // to fix the fact that DFAs and NFAs can't be used without a lexer
-    std::unique_ptr<RegexDFA<RegexDFAByteState>> dfa2 = lexer.nfa_to_dfa(nfa);
-    [[maybe_unused]] std::unique_ptr<RegexDFA<RegexDFAByteState>> const& dfa1 = lexer.get_dfa();
+    std::unique_ptr<RegexDFA<RegexDFAByteState>> dfa2 = ByteLexer::nfa_to_dfa(nfa);
+    std::unique_ptr<RegexDFA<RegexDFAByteState>> const& dfa1 = lexer.get_dfa();
     std::set<uint32_t> schema_types = dfa1->get_intersect(dfa2);
-
     std::cout << search_string << ":";
     for (auto const& schema_type : schema_types) {
         std::cout << lexer.m_id_symbol[schema_type] << ",";

--- a/examples/intersect-test.cpp
+++ b/examples/intersect-test.cpp
@@ -30,15 +30,14 @@ auto get_intersect_for_query(
     log_surgeon::Schema schema;
     schema.add_variable("search", processed_search_string, -1);
     RegexNFA<RegexNFAByteState> nfa;
-    std::unique_ptr<log_surgeon::SchemaAST> schema_ast = schema.release_schema_ast_ptr();
-    for (unique_ptr<ParserAST> const& parser_ast : schema_ast->m_schema_vars)
-    {
+    auto schema_ast = schema.release_schema_ast_ptr();
+    for (unique_ptr<ParserAST> const& parser_ast : schema_ast->m_schema_vars) {
         auto* schema_var_ast = dynamic_cast<SchemaVarAST*>(parser_ast.get());
         ByteLexer::Rule rule(0, std::move(schema_var_ast->m_regex_ptr));
         rule.add_ast(&nfa);
     }
-    std::unique_ptr<RegexDFA<RegexDFAByteState>> dfa2 = ByteLexer::nfa_to_dfa(nfa);
-    std::set<uint32_t> schema_types = dfa1->get_intersect(dfa2);
+    auto dfa2 = ByteLexer::nfa_to_dfa(nfa);
+    auto schema_types = dfa1->get_intersect(dfa2);
     std::cout << search_string << ":";
     for (auto const& schema_type : schema_types) {
         std::cout << m_id_symbol[schema_type] << ",";
@@ -68,15 +67,14 @@ auto main() -> int {
         }
         std::map<uint32_t, std::string> m_id_symbol;
         RegexNFA<RegexNFAByteState> nfa;
-
-        std::unique_ptr<log_surgeon::SchemaAST> schema_ast = schema.release_schema_ast_ptr();
+        auto schema_ast = schema.release_schema_ast_ptr();
         for (unique_ptr<ParserAST> const& parser_ast : schema_ast->m_schema_vars) {
             auto* var_ast = dynamic_cast<SchemaVarAST*>(parser_ast.get());
             ByteLexer::Rule rule(m_id_symbol.size(), std::move(var_ast->m_regex_ptr));
             m_id_symbol[m_id_symbol.size()] = var_ast->m_name;
             rule.add_ast(&nfa);
         }
-        std::unique_ptr<RegexDFA<RegexDFAByteState>> dfa = ByteLexer::nfa_to_dfa(nfa);
+        auto dfa = ByteLexer::nfa_to_dfa(nfa);
         get_intersect_for_query(m_id_symbol, dfa, "*1*");
         get_intersect_for_query(m_id_symbol, dfa, "*a*");
         get_intersect_for_query(m_id_symbol, dfa, "*a1*");

--- a/src/log_surgeon/BufferParser.cpp
+++ b/src/log_surgeon/BufferParser.cpp
@@ -7,7 +7,8 @@
 #include <log_surgeon/Schema.hpp>
 
 namespace log_surgeon {
-BufferParser::BufferParser(Schema& schema) : m_log_parser(schema.get_schema_ast_ptr()) {}
+BufferParser::BufferParser(std::unique_ptr<log_surgeon::SchemaAST> schema_ast)
+        : m_log_parser(std::move(schema_ast)) {}
 
 BufferParser::BufferParser(std::string const& schema_file_path)
         : m_log_parser(LogParser(schema_file_path)) {}

--- a/src/log_surgeon/BufferParser.hpp
+++ b/src/log_surgeon/BufferParser.hpp
@@ -27,7 +27,7 @@ public:
     explicit BufferParser(std::string const& schema_file_path);
 
     /**
-     * Constructs the parser using the given schema object.
+     * Constructs the parser using the given schema AST.
      * @param schema_ast
      * @throw std::runtime_error from LALR1Parser, RegexAST, or Lexer
      * describing the failure processing the schema AST.

--- a/src/log_surgeon/BufferParser.hpp
+++ b/src/log_surgeon/BufferParser.hpp
@@ -28,11 +28,11 @@ public:
 
     /**
      * Constructs the parser using the given schema object.
-     * @param schema
+     * @param schema_ast
      * @throw std::runtime_error from LALR1Parser, RegexAST, or Lexer
      * describing the failure processing the schema AST.
      */
-    explicit BufferParser(Schema& schema);
+    explicit BufferParser(std::unique_ptr<log_surgeon::SchemaAST> schema_ast);
 
     /**
      * Clears the internal state of the log parser (lexer and input buffer) so

--- a/src/log_surgeon/LogParser.cpp
+++ b/src/log_surgeon/LogParser.cpp
@@ -28,10 +28,10 @@ using finite_automata::RegexDFAByteState;
 using finite_automata::RegexNFAByteState;
 
 LogParser::LogParser(string const& schema_file_path)
-        : LogParser::LogParser(SchemaParser::try_schema_file(schema_file_path).get()) {}
+        : LogParser::LogParser(SchemaParser::try_schema_file(schema_file_path)) {}
 
-LogParser::LogParser(SchemaAST const* schema_ast) {
-    add_rules(schema_ast);
+LogParser::LogParser(std::unique_ptr<SchemaAST> schema_ast) {
+    add_rules(std::move(schema_ast));
     m_lexer.generate();
     m_log_event_view = make_unique<LogEventView>(*this);
 }
@@ -43,7 +43,7 @@ auto LogParser::add_delimiters(unique_ptr<ParserAST> const& delimiters) -> void 
     }
 }
 
-void LogParser::add_rules(SchemaAST const* schema_ast) {
+void LogParser::add_rules(std::unique_ptr<SchemaAST> schema_ast) {
     for (auto const& delimiters : schema_ast->m_delimiters) {
         add_delimiters(delimiters);
     }

--- a/src/log_surgeon/LogParser.hpp
+++ b/src/log_surgeon/LogParser.hpp
@@ -35,11 +35,11 @@ public:
 
     /**
      * Constructs the parser using the given schema object.
-     * @param schema
+     * @param schema_ast
      * @throw std::runtime_error from LALR1Parser, RegexAST, or Lexer
      * describing the failure processing the schema AST.
      */
-    explicit LogParser(log_surgeon::SchemaAST const* schema_ast);
+    explicit LogParser(std::unique_ptr<log_surgeon::SchemaAST> schema_ast);
 
     /**
      * Returns the parser to its initial state, clearing any existing
@@ -158,7 +158,7 @@ private:
      * @param schema_ast The AST from which parsing and lexing rules are
      * generated.
      */
-    auto add_rules(SchemaAST const* schema_ast) -> void;
+    auto add_rules(std::unique_ptr<SchemaAST> schema_ast) -> void;
 
     // TODO: move ownership of the buffer to the lexer
     ParserInputBuffer m_input_buffer;

--- a/src/log_surgeon/LogParser.hpp
+++ b/src/log_surgeon/LogParser.hpp
@@ -34,7 +34,7 @@ public:
     explicit LogParser(std::string const& schema_file_path);
 
     /**
-     * Constructs the parser using the given schema object.
+     * Constructs the parser using the given schema AST.
      * @param schema_ast
      * @throw std::runtime_error from LALR1Parser, RegexAST, or Lexer
      * describing the failure processing the schema AST.

--- a/src/log_surgeon/ReaderParser.cpp
+++ b/src/log_surgeon/ReaderParser.cpp
@@ -7,7 +7,8 @@
 #include <log_surgeon/Schema.hpp>
 
 namespace log_surgeon {
-ReaderParser::ReaderParser(Schema& schema) : m_log_parser(schema.get_schema_ast_ptr()) {}
+ReaderParser::ReaderParser(std::unique_ptr<log_surgeon::SchemaAST> schema_ast)
+        : m_log_parser(std::move(schema_ast)) {}
 
 ReaderParser::ReaderParser(std::string const& schema_file_path) : m_log_parser(schema_file_path) {}
 

--- a/src/log_surgeon/ReaderParser.hpp
+++ b/src/log_surgeon/ReaderParser.hpp
@@ -26,7 +26,7 @@ public:
     explicit ReaderParser(std::string const& schema_file_path);
 
     /**
-     * Constructs the parser using the given schema object.
+     * Constructs the parser using the given schema AST.
      * @param schema_ast
      * @throw std::runtime_error from LALR1Parser, RegexAST, or Lexer
      * describing the failure processing the schema AST.

--- a/src/log_surgeon/ReaderParser.hpp
+++ b/src/log_surgeon/ReaderParser.hpp
@@ -27,11 +27,11 @@ public:
 
     /**
      * Constructs the parser using the given schema object.
-     * @param schema
+     * @param schema_ast
      * @throw std::runtime_error from LALR1Parser, RegexAST, or Lexer
      * describing the failure processing the schema AST.
      */
-    explicit ReaderParser(Schema& schema);
+    explicit ReaderParser(std::unique_ptr<log_surgeon::SchemaAST> schema_ast);
 
     /**
      * Clears the internal state of the log parser (lexer and input buffer),

--- a/src/log_surgeon/Schema.hpp
+++ b/src/log_surgeon/Schema.hpp
@@ -56,7 +56,17 @@ public:
     auto clear ();
     */
 
-    [[nodiscard]] auto get_schema_ast_ptr() const -> SchemaAST const* { return m_schema_ast.get(); }
+    /**
+     * Transfers ownership of the previously built schema_ast to the caller and
+     * replaces it with an empty schema_ast to be used by this schema object in
+     * the future
+     * @return the previously built schema_ast
+     */
+    [[nodiscard]] auto release_schema_ast_ptr() -> std::unique_ptr<SchemaAST> {
+        auto old_schema_ast = std::move(m_schema_ast);
+        m_schema_ast = std::make_unique<SchemaAST>();
+        return old_schema_ast;
+    }
 
 private:
     std::unique_ptr<SchemaAST> m_schema_ast;

--- a/src/log_surgeon/finite_automata/RegexDFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.hpp
@@ -71,10 +71,13 @@ public:
     }
 
     /**
-     * Generates all pairs reachable from the current pair via a single input.
-     * @return A vector of reachable pairs
+     * Generates all pairs reachable from the current pair via any string and
+     * store any reachable pair not previously visited in unvisited_pairs
      */
-    auto get_reachable_pairs() -> std::set<RegexDFAStatePair>;
+    auto get_reachable_pairs(
+            std::set<RegexDFAStatePair<DFAState>>& visited_pairs,
+            std::set<RegexDFAStatePair<DFAState>>& unvisited_pairs
+    ) -> void;
 
     /**
      * @return Whether both states are accepting

--- a/src/log_surgeon/finite_automata/RegexDFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.hpp
@@ -77,7 +77,7 @@ public:
     auto get_reachable_pairs(
             std::set<RegexDFAStatePair<DFAState>>& visited_pairs,
             std::set<RegexDFAStatePair<DFAState>>& unvisited_pairs
-    ) -> void;
+    ) const -> void;
 
     /**
      * @return Whether both states are accepting

--- a/src/log_surgeon/finite_automata/RegexDFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.hpp
@@ -60,8 +60,8 @@ public:
     /**
      * Used for ordering in a set by considering the states' addresses
      * @param rhs
-     * @return true if m_state1 in lhs has a lower address than in rhs, if tied,
-     * true if m_state2 in lhs has a lower address than in rhs, false otherwise
+     * @return Whether m_state1 in lhs has a lower address than in rhs, or if they're equal,
+     * whether m_state2 in lhs has a lower address than in rhs
      */
     auto operator<(RegexDFAStatePair const& rhs) const -> bool {
         if (m_state1 == rhs.m_state1) {
@@ -71,8 +71,10 @@ public:
     }
 
     /**
-     * Generates all pairs reachable from the current pair via any string and
-     * store any reachable pair not previously visited in unvisited_pairs
+     * Generates all pairs reachable from the current pair via any string and store any reachable
+     * pair not previously visited in unvisited_pairs
+     * @param visited_pairs Previously visited pairs
+     * @param unvisited_pairs Set to add unvisited reachable pairs
      */
     auto get_reachable_pairs(
             std::set<RegexDFAStatePair<DFAState>>& visited_pairs,
@@ -122,7 +124,7 @@ public:
      * a set of types containing the type, and (2) dfa_in returns any non-empty
      * set of types.
      * @param dfa_in
-     * @return set of schema types reachable by dfa_in
+     * @return The set of schema types reachable by dfa_in
      */
     [[nodiscard]] auto get_intersect(std::unique_ptr<RegexDFA> const& dfa_in) const
             -> std::set<uint32_t>;

--- a/src/log_surgeon/finite_automata/RegexDFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.hpp
@@ -112,7 +112,17 @@ public:
 
     auto get_root() const -> DFAStateType const* { return m_states.at(0).get(); }
 
-    auto get_intersect(std::unique_ptr<RegexDFA> const& dfa_in) -> std::set<uint32_t>;
+    /**
+     * Compares this dfa with dfa_in to determine the set of schema types in
+     * this dfa that are reachable by any type in dfa_in. A type is considered
+     * reachable if there is at least one string for which: (1) this dfa returns
+     * a set of types containing the type, and (2) dfa_in returns any non-empty
+     * set of types.
+     * @param dfa_in
+     * @return set of schema types reachable by dfa_in
+     */
+    [[nodiscard]] auto get_intersect(std::unique_ptr<RegexDFA> const& dfa_in) const
+            -> std::set<uint32_t>;
 
 private:
     std::vector<std::unique_ptr<DFAStateType>> m_states;

--- a/src/log_surgeon/finite_automata/RegexDFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.hpp
@@ -62,7 +62,7 @@ public:
         if (m_state1 == rhs.m_state1) {
             return m_state2 < rhs.m_state2;
         }
-        return m_state1 < rhs.m_state1;  // assume that you compare the record based on a
+        return m_state1 < rhs.m_state1;
     }
 
     /**

--- a/src/log_surgeon/finite_automata/RegexDFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.hpp
@@ -58,7 +58,7 @@ public:
             : m_state1(state1),
               m_state2(state2){};
 
-    bool operator<(RegexDFAStatePair const& rhs) const {
+    auto operator<(RegexDFAStatePair const& rhs) const -> bool {
         if (m_state1 == rhs.m_state1) {
             return m_state2 < rhs.m_state2;
         }
@@ -69,12 +69,12 @@ public:
      * Generates all pairs reachable from the current pair via a single input.
      * @return vector of reachable pairs
      */
-    auto generate_reachable_pairs() -> std::set<RegexDFAStatePair>;
+    auto get_reachable_pairs() -> std::set<RegexDFAStatePair>;
 
     /**
-     * @return if both pairs are accepting
+     * @return Whether both states are accepting
      */
-    auto is_accepting() const -> bool;
+    [[nodiscard]] auto is_accepting() const -> bool;
 
     /**
      * @return the tags of the first state of the pair

--- a/src/log_surgeon/finite_automata/RegexDFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.hpp
@@ -67,19 +67,23 @@ public:
 
     /**
      * Generates all pairs reachable from the current pair via a single input.
-     * @return vector of reachable pairs
+     * @return A vector of reachable pairs
      */
     auto get_reachable_pairs() -> std::set<RegexDFAStatePair>;
 
     /**
      * @return Whether both states are accepting
      */
-    [[nodiscard]] auto is_accepting() const -> bool;
+    [[nodiscard]] auto is_accepting() const -> bool {
+        return m_state1->is_accepting() && m_state2->is_accepting();
+    }
 
     /**
-     * @return the tags of the first state of the pair
+     * @return The tags of the first state of the pair
      */
-    [[nodiscard]] auto get_first_tags() const -> std::vector<int> const&;
+    [[nodiscard]] auto get_first_tags() const -> std::vector<int> const& {
+        return m_state1->get_tags();
+    }
 
 private:
     DFAState const* m_state1;

--- a/src/log_surgeon/finite_automata/RegexDFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.hpp
@@ -53,7 +53,6 @@ private:
 template <typename DFAState>
 class RegexDFAStatePair {
 public:
-    /// TODO: a lot of this pointer usage could probably be references
     RegexDFAStatePair(DFAState const* state1, DFAState const* state2)
             : m_state1(state1),
               m_state2(state2){};

--- a/src/log_surgeon/finite_automata/RegexDFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.hpp
@@ -57,6 +57,12 @@ public:
             : m_state1(state1),
               m_state2(state2){};
 
+    /**
+     * Used for ordering in a set by considering the states' addresses
+     * @param rhs
+     * @return true if m_state1 in lhs has a lower address than in rhs, if tied,
+     * true if m_state2 in lhs has a lower address than in rhs, false otherwise
+     */
     auto operator<(RegexDFAStatePair const& rhs) const -> bool {
         if (m_state1 == rhs.m_state1) {
             return m_state2 < rhs.m_state2;

--- a/src/log_surgeon/finite_automata/RegexDFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.hpp
@@ -50,6 +50,42 @@ private:
     std::conditional_t<stateType == RegexDFAStateType::UTF8, Tree, std::tuple<>> m_tree_transitions;
 };
 
+template <typename DFAState>
+class RegexDFAStatePair {
+public:
+    /// TODO: a lot of this pointer usage could probably be references
+    RegexDFAStatePair(DFAState const* state1, DFAState const* state2)
+            : m_state1(state1),
+              m_state2(state2){};
+
+    bool operator<(RegexDFAStatePair const& rhs) const {
+        if (m_state1 == rhs.m_state1) {
+            return m_state2 < rhs.m_state2;
+        }
+        return m_state1 < rhs.m_state1;  // assume that you compare the record based on a
+    }
+
+    /**
+     * Generates all pairs reachable from the current pair via a single input.
+     * @return vector of reachable pairs
+     */
+    auto generate_reachable_pairs() -> std::set<RegexDFAStatePair>;
+
+    /**
+     * @return if both pairs are accepting
+     */
+    auto is_accepting() const -> bool;
+
+    /**
+     * @return the tags of the first state of the pair
+     */
+    [[nodiscard]] auto get_first_tags() const -> std::vector<int> const&;
+
+private:
+    DFAState const* m_state1;
+    DFAState const* m_state2;
+};
+
 using RegexDFAByteState = RegexDFAState<RegexDFAStateType::Byte>;
 using RegexDFAUTF8State = RegexDFAState<RegexDFAStateType::UTF8>;
 
@@ -66,6 +102,8 @@ public:
     auto new_state(std::set<NFAStateType*> const& set) -> DFAStateType*;
 
     auto get_root() const -> DFAStateType const* { return m_states.at(0).get(); }
+
+    auto get_intersect(std::unique_ptr<RegexDFA> const& dfa_in) -> std::set<uint32_t>;
 
 private:
     std::vector<std::unique_ptr<DFAStateType>> m_states;

--- a/src/log_surgeon/finite_automata/RegexDFA.tpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.tpp
@@ -21,6 +21,28 @@ auto RegexDFAState<stateType>::next(uint32_t character) const -> RegexDFAState<s
     }
 }
 
+template <typename DFAState>
+auto RegexDFAStatePair<DFAState>::generate_reachable_pairs() -> std::set<RegexDFAStatePair> {
+    std::set<RegexDFAStatePair> reachable_pairs;
+    // TODO: currently assumes it is a byte input, needs to handle utf8 as well
+    for (uint32_t i = 0; i < cSizeOfByte; i++) {
+        if (m_state1->next(i) != nullptr && m_state2->next(i) != nullptr) {
+            reachable_pairs.emplace(m_state1->next(i), m_state2->next(i));
+        }
+    }
+    return reachable_pairs;
+}
+
+template <typename DFAState>
+auto RegexDFAStatePair<DFAState>::is_accepting() const -> bool {
+    return m_state1->is_accepting() && m_state2->is_accepting();
+}
+
+template <typename DFAState>
+auto RegexDFAStatePair<DFAState>::get_first_tags() const -> std::vector<int> const& {
+    return m_state1->get_tags();
+}
+
 template <typename DFAStateType>
 template <typename NFAStateType>
 auto RegexDFA<DFAStateType>::new_state(std::set<NFAStateType*> const& set) -> DFAStateType* {
@@ -33,6 +55,33 @@ auto RegexDFA<DFAStateType>::new_state(std::set<NFAStateType*> const& set) -> DF
         }
     }
     return state;
+}
+
+template <typename DFAStateType>
+auto RegexDFA<DFAStateType>::get_intersect(std::unique_ptr<RegexDFA> const& dfa_in)
+        -> std::set<uint32_t> {
+    std::set<uint32_t> schema_types;
+    std::set<RegexDFAStatePair<DFAStateType>> unused_pairs;
+    std::set<RegexDFAStatePair<DFAStateType>> used_pairs;
+    unused_pairs.emplace(this->get_root(), dfa_in->get_root());
+    // TODO: currently assumes it is a byte input, needs to handle utf8 as well
+    while (false == unused_pairs.empty()) {
+        auto current_pair = *unused_pairs.begin();
+        if (current_pair.is_accepting()) {
+            std::vector<int> const& tags = current_pair.get_first_tags();
+            schema_types.insert(tags.begin(), tags.end());
+        }
+        unused_pairs.erase(unused_pairs.begin());
+        used_pairs.insert(current_pair);
+        std::set<RegexDFAStatePair<DFAStateType>> reachable_pairs
+                = current_pair.generate_reachable_pairs();
+        for (RegexDFAStatePair<DFAStateType> const& reachable_pair : reachable_pairs) {
+            if (used_pairs.find(reachable_pair) == used_pairs.end()) {
+                unused_pairs.insert(reachable_pair);
+            }
+        }
+    }
+    return schema_types;
 }
 }  // namespace log_surgeon::finite_automata
 

--- a/src/log_surgeon/finite_automata/RegexDFA.tpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.tpp
@@ -48,7 +48,7 @@ auto RegexDFA<DFAStateType>::new_state(std::set<NFAStateType*> const& set) -> DF
 }
 
 template <typename DFAStateType>
-auto RegexDFA<DFAStateType>::get_intersect(std::unique_ptr<RegexDFA> const& dfa_in)
+auto RegexDFA<DFAStateType>::get_intersect(std::unique_ptr<RegexDFA> const& dfa_in) const
         -> std::set<uint32_t> {
     std::set<uint32_t> schema_types;
     std::set<RegexDFAStatePair<DFAStateType>> unvisited_pairs;

--- a/src/log_surgeon/finite_automata/RegexDFA.tpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.tpp
@@ -26,8 +26,10 @@ auto RegexDFAStatePair<DFAState>::get_reachable_pairs() -> std::set<RegexDFAStat
     std::set<RegexDFAStatePair> reachable_pairs;
     // TODO: Handle UTF-8 (multi-byte transitions) as well
     for (uint32_t i = 0; i < cSizeOfByte; i++) {
-        if (m_state1->next(i) != nullptr && m_state2->next(i) != nullptr) {
-            reachable_pairs.emplace(m_state1->next(i), m_state2->next(i));
+        auto next_state1 = m_state1->next(i);
+        auto next_state2 = m_state2->next(i);
+        if (next_state1 != nullptr && next_state2 != nullptr) {
+            reachable_pairs.emplace(next_state1, next_state2);
         }
     }
     return reachable_pairs;

--- a/src/log_surgeon/finite_automata/RegexDFA.tpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.tpp
@@ -38,7 +38,6 @@ auto RegexDFAStatePair<DFAState>::get_reachable_pairs(
             }
         }
     }
-    return reachable_pairs;
 }
 
 template <typename DFAStateType>

--- a/src/log_surgeon/finite_automata/RegexDFA.tpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.tpp
@@ -58,15 +58,15 @@ auto RegexDFA<DFAStateType>::get_intersect(std::unique_ptr<RegexDFA> const& dfa_
     unvisited_pairs.emplace(this->get_root(), dfa_in->get_root());
     // TODO: Handle UTF-8 (multi-byte transitions) as well
     while (false == unvisited_pairs.empty()) {
-        auto current_pair = *unvisited_pairs.begin();
-        if (current_pair.is_accepting()) {
-            auto tags = current_pair.get_first_tags();
+        auto current_pair_itt = unvisited_pairs.begin();
+        if (current_pair_itt->is_accepting()) {
+            auto tags = current_pair_itt->get_first_tags();
             schema_types.insert(tags.begin(), tags.end());
         }
-        unvisited_pairs.erase(unvisited_pairs.begin());
-        visited_pairs.insert(current_pair);
+        visited_pairs.insert(*current_pair_itt);
         std::set<RegexDFAStatePair<DFAStateType>> reachable_pairs
-                = current_pair.get_reachable_pairs();
+                = current_pair_itt->get_reachable_pairs();
+        unvisited_pairs.erase(current_pair_itt);
         for (RegexDFAStatePair<DFAStateType> const& reachable_pair : reachable_pairs) {
             if (visited_pairs.find(reachable_pair) == visited_pairs.end()) {
                 unvisited_pairs.insert(reachable_pair);

--- a/src/log_surgeon/finite_automata/RegexDFA.tpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.tpp
@@ -26,13 +26,12 @@ auto RegexDFAStatePair<DFAState>::get_reachable_pairs(
         std::set<RegexDFAStatePair<DFAState>>& visited_pairs,
         std::set<RegexDFAStatePair<DFAState>>& unvisited_pairs
 ) const -> void {
-    std::set<RegexDFAStatePair> reachable_pairs;
     // TODO: Handle UTF-8 (multi-byte transitions) as well
     for (uint32_t i = 0; i < cSizeOfByte; i++) {
         auto next_state1 = m_state1->next(i);
         auto next_state2 = m_state2->next(i);
         if (next_state1 != nullptr && next_state2 != nullptr) {
-            RegexDFAStatePair<DFAState> reachable_pair(next_state1, next_state2);
+            RegexDFAStatePair<DFAState> reachable_pair{next_state1, next_state2};
             if (visited_pairs.count(reachable_pair) == 0) {
                 unvisited_pairs.insert(reachable_pair);
             }

--- a/src/log_surgeon/finite_automata/RegexDFA.tpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.tpp
@@ -22,9 +22,9 @@ auto RegexDFAState<stateType>::next(uint32_t character) const -> RegexDFAState<s
 }
 
 template <typename DFAState>
-auto RegexDFAStatePair<DFAState>::generate_reachable_pairs() -> std::set<RegexDFAStatePair> {
+auto RegexDFAStatePair<DFAState>::get_reachable_pairs() -> std::set<RegexDFAStatePair> {
     std::set<RegexDFAStatePair> reachable_pairs;
-    // TODO: currently assumes it is a byte input, needs to handle utf8 as well
+    // TODO: Handle UTF-8 (multi-byte transitions) as well
     for (uint32_t i = 0; i < cSizeOfByte; i++) {
         if (m_state1->next(i) != nullptr && m_state2->next(i) != nullptr) {
             reachable_pairs.emplace(m_state1->next(i), m_state2->next(i));
@@ -64,17 +64,17 @@ auto RegexDFA<DFAStateType>::get_intersect(std::unique_ptr<RegexDFA> const& dfa_
     std::set<RegexDFAStatePair<DFAStateType>> unused_pairs;
     std::set<RegexDFAStatePair<DFAStateType>> used_pairs;
     unused_pairs.emplace(this->get_root(), dfa_in->get_root());
-    // TODO: currently assumes it is a byte input, needs to handle utf8 as well
+    // TODO: Handle UTF-8 (multi-byte transitions) as well
     while (false == unused_pairs.empty()) {
         auto current_pair = *unused_pairs.begin();
         if (current_pair.is_accepting()) {
-            std::vector<int> const& tags = current_pair.get_first_tags();
+            auto tags = current_pair.get_first_tags();
             schema_types.insert(tags.begin(), tags.end());
         }
         unused_pairs.erase(unused_pairs.begin());
         used_pairs.insert(current_pair);
         std::set<RegexDFAStatePair<DFAStateType>> reachable_pairs
-                = current_pair.generate_reachable_pairs();
+                = current_pair.get_reachable_pairs();
         for (RegexDFAStatePair<DFAStateType> const& reachable_pair : reachable_pairs) {
             if (used_pairs.find(reachable_pair) == used_pairs.end()) {
                 unused_pairs.insert(reachable_pair);

--- a/src/log_surgeon/finite_automata/RegexDFA.tpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.tpp
@@ -25,7 +25,7 @@ template <typename DFAState>
 auto RegexDFAStatePair<DFAState>::get_reachable_pairs(
         std::set<RegexDFAStatePair<DFAState>>& visited_pairs,
         std::set<RegexDFAStatePair<DFAState>>& unvisited_pairs
-) -> void {
+) const -> void {
     std::set<RegexDFAStatePair> reachable_pairs;
     // TODO: Handle UTF-8 (multi-byte transitions) as well
     for (uint32_t i = 0; i < cSizeOfByte; i++) {
@@ -69,8 +69,7 @@ auto RegexDFA<DFAStateType>::get_intersect(std::unique_ptr<RegexDFA> const& dfa_
             schema_types.insert(tags.begin(), tags.end());
         }
         visited_pairs.insert(*current_pair_it);
-        std::set<RegexDFAStatePair<DFAStateType>> reachable_pairs
-                = current_pair_it->get_reachable_pairs(visited_pairs, unvisited_pairs);
+        current_pair_it->get_reachable_pairs(visited_pairs, unvisited_pairs);
         unvisited_pairs.erase(current_pair_it);
     }
     return schema_types;

--- a/src/log_surgeon/finite_automata/RegexDFA.tpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.tpp
@@ -58,15 +58,15 @@ auto RegexDFA<DFAStateType>::get_intersect(std::unique_ptr<RegexDFA> const& dfa_
     unvisited_pairs.emplace(this->get_root(), dfa_in->get_root());
     // TODO: Handle UTF-8 (multi-byte transitions) as well
     while (false == unvisited_pairs.empty()) {
-        auto current_pair_itt = unvisited_pairs.begin();
-        if (current_pair_itt->is_accepting()) {
-            auto tags = current_pair_itt->get_first_tags();
+        auto current_pair_it = unvisited_pairs.begin();
+        if (current_pair_it->is_accepting()) {
+            auto& tags = current_pair_it->get_first_tags();
             schema_types.insert(tags.begin(), tags.end());
         }
-        visited_pairs.insert(*current_pair_itt);
+        visited_pairs.insert(*current_pair_it);
         std::set<RegexDFAStatePair<DFAStateType>> reachable_pairs
-                = current_pair_itt->get_reachable_pairs();
-        unvisited_pairs.erase(current_pair_itt);
+                = current_pair_it->get_reachable_pairs();
+        unvisited_pairs.erase(current_pair_it);
         for (RegexDFAStatePair<DFAStateType> const& reachable_pair : reachable_pairs) {
             if (visited_pairs.find(reachable_pair) == visited_pairs.end()) {
                 unvisited_pairs.insert(reachable_pair);

--- a/src/log_surgeon/finite_automata/RegexDFA.tpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.tpp
@@ -33,16 +33,6 @@ auto RegexDFAStatePair<DFAState>::get_reachable_pairs() -> std::set<RegexDFAStat
     return reachable_pairs;
 }
 
-template <typename DFAState>
-auto RegexDFAStatePair<DFAState>::is_accepting() const -> bool {
-    return m_state1->is_accepting() && m_state2->is_accepting();
-}
-
-template <typename DFAState>
-auto RegexDFAStatePair<DFAState>::get_first_tags() const -> std::vector<int> const& {
-    return m_state1->get_tags();
-}
-
 template <typename DFAStateType>
 template <typename NFAStateType>
 auto RegexDFA<DFAStateType>::new_state(std::set<NFAStateType*> const& set) -> DFAStateType* {

--- a/src/log_surgeon/finite_automata/RegexDFA.tpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.tpp
@@ -51,23 +51,23 @@ template <typename DFAStateType>
 auto RegexDFA<DFAStateType>::get_intersect(std::unique_ptr<RegexDFA> const& dfa_in)
         -> std::set<uint32_t> {
     std::set<uint32_t> schema_types;
-    std::set<RegexDFAStatePair<DFAStateType>> unused_pairs;
-    std::set<RegexDFAStatePair<DFAStateType>> used_pairs;
-    unused_pairs.emplace(this->get_root(), dfa_in->get_root());
+    std::set<RegexDFAStatePair<DFAStateType>> unvisited_pairs;
+    std::set<RegexDFAStatePair<DFAStateType>> visited_pairs;
+    unvisited_pairs.emplace(this->get_root(), dfa_in->get_root());
     // TODO: Handle UTF-8 (multi-byte transitions) as well
-    while (false == unused_pairs.empty()) {
-        auto current_pair = *unused_pairs.begin();
+    while (false == unvisited_pairs.empty()) {
+        auto current_pair = *unvisited_pairs.begin();
         if (current_pair.is_accepting()) {
             auto tags = current_pair.get_first_tags();
             schema_types.insert(tags.begin(), tags.end());
         }
-        unused_pairs.erase(unused_pairs.begin());
-        used_pairs.insert(current_pair);
+        unvisited_pairs.erase(unvisited_pairs.begin());
+        visited_pairs.insert(current_pair);
         std::set<RegexDFAStatePair<DFAStateType>> reachable_pairs
                 = current_pair.get_reachable_pairs();
         for (RegexDFAStatePair<DFAStateType> const& reachable_pair : reachable_pairs) {
-            if (used_pairs.find(reachable_pair) == used_pairs.end()) {
-                unused_pairs.insert(reachable_pair);
+            if (visited_pairs.find(reachable_pair) == visited_pairs.end()) {
+                unvisited_pairs.insert(reachable_pair);
             }
         }
     }


### PR DESCRIPTION
# Description
- Add a method to DFA that returns its intersect with another DFA. This returns each schema type in the DFA that have at least 1 string in its language that can match the DFA passed in to the method.
- Add test for DFA intersect

# Validation performed
- Ran buffer-parser, reader-parser, and intersect test with expected output
