### PR TITLE
Fix clang-tidy errors in Constants.hpp. 

### DIFF
--- a/src/log_surgeon/Constants.hpp
+++ b/src/log_surgeon/Constants.hpp
@@ -2,7 +2,6 @@
 #define LOG_SURGEON_CONSTANTS_HPP
 
 #include <cstdint>
-#include <utility>
 
 namespace log_surgeon {
 constexpr uint32_t cUnicodeMax = 0x10'FFFF;
@@ -10,7 +9,7 @@ constexpr uint32_t cSizeOfByte = 256;
 constexpr uint32_t cSizeOfAllChildren = 10'000;
 constexpr uint32_t cNullSymbol = 10'000'000;
 
-enum class ErrorCode {
+enum class ErrorCode  : std::uint8_t {
     Success,
     BufferOutOfBounds,
     LogFullyConsumed,
@@ -22,7 +21,7 @@ enum class ErrorCode {
     Truncated,
 };
 
-enum class SymbolID {
+enum class SymbolID  : std::uint8_t {
     TokenEndID,
     TokenUncaughtStringID,
     TokenIntId,
@@ -33,22 +32,22 @@ enum class SymbolID {
     TokenNewlineId
 };
 
-constexpr char cTokenEnd[] = "$end";
-constexpr char cTokenUncaughtString[] = "$UncaughtString";
-constexpr char cTokenInt[] = "int";
-constexpr char cTokenFloat[] = "float";
-constexpr char cTokenHex[] = "hex";
-constexpr char cTokenFirstTimestamp[] = "firstTimestamp";
-constexpr char cTokenNewlineTimestamp[] = "newLineTimestamp";
-constexpr char cTokenNewline[] = "newLine";
+constexpr auto cTokenEnd = "$end";
+constexpr auto cTokenUncaughtString = "$UncaughtString";
+constexpr auto cTokenInt = "int";
+constexpr auto cTokenFloat = "float";
+constexpr auto cTokenHex = "hex";
+constexpr auto cTokenFirstTimestamp = "firstTimestamp";
+constexpr auto cTokenNewlineTimestamp = "newLineTimestamp";
+constexpr auto cTokenNewline = "newLine";
 constexpr uint32_t cStaticByteBuffSize = 48'000;
 
 namespace utf8 {
 // 0xC0, 0xC1, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE,
 // 0xFF are invalid UTF-8 code units
-static unsigned char const cCharEOF = 0xFF;
-static unsigned char const cCharErr = 0xFE;
-static unsigned char const cCharStartOfFile = 0xFD;
+static constexpr unsigned char  cCharEOF = 0xFF;
+static constexpr unsigned char  cCharErr = 0xFE;
+static constexpr unsigned char  cCharStartOfFile = 0xFD;
 }  // namespace utf8
 }  // namespace log_surgeon
 

--- a/src/log_surgeon/Constants.hpp
+++ b/src/log_surgeon/Constants.hpp
@@ -9,7 +9,7 @@ constexpr uint32_t cSizeOfByte = 256;
 constexpr uint32_t cSizeOfAllChildren = 10'000;
 constexpr uint32_t cNullSymbol = 10'000'000;
 
-enum class ErrorCode  : std::uint8_t {
+enum class ErrorCode : std::uint8_t {
     Success,
     BufferOutOfBounds,
     LogFullyConsumed,
@@ -21,7 +21,7 @@ enum class ErrorCode  : std::uint8_t {
     Truncated,
 };
 
-enum class SymbolID  : std::uint8_t {
+enum class SymbolID : std::uint8_t {
     TokenEndID,
     TokenUncaughtStringID,
     TokenIntId,
@@ -45,9 +45,9 @@ constexpr uint32_t cStaticByteBuffSize = 48'000;
 namespace utf8 {
 // 0xC0, 0xC1, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE,
 // 0xFF are invalid UTF-8 code units
-static constexpr unsigned char  cCharEOF = 0xFF;
-static constexpr unsigned char  cCharErr = 0xFE;
-static constexpr unsigned char  cCharStartOfFile = 0xFD;
+static constexpr unsigned char cCharEOF = 0xFF;
+static constexpr unsigned char cCharErr = 0xFE;
+static constexpr unsigned char cCharStartOfFile = 0xFD;
 }  // namespace utf8
 }  // namespace log_surgeon
 


### PR DESCRIPTION
- Switch char[] to auto. This may be hiding the error instead of fixing it, as I believe auto will just select char[]. Perhaps this should be a string, unless there are some performance implications as these consts need to be used a lot (per token in the log).
- Remove unused header
- Make enum uint8_t
- Use constexpr

# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

# Validation performed
<!-- What tests and validation you performed on the change -->

