### PR TITLE
Fix clang-tidy errors in FileReader class.

### DIFF
--- a/examples/reader-parser.cpp
+++ b/examples/reader-parser.cpp
@@ -26,7 +26,7 @@ auto process_logs(string& schema_path, string const& input_path) -> void {
         return;
     }
 
-    Reader reader{[&](char* buf, size_t count, size_t& read_to) -> ErrorCode {
+    Reader reader{[&](char* buf, uint32_t count, uint32_t& read_to) -> ErrorCode {
         infs.read(buf, count);
         read_to = infs.gcount();
         if (0 == read_to && infs.eof()) {

--- a/src/log_surgeon/Buffer.hpp
+++ b/src/log_surgeon/Buffer.hpp
@@ -78,8 +78,8 @@ public:
     }
 
     template <class T>
-    auto
-    read(T& reader, uint32_t read_offset, uint32_t bytes_to_read, uint32_t& bytes_read) -> ErrorCode {
+    auto read(T& reader, uint32_t read_offset, uint32_t bytes_to_read, uint32_t& bytes_read)
+            -> ErrorCode {
         static_assert(std::is_same_v<T, Reader>, "T should be a Reader");
         return reader.read(m_active_storage + read_offset, bytes_to_read, bytes_read);
     }

--- a/src/log_surgeon/Buffer.hpp
+++ b/src/log_surgeon/Buffer.hpp
@@ -79,7 +79,7 @@ public:
 
     template <class T>
     auto
-    read(T& reader, uint32_t read_offset, uint32_t bytes_to_read, size_t& bytes_read) -> ErrorCode {
+    read(T& reader, uint32_t read_offset, uint32_t bytes_to_read, uint32_t& bytes_read) -> ErrorCode {
         static_assert(std::is_same_v<T, Reader>, "T should be a Reader");
         return reader.read(m_active_storage + read_offset, bytes_to_read, bytes_read);
     }

--- a/src/log_surgeon/FileReader.cpp
+++ b/src/log_surgeon/FileReader.cpp
@@ -2,7 +2,8 @@
 
 #include <cassert>
 #include <cerrno>
-#include <cstdio>
+#include <cstdint>
+#include <ios>
 #include <string>
 #include <variant>
 
@@ -12,7 +13,7 @@ using std::string;
 using std::variant;
 
 namespace log_surgeon {
-auto FileReader::read(char* buf, size_t const num_bytes_to_read, size_t& num_bytes_read)
+auto FileReader::read(char* buf, uint32_t const num_bytes_to_read, uint32_t& num_bytes_read)
         -> ErrorCode {
     if (false == m_file_stream.is_open()) {
         return ErrorCode::NotInit;

--- a/src/log_surgeon/FileReader.hpp
+++ b/src/log_surgeon/FileReader.hpp
@@ -1,18 +1,19 @@
 #ifndef LOG_SURGEON_FILE_READER_HPP
 #define LOG_SURGEON_FILE_READER_HPP
 
-#include <cstdio>
+#include <fstream>
 #include <string>
+#include <variant>
 
 #include <log_surgeon/Constants.hpp>
 #include <log_surgeon/Reader.hpp>
 
 namespace log_surgeon {
+/// TODO: rename to SchemaFileReader and move to file called SchemaFileReader.hpp
 class FileReader : public Reader {
 public:
-    ~FileReader();
     /**
-     * Tries to read up to a given number of bytes from the file
+     * Read the given number of bytes from the file
      * @param buf
      * @param num_bytes_to_read The number of bytes to try and read
      * @param num_bytes_read The actual number of bytes read
@@ -22,44 +23,38 @@ public:
      * @return ErrorCode::EndOfFile on EOF
      * @return ErrorCode::Success on success
      */
-    auto read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) const -> ErrorCode;
+    auto read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) -> ErrorCode;
 
     /**
-     * Tries to read a string from the file until it reaches the specified
-     * delimiter
-     * @param delim The delimiter to stop at
-     * @param keep_delimiter Whether to include the delimiter in the output
-     * string or not
-     * @param append Whether to append to the given string or replace its
-     * contents
-     * @param str The string read
-     * @return ErrorCode::Success on success
+     * Read the desired desired line from the file
+     * @param schema_path
+     * @param line_num
+     * @return The string at the desired line if successful
+     * @return ErrorCode::FileNotFound if the file was not found
      * @return ErrorCode::EndOfFile on EOF
      * @return ErrorCode::Errno otherwise
      */
-    auto try_read_to_delimiter(char delim, bool keep_delimiter, bool append, std::string& str)
-            -> ErrorCode;
+    auto open_and_read_to_line_number(std::string const& schema_path, uint32_t line_num)
+            -> std::variant<std::string, ErrorCode>;
 
     /**
-     * Tries to open a file
+     * Opens the file
      * @param path
      * @return ErrorCode::Success on success
      * @return ErrorCode::FileNotFound if the file was not found
      * @return ErrorCode::Errno otherwise
      */
-    auto try_open(std::string const& path) -> ErrorCode;
+    auto open(std::string const& path) -> ErrorCode;
 
     /**
-     * Closes the file if it's open
+     * Closes the file
      * @return ErrorCode::Success on success
      * @return ErrorCode::Errno otherwise
      */
     auto close() -> ErrorCode;
 
 private:
-    FILE* m_file{nullptr};
-    size_t m_get_delim_buf_len{0};
-    char* m_get_delim_buf{nullptr};
+    std::ifstream m_file_stream;
 };
 }  // namespace log_surgeon
 

--- a/src/log_surgeon/FileReader.hpp
+++ b/src/log_surgeon/FileReader.hpp
@@ -1,6 +1,7 @@
 #ifndef LOG_SURGEON_FILE_READER_HPP
 #define LOG_SURGEON_FILE_READER_HPP
 
+#include <cstdint>
 #include <fstream>
 #include <string>
 #include <variant>
@@ -23,7 +24,7 @@ public:
      * @return ErrorCode::EndOfFile on EOF
      * @return ErrorCode::Success on success
      */
-    auto read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) -> ErrorCode;
+    auto read(char* buf, uint32_t num_bytes_to_read, uint32_t& num_bytes_read) -> ErrorCode;
 
     /**
      * Read the desired desired line from the file

--- a/src/log_surgeon/FileReader.hpp
+++ b/src/log_surgeon/FileReader.hpp
@@ -22,7 +22,7 @@ public:
      * @return ErrorCode::EndOfFile on EOF
      * @return ErrorCode::Success on success
      */
-    auto read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) -> ErrorCode;
+    auto read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) const -> ErrorCode;
 
     /**
      * Tries to read a string from the file until it reaches the specified
@@ -51,8 +51,10 @@ public:
 
     /**
      * Closes the file if it's open
+     * @return ErrorCode::Success on success
+     * @return ErrorCode::Errno otherwise
      */
-    auto close() -> void;
+    auto close() -> ErrorCode;
 
 private:
     FILE* m_file{nullptr};

--- a/src/log_surgeon/LogParser.cpp
+++ b/src/log_surgeon/LogParser.cpp
@@ -139,8 +139,8 @@ void LogParser::add_rules(std::unique_ptr<SchemaAST> schema_ast) {
             throw std::runtime_error(
                     schema_ast->m_file_path + ":" + to_string(rule->m_line_num + 1) + ": error: '"
                     + rule->m_name + "' has regex pattern which contains delimiter '"
-                    + char(delimiter_name) + "'.\n" + indent + line + indent + spaces
-                    + arrows + "\n"
+                    + char(delimiter_name) + "'.\n" + indent + line + indent + spaces + arrows
+                    + "\n"
             );
         }
         unique_ptr<RegexASTGroup<RegexNFAByteState>> delimiter_group

--- a/src/log_surgeon/ParserInputBuffer.cpp
+++ b/src/log_surgeon/ParserInputBuffer.cpp
@@ -33,7 +33,7 @@ auto ParserInputBuffer::read_is_safe() -> bool {
 }
 
 auto ParserInputBuffer::read(Reader& reader) -> ErrorCode {
-    size_t bytes_read{0};
+    uint32_t bytes_read{0};
     // read into the correct half of the buffer
     uint32_t read_offset{0};
     if (m_last_read_first_half) {

--- a/src/log_surgeon/Reader.hpp
+++ b/src/log_surgeon/Reader.hpp
@@ -23,7 +23,7 @@ public:
      * @return ErrorCode::EndOfFile if the end of file was reached
      * @return ErrorCode::Success if any bytes read
      */
-    std::function<ErrorCode(char*, size_t, size_t&)> read{};
+    std::function<ErrorCode(char*, uint32_t, uint32_t&)> read{};
 };
 
 }  // namespace log_surgeon

--- a/src/log_surgeon/SchemaParser.cpp
+++ b/src/log_surgeon/SchemaParser.cpp
@@ -63,7 +63,7 @@ auto SchemaParser::try_schema_file(string const& schema_file_path) -> unique_ptr
         );
     }
     SchemaParser sp;
-    Reader reader{[&](char* buf, size_t count, size_t& read_to) -> ErrorCode {
+    Reader reader{[&](char* buf, uint32_t count, uint32_t& read_to) -> ErrorCode {
         schema_reader.read(buf, count, read_to);
         if (read_to == 0) {
             return ErrorCode::EndOfFile;
@@ -76,7 +76,7 @@ auto SchemaParser::try_schema_file(string const& schema_file_path) -> unique_ptr
 }
 
 auto SchemaParser::try_schema_string(string const& schema_string) -> unique_ptr<SchemaAST> {
-    Reader reader{[&](char* dst_buf, size_t count, size_t& read_to) -> ErrorCode {
+    Reader reader{[&](char* dst_buf, uint32_t count, uint32_t& read_to) -> ErrorCode {
         uint32_t unparsed_string_pos = 0;
         std::span<char> const buf{dst_buf, count};
         if (unparsed_string_pos + count > schema_string.length()) {

--- a/src/log_surgeon/SchemaParser.cpp
+++ b/src/log_surgeon/SchemaParser.cpp
@@ -50,7 +50,7 @@ auto SchemaParser::generate_schema_ast(Reader& reader) -> unique_ptr<SchemaAST> 
 
 auto SchemaParser::try_schema_file(string const& schema_file_path) -> unique_ptr<SchemaAST> {
     FileReader schema_reader;
-    ErrorCode error_code = schema_reader.try_open(schema_file_path);
+    ErrorCode error_code = schema_reader.open(schema_file_path);
     if (ErrorCode::Success != error_code) {
         if (ErrorCode::Errno == error_code) {
             throw std::runtime_error(


### PR DESCRIPTION
- Use `std::ifstream` instead of `FILE*`
- Swap `read` to use `uint32_t` instead of `size_t` to match `std::ifstream`
- Specialize `try_read_to_delim` function as `open_and_read_to_line_number` which returns a `variant<string, ErrorCode>`
- Remove indirect headers and add direct headers 
- Add `const` where possible
- Handle error code from `close`

