### PR TITLE
Add support for parsing regex named capture groups to AST.

### DIFF
--- a/examples/schema.txt
+++ b/examples/schema.txt
@@ -41,7 +41,7 @@ timestamp:\[\d{2}/\d{2}/\d{4}:\d{2}:\d{2}:\d{2}
 // E.g. ERROR: apport (pid 4557) Sun Jan  1 15:50:45 2015
 timestamp:[A-Z][a-z]{2} [A-Z][a-z]{2} [ 0-9]{2} \d{2}:\d{2}:\d{2} \d{4}
 // E.g. <<<2016-11-10 03:02:29:936
-timestamp:<<<\d{4}\-\d{2}\-\d{2} \d{2}:\d{2}:\d{2}:\d{3}
+timestamp:\<\<\<\d{4}\-\d{2}\-\d{2} \d{2}:\d{2}:\d{2}:\d{3}
 // E.g. Jan 21 11:56:42
 timestamp:[A-Z][a-z]{2} \d{2} \d{2}:\d{2}:\d{2}
 // E.g. 01-21 11:56:42.392
@@ -51,6 +51,9 @@ timestamp:\d{4}\-\d{2}\-\d{2} \d{2}:\d{2}:\d{2}.\d{6}
 
 // Delimiters
 delimiters: \t\r\n:,!;%
+
+// Capture
+capture:user_(?<userID>[0-9]+)
 
 // First set of variables
 int:\-{0,1}[0-9]+

--- a/src/log_surgeon/LogParser.cpp
+++ b/src/log_surgeon/LogParser.cpp
@@ -89,7 +89,7 @@ void LogParser::add_rules(std::unique_ptr<SchemaAST> schema_ast) {
             continue;
         }
         // currently capture groups are not yet supported
-        if (rule->m_name == "capture") {
+        if ("capture" == rule->m_name) {
             continue;
         }
         // transform '.' from any-character into any non-delimiter character

--- a/src/log_surgeon/LogParser.cpp
+++ b/src/log_surgeon/LogParser.cpp
@@ -88,6 +88,10 @@ void LogParser::add_rules(std::unique_ptr<SchemaAST> schema_ast) {
             // prevent timestamps from going into the dictionary
             continue;
         }
+        // currently capture groups are not yet supported
+        if (rule->m_name == "capture") {
+            continue;
+        }
         // transform '.' from any-character into any non-delimiter character
         rule->m_regex_ptr->remove_delimiters_from_wildcard(delimiters);
         // currently, error out if non-timestamp pattern contains a delimiter

--- a/src/log_surgeon/SchemaParser.cpp
+++ b/src/log_surgeon/SchemaParser.cpp
@@ -34,7 +34,6 @@ using std::string;
 using std::unique_ptr;
 
 namespace log_surgeon {
-
 SchemaParser::SchemaParser() {
     add_lexical_rules();
     add_productions();

--- a/src/log_surgeon/SchemaParser.cpp
+++ b/src/log_surgeon/SchemaParser.cpp
@@ -388,6 +388,23 @@ static auto new_delimiter_string_rule(NonTerminal* m) -> unique_ptr<ParserAST> {
 }
 
 void SchemaParser::add_lexical_rules() {
+    if (m_special_regex_characters.empty()) {
+        m_special_regex_characters['('] = "Lparen";
+        m_special_regex_characters[')'] = "Rparen";
+        m_special_regex_characters['*'] = "Star";
+        m_special_regex_characters['+'] = "Plus";
+        m_special_regex_characters['-'] = "Dash";
+        m_special_regex_characters['.'] = "Dot";
+        m_special_regex_characters['['] = "Lbracket";
+        m_special_regex_characters[']'] = "Rbracket";
+        m_special_regex_characters['\\'] = "Backslash";
+        m_special_regex_characters['^'] = "Hat";
+        m_special_regex_characters['{'] = "Lbrace";
+        m_special_regex_characters['}'] = "Rbrace";
+        m_special_regex_characters['|'] = "Vbar";
+        m_special_regex_characters['<'] = "Langle";
+        m_special_regex_characters['>'] = "Rangle";
+    }
     for (auto const& [special_regex_char, special_regex_name] : m_special_regex_characters) {
         add_token(special_regex_name, special_regex_char);
     }
@@ -409,9 +426,7 @@ void SchemaParser::add_lexical_rules() {
     add_token_group("Numeric", make_unique<RegexASTGroupByte>('0', '9'));
     add_token("Colon", ':');
     add_token("SemiColon", ';');
-    add_token("LAngle", '<');
     add_token("Equal", '=');
-    add_token("RAngle", '>');
     add_token("QuestionMark", '?');
     add_token("At", '@');
     add_token_group("AlphaNumeric", make_unique<RegexASTGroupByte>('a', 'z'));
@@ -428,6 +443,7 @@ void SchemaParser::add_lexical_rules() {
     add_token("f", 'f');
     add_token("v", 'v');
     add_token_chain("Delimiters", "delimiters");
+    add_token_chain("Capture", "capture");
     // RegexASTGroupByte default constructs to an m_negate group, so we add the only two characters
     // which can't be in a comment, the newline and carriage return characters as they signify the
     // end of the comment.
@@ -560,9 +576,7 @@ void SchemaParser::add_productions() {
     add_production("Literal", {"AlphaNumeric"}, regex_literal_rule);
     add_production("Literal", {"Colon"}, regex_literal_rule);
     add_production("Literal", {"SemiColon"}, regex_literal_rule);
-    add_production("Literal", {"LAngle"}, regex_literal_rule);
     add_production("Literal", {"Equal"}, regex_literal_rule);
-    add_production("Literal", {"RAngle"}, regex_literal_rule);
     add_production("Literal", {"QuestionMark"}, regex_literal_rule);
     add_production("Literal", {"At"}, regex_literal_rule);
     add_production("Literal", {"Backslash", "Lbracket"}, regex_cancel_literal_rule);
@@ -574,6 +588,8 @@ void SchemaParser::add_productions() {
     add_production("Literal", {"Backslash", "Lbrace"}, regex_cancel_literal_rule);
     add_production("Literal", {"Backslash", "Vbar"}, regex_cancel_literal_rule);
     add_production("Literal", {"Backslash", "Rbrace"}, regex_cancel_literal_rule);
+    add_production("Literal", {"Backslash", "Langle"}, regex_cancel_literal_rule);
+    add_production("Literal", {"Backslash", "Rangle"}, regex_cancel_literal_rule);
     add_production("Literal", {"Tilde"}, regex_literal_rule);
     add_production("Literal", {"Lparen", "Regex", "Rparen"}, regex_middle_identity_rule);
     for (auto const& [special_regex_char, special_regex_name] : m_special_regex_characters) {

--- a/src/log_surgeon/SchemaParser.cpp
+++ b/src/log_surgeon/SchemaParser.cpp
@@ -35,8 +35,6 @@ using std::unique_ptr;
 
 namespace log_surgeon {
 
-std::unordered_map<char, std::string> SchemaParser::m_special_regex_characters;
-
 SchemaParser::SchemaParser() {
     add_lexical_rules();
     add_productions();
@@ -402,22 +400,22 @@ static auto new_delimiter_string_rule(NonTerminal* m) -> unique_ptr<ParserAST> {
 
 void SchemaParser::add_lexical_rules() {
     if (m_special_regex_characters.empty()) {
-        m_special_regex_characters['('] = "Lparen";
-        m_special_regex_characters[')'] = "Rparen";
-        m_special_regex_characters['*'] = "Star";
-        m_special_regex_characters['+'] = "Plus";
-        m_special_regex_characters['-'] = "Dash";
-        m_special_regex_characters['.'] = "Dot";
-        m_special_regex_characters['['] = "Lbracket";
-        m_special_regex_characters[']'] = "Rbracket";
-        m_special_regex_characters['\\'] = "Backslash";
-        m_special_regex_characters['^'] = "Hat";
-        m_special_regex_characters['{'] = "Lbrace";
-        m_special_regex_characters['}'] = "Rbrace";
-        m_special_regex_characters['|'] = "Vbar";
-        m_special_regex_characters['<'] = "Langle";
-        m_special_regex_characters['>'] = "Rangle";
-        m_special_regex_characters['?'] = "QuestionMark";
+        m_special_regex_characters.emplace('(', "Lparen");
+        m_special_regex_characters.emplace(')', "Rparen");
+        m_special_regex_characters.emplace('*', "Star");
+        m_special_regex_characters.emplace('+', "Plus");
+        m_special_regex_characters.emplace('-', "Dash");
+        m_special_regex_characters.emplace('.', "Dot");
+        m_special_regex_characters.emplace('[', "Lbracket");
+        m_special_regex_characters.emplace(']', "Rbracket");
+        m_special_regex_characters.emplace('\\', "Backslash");
+        m_special_regex_characters.emplace('^', "Hat");
+        m_special_regex_characters.emplace('{', "Lbrace");
+        m_special_regex_characters.emplace('}', "Rbrace");
+        m_special_regex_characters.emplace('|', "Vbar");
+        m_special_regex_characters.emplace('<', "Langle");
+        m_special_regex_characters.emplace('>', "Rangle");
+        m_special_regex_characters.emplace('?', "QuestionMark");
     }
     for (auto const& [special_regex_char, special_regex_name] : m_special_regex_characters) {
         add_token(special_regex_name, special_regex_char);

--- a/src/log_surgeon/SchemaParser.hpp
+++ b/src/log_surgeon/SchemaParser.hpp
@@ -57,6 +57,27 @@ public:
     std::unique_ptr<finite_automata::RegexAST<finite_automata::RegexNFAByteState>> m_regex_ptr;
 };
 
+class CaptureAST : public ParserAST {
+public:
+    // Constructor
+    CaptureAST(
+            std::unique_ptr<SchemaVarAST> schema_var_ast,
+            std::unique_ptr<finite_automata::RegexAST<finite_automata::RegexNFAByteState>>
+                    regex_ptr,
+            std::unique_ptr<CaptureAST> capture_ast,
+            uint32_t line_num
+    )
+            : m_line_num(line_num),
+              m_schema_var_ast(std::move(schema_var_ast)),
+              m_regex_ptr(std::move(regex_ptr)),
+              m_capture_ast(std::move(capture_ast)) {}
+
+    uint32_t m_line_num;
+    std::unique_ptr<SchemaVarAST> m_schema_var_ast;
+    std::unique_ptr<finite_automata::RegexAST<finite_automata::RegexNFAByteState>> m_regex_ptr;
+    std::unique_ptr<CaptureAST> m_capture_ast;
+};
+
 class DelimiterStringAST : public ParserAST {
 public:
     // Constructor
@@ -125,21 +146,7 @@ private:
      */
     auto generate_schema_ast(Reader& reader) -> std::unique_ptr<SchemaAST>;
 
-    static inline std::unordered_map<char, std::string> const m_special_regex_characters{
-            {'(', "Lparen"},
-            {')', "Rparen"},
-            {'*', "Star"},
-            {'+', "Plus"},
-            {'-', "Dash"},
-            {'.', "Dot"},
-            {'[', "Lbracket"},
-            {']', "Rbracket"},
-            {'\\', "Backslash"},
-            {'^', "Hat"},
-            {'{', "Lbrace"},
-            {'}', "Rbrace"},
-            {'|', "Vbar"}
-    };
+    static std::unordered_map<char, std::string> m_special_regex_characters;
 };
 }  // namespace log_surgeon
 

--- a/src/log_surgeon/SchemaParser.hpp
+++ b/src/log_surgeon/SchemaParser.hpp
@@ -125,7 +125,7 @@ private:
      */
     auto generate_schema_ast(Reader& reader) -> std::unique_ptr<SchemaAST>;
 
-    static std::unordered_map<char, std::string> m_special_regex_characters;
+    static inline std::unordered_map<char, std::string> m_special_regex_characters;
 };
 }  // namespace log_surgeon
 

--- a/src/log_surgeon/SchemaParser.hpp
+++ b/src/log_surgeon/SchemaParser.hpp
@@ -57,27 +57,6 @@ public:
     std::unique_ptr<finite_automata::RegexAST<finite_automata::RegexNFAByteState>> m_regex_ptr;
 };
 
-class CaptureAST : public ParserAST {
-public:
-    // Constructor
-    CaptureAST(
-            std::unique_ptr<SchemaVarAST> schema_var_ast,
-            std::unique_ptr<finite_automata::RegexAST<finite_automata::RegexNFAByteState>>
-                    regex_ptr,
-            std::unique_ptr<CaptureAST> capture_ast,
-            uint32_t line_num
-    )
-            : m_line_num(line_num),
-              m_schema_var_ast(std::move(schema_var_ast)),
-              m_regex_ptr(std::move(regex_ptr)),
-              m_capture_ast(std::move(capture_ast)) {}
-
-    uint32_t m_line_num;
-    std::unique_ptr<SchemaVarAST> m_schema_var_ast;
-    std::unique_ptr<finite_automata::RegexAST<finite_automata::RegexNFAByteState>> m_regex_ptr;
-    std::unique_ptr<CaptureAST> m_capture_ast;
-};
-
 class DelimiterStringAST : public ParserAST {
 public:
     // Constructor

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -425,7 +425,7 @@ template <typename NFAStateType>
 class RegexASTCapture : public RegexAST<NFAStateType> {
 public:
     RegexASTCapture(std::string group_name, std::unique_ptr<RegexAST<NFAStateType>> regex)
-            : m_group_name(group_name),
+            : m_group_name(std::move(group_name)),
               m_regex(std::move(regex)) {}
 
     RegexASTCapture(RegexASTCapture const& rhs)

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <memory>
-#include <set>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -424,13 +424,15 @@ private:
 template <typename NFAStateType>
 class RegexASTCapture : public RegexAST<NFAStateType> {
 public:
-    RegexASTCapture(std::string group_name, std::unique_ptr<RegexAST<NFAStateType>> regex)
+    RegexASTCapture(std::string group_name, std::unique_ptr<RegexAST<NFAStateType>> group_regex_ast)
             : m_group_name(std::move(group_name)),
-              m_regex(std::move(regex)) {}
+              m_group_regex_ast(std::move(group_regex_ast)) {}
 
     RegexASTCapture(RegexASTCapture const& rhs)
             : m_group_name(rhs.m_group_name),
-              m_regex(std::unique_ptr<RegexAST<NFAStateType>>(rhs.m_regex->clone())) {}
+              m_group_regex_ast(
+                      std::unique_ptr<RegexAST<NFAStateType>>(rhs.m_group_regex_ast->clone())
+              ) {}
 
     /**
      * Used for cloning a `unique_pointer` of type `RegexASTCapture`.
@@ -446,7 +448,7 @@ public:
      * @param is_possible_input
      */
     auto set_possible_inputs_to_true(bool is_possible_input[]) const -> void override {
-        m_regex->set_possible_inputs_to_true(is_possible_input);
+        m_group_regex_ast->set_possible_inputs_to_true(is_possible_input);
     }
 
     /**
@@ -455,7 +457,7 @@ public:
      * @param delimiters
      */
     auto remove_delimiters_from_wildcard(std::vector<uint32_t>& delimiters) -> void override {
-        m_regex->remove_delimiters_from_wildcard(delimiters);
+        m_group_regex_ast->remove_delimiters_from_wildcard(delimiters);
     }
 
     /**
@@ -468,7 +470,7 @@ public:
 
 private:
     std::string m_group_name;
-    std::unique_ptr<RegexAST<NFAStateType>> m_regex;
+    std::unique_ptr<RegexAST<NFAStateType>> m_group_regex_ast;
 };
 
 }  // namespace log_surgeon::finite_automata

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -425,12 +425,12 @@ template <typename NFAStateType>
 class RegexASTCapture : public RegexAST<NFAStateType> {
 public:
     RegexASTCapture(
-            std::string /*name*/,
-            std::unique_ptr<RegexAST<NFAStateType>> /*regex*/
+            std::string group_name ,
+            std::unique_ptr<RegexAST<NFAStateType>> regex
     );
 
     RegexASTCapture(RegexASTCapture const& rhs)
-            : m_name(rhs.m_name),
+            : m_group_name(rhs.m_group_name),
               m_regex(std::unique_ptr<RegexAST<NFAStateType>>(rhs.m_regex->clone())) {}
 
     /**
@@ -468,7 +468,7 @@ public:
     auto add(RegexNFA<NFAStateType>* nfa, NFAStateType* end_state) -> void override;
 
 private:
-    std::string m_name;
+    std::string m_group_name;
     std::unique_ptr<RegexAST<NFAStateType>> m_regex;
 };
 

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -441,8 +441,8 @@ public:
     }
 
     /**
-     * Sets is_possible_input to specify which utf8 characters are allowed in a
-     * lexer rule containing RegexASTCat at a leaf node in its AST
+     * Sets `is_possible_input` to specify which utf8 characters are allowed in a
+     * lexer rule containing `RegexASTCat` at a leaf node in its AST.
      * @param is_possible_input
      */
     auto set_possible_inputs_to_true(bool is_possible_input[]) const -> void override {

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -424,10 +424,9 @@ private:
 template <typename NFAStateType>
 class RegexASTCapture : public RegexAST<NFAStateType> {
 public:
-    RegexASTCapture(
-            std::string group_name ,
-            std::unique_ptr<RegexAST<NFAStateType>> regex
-    );
+    RegexASTCapture(std::string group_name, std::unique_ptr<RegexAST<NFAStateType>> regex)
+            : m_group_name(group_name),
+              m_regex(std::move(regex)) {}
 
     RegexASTCapture(RegexASTCapture const& rhs)
             : m_group_name(rhs.m_group_name),

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -430,7 +430,8 @@ public:
     );
 
     RegexASTCapture(RegexASTCapture const& rhs)
-            : m_regex(std::unique_ptr<RegexAST<NFAStateType>>(rhs.m_regex->clone())) {}
+            : m_name(rhs.m_name),
+              m_regex(std::unique_ptr<RegexAST<NFAStateType>>(rhs.m_regex->clone())) {}
 
     /**
      * Used for cloning a unique_pointer of type RegexASTCat

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -433,7 +433,7 @@ public:
               m_regex(std::unique_ptr<RegexAST<NFAStateType>>(rhs.m_regex->clone())) {}
 
     /**
-     * Used for cloning a unique_pointer of type RegexASTCat
+     * Used for cloning a `unique_pointer` of type `RegexASTCapture`.
      * @return RegexASTCapture*
      */
     [[nodiscard]] auto clone() const -> RegexASTCapture* override {
@@ -442,7 +442,7 @@ public:
 
     /**
      * Sets `is_possible_input` to specify which utf8 characters are allowed in a
-     * lexer rule containing `RegexASTCat` at a leaf node in its AST.
+     * lexer rule containing `RegexASTCapture` at a leaf node in its AST.
      * @param is_possible_input
      */
     auto set_possible_inputs_to_true(bool is_possible_input[]) const -> void override {
@@ -451,7 +451,7 @@ public:
 
     /**
      * Transforms '.' to to be any non-delimiter in a lexer rule if
-     * RegexASTGroup with `.` is a descendant of this RegexASTCapture node
+     * `RegexASTGroup` with `.` is a descendant of this `RegexASTCapture` node.
      * @param delimiters
      */
     auto remove_delimiters_from_wildcard(std::vector<uint32_t>& delimiters) -> void override {
@@ -459,8 +459,8 @@ public:
     }
 
     /**
-     * Add the needed RegexNFA::states to the passed in nfa to handle a
-     * RegexASTCapture before transitioning to a pre-tagged end_state
+     * Adds the needed `RegexNFA::states` to the passed in nfa to handle a
+     * `RegexASTCapture` before transitioning to a pre-tagged `end_state`.
      * @param nfa
      * @param end_state
      */

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -241,6 +241,12 @@ public:
 
     auto set_is_wildcard_true() -> void { m_is_wildcard = true; }
 
+    [[nodiscard]] auto is_wildcard() const -> bool { return m_is_wildcard; }
+
+    [[nodiscard]] auto get_negate() const -> bool { return m_negate; }
+
+    [[nodiscard]] auto get_ranges() const -> std::vector<Range> { return m_ranges; }
+
 private:
     /**
      * Merges multiple ranges such that the resulting m_ranges is sorted and
@@ -359,6 +365,14 @@ public:
      */
     auto add(RegexNFA<NFAStateType>* nfa, NFAStateType* end_state) -> void override;
 
+    [[nodiscard]] auto get_left() const -> std::unique_ptr<RegexAST<NFAStateType>> const& {
+        return m_left;
+    }
+
+    [[nodiscard]] auto get_right() const -> std::unique_ptr<RegexAST<NFAStateType>> const& {
+        return m_right;
+    }
+
 private:
     std::unique_ptr<RegexAST<NFAStateType>> m_left;
     std::unique_ptr<RegexAST<NFAStateType>> m_right;
@@ -415,6 +429,14 @@ public:
 
     [[nodiscard]] auto is_infinite() const -> bool { return this->m_max == 0; }
 
+    [[nodiscard]] auto get_operand() const -> std::unique_ptr<RegexAST<NFAStateType>> const& {
+        return m_operand;
+    }
+
+    [[nodiscard]] auto get_min() const -> uint32_t { return m_min; }
+
+    [[nodiscard]] auto get_max() const -> uint32_t { return m_max; }
+
 private:
     std::unique_ptr<RegexAST<NFAStateType>> m_operand;
     uint32_t m_min;
@@ -467,6 +489,13 @@ public:
      * @param end_state
      */
     auto add(RegexNFA<NFAStateType>* nfa, NFAStateType* end_state) -> void override;
+
+    [[nodiscard]] auto get_group_name() const -> std::string const& { return m_group_name; }
+
+    [[nodiscard]] auto get_group_regex_ast(
+    ) const -> std::unique_ptr<RegexAST<NFAStateType>> const& {
+        return m_group_regex_ast;
+    }
 
 private:
     std::string m_group_name;

--- a/src/log_surgeon/finite_automata/RegexAST.tpp
+++ b/src/log_surgeon/finite_automata/RegexAST.tpp
@@ -118,10 +118,10 @@ void RegexASTMultiplication<NFAStateType>::add(
 
 template <typename NFAStateType>
 RegexASTCapture<NFAStateType>::RegexASTCapture(
-        std::string name,
+        std::string group_name,
         std::unique_ptr<RegexAST<NFAStateType>> regex
 )
-        : m_name(name),
+        : m_group_name(group_name),
           m_regex(std::move(regex)) {}
 
 template <typename NFAStateType>

--- a/src/log_surgeon/finite_automata/RegexAST.tpp
+++ b/src/log_surgeon/finite_automata/RegexAST.tpp
@@ -118,7 +118,7 @@ void RegexASTMultiplication<NFAStateType>::add(
 
 template <typename NFAStateType>
 void RegexASTCapture<NFAStateType>::add(RegexNFA<NFAStateType>* nfa, NFAStateType* end_state) {
-    m_regex->add(nfa, end_state);
+    m_group_regex_ast->add(nfa, end_state);
 }
 
 template <typename NFAStateType>

--- a/src/log_surgeon/finite_automata/RegexAST.tpp
+++ b/src/log_surgeon/finite_automata/RegexAST.tpp
@@ -117,14 +117,6 @@ void RegexASTMultiplication<NFAStateType>::add(
 }
 
 template <typename NFAStateType>
-RegexASTCapture<NFAStateType>::RegexASTCapture(
-        std::string group_name,
-        std::unique_ptr<RegexAST<NFAStateType>> regex
-)
-        : m_group_name(group_name),
-          m_regex(std::move(regex)) {}
-
-template <typename NFAStateType>
 void RegexASTCapture<NFAStateType>::add(RegexNFA<NFAStateType>* nfa, NFAStateType* end_state) {
     m_regex->add(nfa, end_state);
 }

--- a/src/log_surgeon/finite_automata/RegexAST.tpp
+++ b/src/log_surgeon/finite_automata/RegexAST.tpp
@@ -27,24 +27,24 @@ RegexASTInteger<NFAStateType>::RegexASTInteger(uint32_t digit) {
 
 template <typename NFAStateType>
 RegexASTInteger<NFAStateType>::RegexASTInteger(RegexASTInteger<NFAStateType>* left, uint32_t digit)
-    : m_digits(std::move(left->m_digits)) {
+        : m_digits(std::move(left->m_digits)) {
     digit = digit - '0';
     m_digits.push_back(digit);
 }
 
 template <typename NFAStateType>
 void RegexASTInteger<
-    NFAStateType>::add(RegexNFA<NFAStateType>* /* nfa */, NFAStateType* /* end_state */) {
+        NFAStateType>::add(RegexNFA<NFAStateType>* /* nfa */, NFAStateType* /* end_state */) {
     throw std::runtime_error("Unsupported");
 }
 
 template <typename NFAStateType>
 RegexASTOr<NFAStateType>::RegexASTOr(
-    std::unique_ptr<RegexAST<NFAStateType>> left,
-    std::unique_ptr<RegexAST<NFAStateType>> right
+        std::unique_ptr<RegexAST<NFAStateType>> left,
+        std::unique_ptr<RegexAST<NFAStateType>> right
 )
-    : m_left(std::move(left)),
-      m_right(std::move(right)) {}
+        : m_left(std::move(left)),
+          m_right(std::move(right)) {}
 
 template <typename NFAStateType>
 void RegexASTOr<NFAStateType>::add(RegexNFA<NFAStateType>* nfa, NFAStateType* end_state) {
@@ -54,11 +54,11 @@ void RegexASTOr<NFAStateType>::add(RegexNFA<NFAStateType>* nfa, NFAStateType* en
 
 template <typename NFAStateType>
 RegexASTCat<NFAStateType>::RegexASTCat(
-    std::unique_ptr<RegexAST<NFAStateType>> left,
-    std::unique_ptr<RegexAST<NFAStateType>> right
+        std::unique_ptr<RegexAST<NFAStateType>> left,
+        std::unique_ptr<RegexAST<NFAStateType>> right
 )
-    : m_left(std::move(left)),
-      m_right(std::move(right)) {}
+        : m_left(std::move(left)),
+          m_right(std::move(right)) {}
 
 template <typename NFAStateType>
 void RegexASTCat<NFAStateType>::add(RegexNFA<NFAStateType>* nfa, NFAStateType* end_state) {
@@ -72,18 +72,18 @@ void RegexASTCat<NFAStateType>::add(RegexNFA<NFAStateType>* nfa, NFAStateType* e
 
 template <typename NFAStateType>
 RegexASTMultiplication<NFAStateType>::RegexASTMultiplication(
-    std::unique_ptr<RegexAST<NFAStateType>> operand,
-    uint32_t min,
-    uint32_t max
+        std::unique_ptr<RegexAST<NFAStateType>> operand,
+        uint32_t min,
+        uint32_t max
 )
-    : m_operand(std::move(operand)),
-      m_min(min),
-      m_max(max) {}
+        : m_operand(std::move(operand)),
+          m_min(min),
+          m_max(max) {}
 
 template <typename NFAStateType>
 void RegexASTMultiplication<NFAStateType>::add(
-    RegexNFA<NFAStateType>* nfa,
-    NFAStateType* end_state
+        RegexNFA<NFAStateType>* nfa,
+        NFAStateType* end_state
 ) {
     NFAStateType* saved_root = nfa->get_root();
     if (this->m_min == 0) {
@@ -117,17 +117,30 @@ void RegexASTMultiplication<NFAStateType>::add(
 }
 
 template <typename NFAStateType>
+RegexASTCapture<NFAStateType>::RegexASTCapture(
+        std::string name,
+        std::unique_ptr<RegexAST<NFAStateType>> regex
+)
+        : m_name(name),
+          m_regex(std::move(regex)) {}
+
+template <typename NFAStateType>
+void RegexASTCapture<NFAStateType>::add(RegexNFA<NFAStateType>* nfa, NFAStateType* end_state) {
+    m_regex->add(nfa, end_state);
+}
+
+template <typename NFAStateType>
 RegexASTGroup<NFAStateType>::RegexASTGroup() = default;
 
 template <typename NFAStateType>
 RegexASTGroup<NFAStateType>::RegexASTGroup(
-    RegexASTGroup<NFAStateType>* left,
-    RegexASTLiteral<NFAStateType>* right
+        RegexASTGroup<NFAStateType>* left,
+        RegexASTLiteral<NFAStateType>* right
 ) {
     if (right == nullptr) {
         throw std::runtime_error("RegexASTGroup1: right == nullptr: A bracket expression in the "
-            "schema contains illegal characters, remember to escape special "
-            "characters. Refer to README-Schema.md for more details.");
+                                 "schema contains illegal characters, remember to escape special "
+                                 "characters. Refer to README-Schema.md for more details.");
     }
     m_negate = left->m_negate;
     m_ranges = left->m_ranges;
@@ -136,12 +149,12 @@ RegexASTGroup<NFAStateType>::RegexASTGroup(
 
 template <typename NFAStateType>
 RegexASTGroup<NFAStateType>::RegexASTGroup(
-    RegexASTGroup<NFAStateType>* left,
-    RegexASTGroup<NFAStateType>* right
+        RegexASTGroup<NFAStateType>* left,
+        RegexASTGroup<NFAStateType>* right
 )
-    : m_negate(left->m_negate),
-      m_ranges(left->m_ranges) {
-    assert(right->m_ranges.size() == 1); // Only add LiteralRange
+        : m_negate(left->m_negate),
+          m_ranges(left->m_ranges) {
+    assert(right->m_ranges.size() == 1);  // Only add LiteralRange
     m_ranges.push_back(right->m_ranges[0]);
 }
 
@@ -149,8 +162,8 @@ template <typename NFAStateType>
 RegexASTGroup<NFAStateType>::RegexASTGroup(RegexASTLiteral<NFAStateType>* right) {
     if (right == nullptr) {
         throw std::runtime_error("RegexASTGroup2: right == nullptr: A bracket expression in the "
-            "schema contains illegal characters, remember to escape special "
-            "characters. Refer to README-Schema.md for more details.");
+                                 "schema contains illegal characters, remember to escape special "
+                                 "characters. Refer to README-Schema.md for more details.");
     }
     m_negate = false;
     m_ranges.emplace_back(right->get_character(), right->get_character());
@@ -158,20 +171,20 @@ RegexASTGroup<NFAStateType>::RegexASTGroup(RegexASTLiteral<NFAStateType>* right)
 
 template <typename NFAStateType>
 RegexASTGroup<NFAStateType>::RegexASTGroup(RegexASTGroup<NFAStateType>* right) : m_negate(false) {
-    assert(right->m_ranges.size() == 1); // Only add LiteralRange
+    assert(right->m_ranges.size() == 1);  // Only add LiteralRange
     m_ranges.push_back(right->m_ranges[0]);
 }
 
 template <typename NFAStateType>
 RegexASTGroup<NFAStateType>::RegexASTGroup(
-    RegexASTLiteral<NFAStateType>* left,
-    RegexASTLiteral<NFAStateType>* right
+        RegexASTLiteral<NFAStateType>* left,
+        RegexASTLiteral<NFAStateType>* right
 ) {
     if (left == nullptr || right == nullptr) {
         throw std::runtime_error(
-            "RegexASTGroup3: left == nullptr || right == nullptr: A bracket expression in the "
-            "schema contains illegal characters, remember to escape special characters. Refer "
-            "to README-Schema.md for more details."
+                "RegexASTGroup3: left == nullptr || right == nullptr: A bracket expression in the "
+                "schema contains illegal characters, remember to escape special characters. Refer "
+                "to README-Schema.md for more details."
         );
     }
     m_negate = false;
@@ -181,7 +194,7 @@ RegexASTGroup<NFAStateType>::RegexASTGroup(
 
 template <typename NFAStateType>
 RegexASTGroup<NFAStateType>::RegexASTGroup(std::vector<uint32_t> const& literals)
-    : m_negate(false) {
+        : m_negate(false) {
     for (uint32_t literal : literals) {
         m_ranges.emplace_back(literal, literal);
     }
@@ -194,8 +207,8 @@ RegexASTGroup<NFAStateType>::RegexASTGroup(uint32_t min, uint32_t max) : m_negat
 
 // ranges must be sorted
 template <typename NFAStateType>
-auto RegexASTGroup<NFAStateType>::merge(std::vector<Range> const& ranges)
-    -> std::vector<typename RegexASTGroup<NFAStateType>::Range> {
+auto RegexASTGroup<NFAStateType>::merge(std::vector<Range> const& ranges
+) -> std::vector<typename RegexASTGroup<NFAStateType>::Range> {
     std::vector<Range> merged;
     if (ranges.empty()) {
         return merged;
@@ -216,8 +229,8 @@ auto RegexASTGroup<NFAStateType>::merge(std::vector<Range> const& ranges)
 
 // ranges must be sorted and non-overlapping
 template <typename NFAStateType>
-auto RegexASTGroup<NFAStateType>::complement(std::vector<Range> const& ranges)
-    -> std::vector<typename RegexASTGroup<NFAStateType>::Range> {
+auto RegexASTGroup<NFAStateType>::complement(std::vector<Range> const& ranges
+) -> std::vector<typename RegexASTGroup<NFAStateType>::Range> {
     std::vector<Range> complemented;
     uint32_t low = 0;
     for (Range const& r : ranges) {
@@ -243,6 +256,6 @@ void RegexASTGroup<NFAStateType>::add(RegexNFA<NFAStateType>* nfa, NFAStateType*
         nfa->get_root()->add_interval(Interval(r.first, r.second), end_state);
     }
 }
-} // namespace log_surgeon::finite_automata
+}  // namespace log_surgeon::finite_automata
 
 #endif  // LOG_SURGEON_FINITE_AUTOMATA_REGEX_AST_TPP

--- a/tests/test-lexer.cpp
+++ b/tests/test-lexer.cpp
@@ -1,20 +1,80 @@
 #include <catch2/catch_test_macros.hpp>
 
+#include <log_surgeon/finite_automata/RegexAST.hpp>
+#include <log_surgeon/finite_automata/RegexNFA.hpp>
 #include <log_surgeon/Schema.hpp>
 #include <log_surgeon/SchemaParser.hpp>
 
+using RegexASTCatByte = log_surgeon::finite_automata::RegexASTCat<
+        log_surgeon::finite_automata::RegexNFAByteState>;
+using RegexASTCaptureByte = log_surgeon::finite_automata::RegexASTCapture<
+        log_surgeon::finite_automata::RegexNFAByteState>;
+using RegexASTGroupByte = log_surgeon::finite_automata::RegexASTGroup<
+        log_surgeon::finite_automata::RegexNFAByteState>;
+using RegexASTLiteralByte = log_surgeon::finite_automata::RegexASTLiteral<
+        log_surgeon::finite_automata::RegexNFAByteState>;
+using RegexASTMultiplicationByte = log_surgeon::finite_automata::RegexASTMultiplication<
+        log_surgeon::finite_automata::RegexNFAByteState>;
+
 TEST_CASE("Test the Schema class", "[Schema]") {
     log_surgeon::Schema schema;
-    schema.add_variable("myNumber", "123", -1);
-    auto const schema_ast = schema.release_schema_ast_ptr();
-    REQUIRE(schema_ast->m_schema_vars.size() == 1);
-    REQUIRE(schema.release_schema_ast_ptr()->m_schema_vars.empty());
 
-    auto& schema_var_ast_ptr = schema_ast->m_schema_vars[0];
-    REQUIRE(nullptr != schema_var_ast_ptr);
-    auto& schema_var_ast = dynamic_cast<log_surgeon::SchemaVarAST&>(*schema_var_ast_ptr);
-    REQUIRE("myNumber" == schema_var_ast.m_name);
+    SECTION("Add a number variable to schema") {
+        schema.add_variable("myNumber", "123", -1);
+        auto const schema_ast = schema.release_schema_ast_ptr();
+        REQUIRE(schema_ast->m_schema_vars.size() == 1);
+        REQUIRE(schema.release_schema_ast_ptr()->m_schema_vars.empty());
 
-    auto& regex_ast_cat = schema_var_ast.m_regex_ptr;
-    REQUIRE(nullptr != regex_ast_cat);
+        auto& schema_var_ast_ptr = schema_ast->m_schema_vars[0];
+        REQUIRE(nullptr != schema_var_ast_ptr);
+        auto& schema_var_ast = dynamic_cast<log_surgeon::SchemaVarAST&>(*schema_var_ast_ptr);
+        REQUIRE("myNumber" == schema_var_ast.m_name);
+
+        REQUIRE_NOTHROW([&]() {
+            auto& regex_ast_cat = dynamic_cast<RegexASTCatByte&>(*schema_var_ast.m_regex_ptr);
+        }());
+    }
+
+    SECTION("Add a capture variable to schema") {
+        schema.add_variable("capture", "u(?<uID>[0-9]+)", -1);
+        auto const schema_ast = schema.release_schema_ast_ptr();
+        REQUIRE(schema_ast->m_schema_vars.size() == 1);
+        REQUIRE(schema.release_schema_ast_ptr()->m_schema_vars.empty());
+
+        auto& schema_var_ast_ptr = schema_ast->m_schema_vars[0];
+        REQUIRE(nullptr != schema_var_ast_ptr);
+        auto& schema_var_ast = dynamic_cast<log_surgeon::SchemaVarAST&>(*schema_var_ast_ptr);
+        REQUIRE("capture" == schema_var_ast.m_name);
+
+        auto* regex_ast_cat_ptr = dynamic_cast<RegexASTCatByte*>(schema_var_ast.m_regex_ptr.get());
+        REQUIRE(nullptr != regex_ast_cat_ptr);
+        REQUIRE(nullptr != regex_ast_cat_ptr->get_left());
+        REQUIRE(nullptr != regex_ast_cat_ptr->get_right());
+
+        auto* regex_ast_literal
+                = dynamic_cast<RegexASTLiteralByte*>(regex_ast_cat_ptr->get_left().get());
+        REQUIRE(nullptr != regex_ast_literal);
+        REQUIRE('u' == regex_ast_literal->get_character());
+
+        auto* regex_ast_capture
+                = dynamic_cast<RegexASTCaptureByte*>(regex_ast_cat_ptr->get_right().get());
+        REQUIRE(nullptr != regex_ast_capture);
+        REQUIRE("uID" == regex_ast_capture->get_group_name());
+
+        auto* regex_ast_multiplication_ast = dynamic_cast<RegexASTMultiplicationByte*>(
+                regex_ast_capture->get_group_regex_ast().get()
+        );
+        REQUIRE(nullptr != regex_ast_multiplication_ast);
+        REQUIRE(1 == regex_ast_multiplication_ast->get_min());
+        REQUIRE(0 == regex_ast_multiplication_ast->get_max());
+        REQUIRE(regex_ast_multiplication_ast->is_infinite());
+
+        auto* regex_ast_group_ast
+                = dynamic_cast<RegexASTGroupByte*>(regex_ast_multiplication_ast->get_operand().get()
+                );
+        REQUIRE(false == regex_ast_group_ast->is_wildcard());
+        REQUIRE(1 == regex_ast_group_ast->get_ranges().size());
+        REQUIRE('0' == regex_ast_group_ast->get_ranges()[0].first);
+        REQUIRE('9' == regex_ast_group_ast->get_ranges()[0].second);
+    }
 }

--- a/tests/test-lexer.cpp
+++ b/tests/test-lexer.cpp
@@ -36,7 +36,8 @@ TEST_CASE("Test the Schema class", "[Schema]") {
     }
 
     SECTION("Add a capture variable to schema") {
-        schema.add_variable("capture", "u(?<uID>[0-9]+)", -1);
+        const std::string var_name = "capture";
+        schema.add_variable(var_name, "u(?<uID>[0-9]+)", -1);
         auto const schema_ast = schema.release_schema_ast_ptr();
         REQUIRE(schema_ast->m_schema_vars.size() == 1);
         REQUIRE(schema.release_schema_ast_ptr()->m_schema_vars.empty());
@@ -44,7 +45,7 @@ TEST_CASE("Test the Schema class", "[Schema]") {
         auto& schema_var_ast_ptr = schema_ast->m_schema_vars[0];
         REQUIRE(nullptr != schema_var_ast_ptr);
         auto& schema_var_ast = dynamic_cast<log_surgeon::SchemaVarAST&>(*schema_var_ast_ptr);
-        REQUIRE("capture" == schema_var_ast.m_name);
+        REQUIRE(var_name == schema_var_ast.m_name);
 
         auto* regex_ast_cat_ptr = dynamic_cast<RegexASTCatByte*>(schema_var_ast.m_regex_ptr.get());
         REQUIRE(nullptr != regex_ast_cat_ptr);

--- a/tests/test-lexer.cpp
+++ b/tests/test-lexer.cpp
@@ -36,7 +36,7 @@ TEST_CASE("Test the Schema class", "[Schema]") {
     }
 
     SECTION("Add a capture variable to schema") {
-        const std::string var_name = "capture";
+        std::string const var_name = "capture";
         schema.add_variable(var_name, "u(?<uID>[0-9]+)", -1);
         auto const schema_ast = schema.release_schema_ast_ptr();
         REQUIRE(schema_ast->m_schema_vars.size() == 1);


### PR DESCRIPTION
# Description
- Initial step for implementing parsing with capture groups.
- Parses capture groups in schema file.
- Currently only adds capture group to AST, but doesn't add to NFA/DFA.
- Move initialization of regex_special_characters into cpp to make it more clear what the lexical rules are for the schema parser.
- Format finite automata files.

# Validation performed
- Ensure the newly added AST doesn't break the existing demo in examples.
- Add unit tests for capture groups.