### PR TITLE
Fix clang-tidy errors in LALR1Parser class. 

### DIFF
--- a/src/log_surgeon/LALR1Parser.cpp
+++ b/src/log_surgeon/LALR1Parser.cpp
@@ -1,16 +1,21 @@
 #include "LALR1Parser.hpp"
 
+#include <array>
+#include <cstdint>
+
+#include "Constants.hpp"
+
 namespace log_surgeon {
-MatchedSymbol NonTerminal::m_all_children[cSizeOfAllChildren];
+std::array<MatchedSymbol, cSizeOfAllChildren> NonTerminal::m_all_children;
 
 ParserAST::~ParserAST() = default;
 
 uint32_t NonTerminal::m_next_children_start = 0;
 
 NonTerminal::NonTerminal(Production* p)
-        : m_children_start(NonTerminal::m_next_children_start),
+        : m_children_start(m_next_children_start),
           m_production(p),
           m_ast(nullptr) {
-    NonTerminal::m_next_children_start += p->m_body.size();
+    m_next_children_start += p->m_body.size();
 }
 }  // namespace log_surgeon

--- a/src/log_surgeon/LALR1Parser.tpp
+++ b/src/log_surgeon/LALR1Parser.tpp
@@ -4,7 +4,7 @@
 #include <optional>
 
 namespace log_surgeon {
-[[maybe_unused]] auto get_line_num(MatchedSymbol& top_symbol) -> uint32_t {
+[[maybe_unused]] inline auto get_line_num(MatchedSymbol& top_symbol) -> uint32_t {
     std::optional<uint32_t> line_num{std::nullopt};
     std::stack<MatchedSymbol> symbols;
     symbols.push(std::move(top_symbol));

--- a/src/log_surgeon/LALR1Parser.tpp
+++ b/src/log_surgeon/LALR1Parser.tpp
@@ -1,15 +1,9 @@
 #ifndef LOG_SURGEON_LALR1_PARSER_TPP
 #define LOG_SURGEON_LALR1_PARSER_TPP
 
-#include <cstddef>
-#include <functional>
-#include <iostream>
 #include <optional>
 
-#include <log_surgeon/Constants.hpp>
-
 namespace log_surgeon {
-namespace {
 [[maybe_unused]] auto get_line_num(MatchedSymbol& top_symbol) -> uint32_t {
     std::optional<uint32_t> line_num{std::nullopt};
     std::stack<MatchedSymbol> symbols;
@@ -35,23 +29,22 @@ namespace {
     return *line_num;
 }
 
-[[maybe_unused]] auto unescape(char const& c) -> std::string {
+[[maybe_unused]] inline auto unescape(char const c) -> std::string {
     switch (c) {
         case '\t':
-            return "\\t";
+            return std::string{"\\t"};
         case '\r':
-            return "\\r";
+            return std::string{"\\r"};
         case '\n':
-            return "\\n";
+            return std::string{"\\n"};
         case '\v':
-            return "\\v";
+            return std::string{"\\v"};
         case '\f':
-            return "\\f";
+            return std::string{"\\f"};
         default:
-            return {c};
+            return std::string{c};
     }
 }
-}  // namespace
 
 template <typename NFAStateType, typename DFAStateType>
 LALR1Parser<NFAStateType, DFAStateType>::LALR1Parser() {

--- a/src/log_surgeon/SchemaParser.cpp
+++ b/src/log_surgeon/SchemaParser.cpp
@@ -98,7 +98,7 @@ auto SchemaParser::try_schema_string(string const& schema_string) -> unique_ptr<
 
 static auto new_identifier_rule(NonTerminal* m) -> unique_ptr<IdentifierAST> {
     string r1 = m->token_cast(0)->to_string();
-    return make_unique<IdentifierAST>(IdentifierAST(r1[0]));
+    return make_unique<IdentifierAST>(r1[0]);
 }
 
 static auto existing_identifier_rule(NonTerminal* m) -> unique_ptr<ParserAST> {


### PR DESCRIPTION
- Switch c-style array to std::array (*** waiting for PR#23 for rest of fixes that need GSL)
- Add constructor to `ParserAST `
- Delete move and copy constructors from `ParserAST`
- Fix usage of `make_unique` that was creating a temporary object for no reason
- Protected switched to private;
- Remove redundant namespace before vars 
- Remove unneeded namespace; 
- Add var names to function definition
- Fix header function comments
- return std::string correctly
- Add direct headers; 
- Remove indirect headers
- Add const where possible
- Add inline to tpp functions until they are added to hpp
- *** Still needs to combine tpp and hpp in a following PR (which should also automatically fix remaining clang-tidy errors)
- *** Still needs a separate PR to move error handling into the SchemaParser 