### PR TITLE
Fix clang-tidy errors in Buffer class.

### DIFF
--- a/examples/buffer-parser.cpp
+++ b/examples/buffer-parser.cpp
@@ -42,7 +42,7 @@ auto process_logs(string& schema_path, string const& input_path) -> void {
     vector<LogEvent> multiline_logs;
     size_t offset{0};
     while (false == parser.done()) {
-        if (ErrorCode err{parser.parse_next_event(buf.data(), valid_size, offset, input_done)};
+        if (ErrorCode err{parser.parse_next_event(buf, valid_size, offset, input_done)};
             ErrorCode::Success != err)
         {
             // The only expected error is the parser has read to the bound

--- a/src/log_surgeon/Buffer.hpp
+++ b/src/log_surgeon/Buffer.hpp
@@ -52,7 +52,7 @@ public:
         m_active_size *= 2;
     }
 
-    [[nodiscard]] static auto static_size()  -> uint32_t { return cStaticByteBuffSize; }
+    [[nodiscard]] static auto static_size() -> uint32_t { return cStaticByteBuffSize; }
 
     [[nodiscard]] auto size() const -> uint32_t { return m_active_size; }
 

--- a/src/log_surgeon/BufferParser.cpp
+++ b/src/log_surgeon/BufferParser.cpp
@@ -19,7 +19,7 @@ auto BufferParser::reset() -> void {
 }
 
 auto BufferParser::parse_next_event(
-        char* buf,
+        std::span<char> buf,
         size_t size,
         size_t& offset,
         bool finished_reading_input

--- a/src/log_surgeon/BufferParser.hpp
+++ b/src/log_surgeon/BufferParser.hpp
@@ -67,7 +67,7 @@ public:
      * @return ErrorCode from LogParser::parse.
      */
     auto parse_next_event(
-            char* buf,
+            std::span<char> buf,
             size_t size,
             size_t& offset,
             bool finished_reading_input = false

--- a/src/log_surgeon/LogEvent.cpp
+++ b/src/log_surgeon/LogEvent.cpp
@@ -94,7 +94,7 @@ LogEvent::LogEvent(LogEventView const& src) : LogEventView{src.get_log_parser()}
         Token copied_token{
                 start_pos,
                 curr_pos,
-                m_buffer.data(),
+                m_buffer,
                 buffer_size,
                 0,
                 token.m_type_ids_ptr

--- a/src/log_surgeon/LogEvent.cpp
+++ b/src/log_surgeon/LogEvent.cpp
@@ -91,14 +91,7 @@ LogEvent::LogEvent(LogEventView const& src) : LogEventView{src.get_log_parser()}
             m_buffer[curr_pos] = c;
             curr_pos++;
         }
-        Token copied_token{
-                start_pos,
-                curr_pos,
-                m_buffer,
-                buffer_size,
-                0,
-                token.m_type_ids_ptr
-        };
+        Token copied_token{start_pos, curr_pos, m_buffer, buffer_size, 0, token.m_type_ids_ptr};
         m_log_output_buffer->set_curr_token(copied_token);
         m_log_output_buffer->advance_to_next_token();
     }

--- a/src/log_surgeon/LogParser.hpp
+++ b/src/log_surgeon/LogParser.hpp
@@ -83,8 +83,12 @@ public:
      * process, so the parser will finish consuming the entire buffer without
      * requesting more input data.
      */
-    auto set_input_buffer(std::span<char> storage, uint32_t size, uint32_t pos, bool finished_reading_input)
-            -> void {
+    auto set_input_buffer(
+            std::span<char> storage,
+            uint32_t size,
+            uint32_t pos,
+            bool finished_reading_input
+    ) -> void {
         m_input_buffer.set_storage(storage, size, pos, finished_reading_input);
     }
 

--- a/src/log_surgeon/LogParser.hpp
+++ b/src/log_surgeon/LogParser.hpp
@@ -83,7 +83,7 @@ public:
      * process, so the parser will finish consuming the entire buffer without
      * requesting more input data.
      */
-    auto set_input_buffer(char* storage, uint32_t size, uint32_t pos, bool finished_reading_input)
+    auto set_input_buffer(std::span<char> storage, uint32_t size, uint32_t pos, bool finished_reading_input)
             -> void {
         m_input_buffer.set_storage(storage, size, pos, finished_reading_input);
     }

--- a/src/log_surgeon/LogParserOutputBuffer.cpp
+++ b/src/log_surgeon/LogParserOutputBuffer.cpp
@@ -8,7 +8,7 @@ namespace log_surgeon {
 auto LogParserOutputBuffer::advance_to_next_token() -> void {
     m_storage.increment_pos();
     if (m_storage.pos() == m_storage.size()) {
-        Token const* old_storage = m_storage.get_active_buffer();
+        Token const* old_storage = m_storage.get_active_buffer().data();
         uint32_t old_size = m_storage.size();
         m_storage.double_size();
         m_storage.copy(old_storage, old_storage + old_size, 0);

--- a/src/log_surgeon/ParserInputBuffer.cpp
+++ b/src/log_surgeon/ParserInputBuffer.cpp
@@ -66,7 +66,7 @@ auto ParserInputBuffer::increase_capacity(uint32_t& old_storage_size, bool& flip
     old_storage_size = m_storage.size();
     uint32_t new_storage_size = old_storage_size * 2;
     flipped_static_buffer = false;
-    char const* old_storage = m_storage.get_active_buffer();
+    char const* old_storage = m_storage.get_active_buffer().data();
     m_storage.double_size();
     if (m_last_read_first_half == false) {
         // Buffer in correct order
@@ -108,7 +108,7 @@ auto ParserInputBuffer::get_next_character(unsigned char& next_char) -> ErrorCod
 // ParserInputBuffer into thinking it never reaches the wrap, while still
 // respecting the actual size of the buffer the user passed in.
 void ParserInputBuffer::set_storage(
-        char* storage,
+        std::span<char> storage,
         uint32_t size,
         uint32_t pos,
         bool finished_reading_input

--- a/src/log_surgeon/ParserInputBuffer.hpp
+++ b/src/log_surgeon/ParserInputBuffer.hpp
@@ -108,8 +108,12 @@ public:
      * process, so the parser will finish consuming the entire buffer without
      * requesting more input data.
      */
-    auto
-    set_storage(char* storage, uint32_t size, uint32_t pos, bool finished_reading_input) -> void;
+    auto set_storage(
+            std::span<char> storage,
+            uint32_t size,
+            uint32_t pos,
+            bool finished_reading_input
+    ) -> void;
 
     /**
      * Return a reference to the underlying storage buffer.

--- a/src/log_surgeon/Token.cpp
+++ b/src/log_surgeon/Token.cpp
@@ -7,24 +7,26 @@ namespace log_surgeon {
 
 auto Token::to_string() -> std::string {
     if (m_start_pos <= m_end_pos) {
-        return {m_buffer + m_start_pos, m_buffer + m_end_pos};
+        return {m_buffer.data() + m_start_pos, m_end_pos - m_start_pos};
     }
     if (m_wrap_around_string.empty()) {
-        m_wrap_around_string = std::string{m_buffer + m_start_pos, m_buffer + m_buffer_size}
-                               + std::string{m_buffer, m_buffer + m_end_pos};
+        m_wrap_around_string.reserve(m_buffer.size() - m_start_pos + m_end_pos);
+        m_wrap_around_string.append(m_buffer.data() + m_start_pos, m_buffer.size() - m_start_pos);
+        m_wrap_around_string.append(m_buffer.data(), m_end_pos);
     }
     return {m_wrap_around_string};
 }
 
 auto Token::to_string_view() -> std::string_view {
     if (m_start_pos <= m_end_pos) {
-        return {m_buffer + m_start_pos, m_end_pos - m_start_pos};
+        return {m_buffer.data() + m_start_pos, m_end_pos - m_start_pos};
     }
     if (m_wrap_around_string.empty()) {
-        m_wrap_around_string = std::string{m_buffer + m_start_pos, m_buffer + m_buffer_size}
-                               + std::string{m_buffer, m_buffer + m_end_pos};
+        m_wrap_around_string.reserve(m_buffer.size() - m_start_pos + m_end_pos);
+        m_wrap_around_string.append(m_buffer.data() + m_start_pos, m_buffer.size() - m_start_pos);
+        m_wrap_around_string.append(m_buffer.data(), m_end_pos);
     }
-    return {m_wrap_around_string};
+    return std::string_view{m_wrap_around_string};
 }
 
 auto Token::get_char(uint8_t i) const -> char {
@@ -35,7 +37,7 @@ auto Token::get_char(uint8_t i) const -> char {
 }
 
 auto Token::get_delimiter() const -> std::string {
-    return {m_buffer + m_start_pos, m_buffer + m_start_pos + 1};
+    return {m_buffer.data() + m_start_pos, 1};
 }
 
 auto Token::get_length() const -> uint32_t {

--- a/src/log_surgeon/Token.hpp
+++ b/src/log_surgeon/Token.hpp
@@ -2,6 +2,7 @@
 #define LOG_SURGEON_TOKEN_HPP
 
 #include <set>
+#include <span>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -37,7 +38,7 @@ public:
 
     uint32_t m_start_pos{0};
     uint32_t m_end_pos{0};
-    char const* m_buffer{nullptr};
+    std::span<char const> m_buffer;
     uint32_t m_buffer_size{0};
     uint32_t m_line{0};
     std::vector<int> const* m_type_ids_ptr{nullptr};


### PR DESCRIPTION
- Change c-style array to std::array
- Change raw pointer to switch between vector and array to std::span
- Make static_size() function static
- Avoid creating temporary strings for assigning wrap_around_string 
- Add missing headers

