### PR TITLE
Fix clang-tidy errors for LogEvent, LogParser, and Parser classes.

### DIFF
--- a/src/log_surgeon/BufferParser.cpp
+++ b/src/log_surgeon/BufferParser.cpp
@@ -34,7 +34,8 @@ auto BufferParser::parse_next_event(
     if (ErrorCode::Success != error_code) {
         if (0 != m_log_parser.get_log_event_view().get_log_output_buffer()->pos()) {
             offset = m_log_parser.get_log_event_view()
-                             .get_log_output_buffer()->get_token(0)
+                             .get_log_output_buffer()
+                             ->get_token(0)
                              .m_start_pos;
         }
         reset();

--- a/src/log_surgeon/BufferParser.cpp
+++ b/src/log_surgeon/BufferParser.cpp
@@ -32,9 +32,9 @@ auto BufferParser::parse_next_event(
     LogParser::ParsingAction parsing_action{LogParser::ParsingAction::None};
     ErrorCode error_code = m_log_parser.parse_and_generate_metadata(parsing_action);
     if (ErrorCode::Success != error_code) {
-        if (0 != m_log_parser.get_log_event_view().m_log_output_buffer->pos()) {
+        if (0 != m_log_parser.get_log_event_view().get_log_output_buffer()->pos()) {
             offset = m_log_parser.get_log_event_view()
-                             .m_log_output_buffer->get_token(0)
+                             .get_log_output_buffer()->get_token(0)
                              .m_start_pos;
         }
         reset();

--- a/src/log_surgeon/LogEvent.cpp
+++ b/src/log_surgeon/LogEvent.cpp
@@ -1,18 +1,20 @@
 #include "LogEvent.hpp"
 
+#include <cstdint>
 #include <memory>
+#include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <log_surgeon/Constants.hpp>
-#include <log_surgeon/LogParser.hpp>
 #include <log_surgeon/LogParserOutputBuffer.hpp>
 #include <log_surgeon/Token.hpp>
 
 namespace log_surgeon {
-LogEventView::LogEventView(LogParser const& log_parser)
-        : m_log_parser{log_parser},
-          m_log_var_occurrences{log_parser.m_lexer.m_id_symbol.size()} {
+LogEventView::LogEventView(std::unordered_map<uint32_t, std::string> const& id_symbols)
+        : m_id_symbols{id_symbols},
+          m_log_var_occurrences{id_symbols.size()} {
     m_log_output_buffer = std::make_unique<LogParserOutputBuffer>();
 }
 
@@ -52,24 +54,24 @@ auto LogEventView::get_logtype() const -> std::string {
     std::string logtype;
     for (uint32_t i = 1; i < m_log_output_buffer->pos(); i++) {
         Token& token = m_log_output_buffer->get_mutable_token(i);
-        if (token.m_type_ids_ptr->at(0) == (int)log_surgeon::SymbolID::TokenUncaughtStringID) {
+        if (token.m_type_ids_ptr->at(0) == static_cast<int>(SymbolID::TokenUncaughtStringID)) {
             logtype += token.to_string_view();
         } else {
-            if ((int)log_surgeon::SymbolID::TokenNewlineId != token.m_type_ids_ptr->at(0)) {
+            if (static_cast<int>(SymbolID::TokenNewlineId) != token.m_type_ids_ptr->at(0)) {
                 logtype += token.get_delimiter();
             }
             logtype += "<";
-            logtype += m_log_parser.get_id_symbol(token.m_type_ids_ptr->at(0));
+            logtype += m_id_symbols.at(token.m_type_ids_ptr->at(0));
             logtype += ">";
         }
     }
     return logtype;
 }
 
-LogEvent::LogEvent(LogEventView const& src) : LogEventView{src.get_log_parser()} {
+LogEvent::LogEvent(LogEventView const& src) : LogEventView{src.get_id_symbols()} {
     set_multiline(src.is_multiline());
-    m_log_output_buffer->set_has_timestamp(src.m_log_output_buffer->has_timestamp());
-    m_log_output_buffer->set_has_delimiters(src.m_log_output_buffer->has_delimiters());
+    get_log_output_buffer()->set_has_timestamp(src.get_log_output_buffer()->has_timestamp());
+    get_log_output_buffer()->set_has_delimiters(src.get_log_output_buffer()->has_delimiters());
     uint32_t start = 0;
     if (nullptr == src.get_timestamp()) {
         start = 1;
@@ -86,7 +88,7 @@ LogEvent::LogEvent(LogEventView const& src) : LogEventView{src.get_log_parser()}
     uint32_t curr_pos = 0;
     for (uint32_t i = start; i < src.get_log_output_buffer()->pos(); i++) {
         Token& token = src.get_log_output_buffer()->get_mutable_token(i);
-        uint32_t start_pos = curr_pos;
+        uint32_t const start_pos = curr_pos;
         for (char const& c : token.to_string_view()) {
             m_buffer[curr_pos] = c;
             curr_pos++;
@@ -99,8 +101,8 @@ LogEvent::LogEvent(LogEventView const& src) : LogEventView{src.get_log_parser()}
                 0,
                 token.m_type_ids_ptr
         };
-        m_log_output_buffer->set_curr_token(copied_token);
-        m_log_output_buffer->advance_to_next_token();
+        get_log_output_buffer()->set_curr_token(copied_token);
+        get_log_output_buffer()->advance_to_next_token();
     }
     for (uint32_t i = 0; i < get_log_output_buffer()->pos(); i++) {
         Token& token = get_log_output_buffer()->get_mutable_token(i);

--- a/src/log_surgeon/LogParser.hpp
+++ b/src/log_surgeon/LogParser.hpp
@@ -1,24 +1,29 @@
 #ifndef LOG_SURGEON_LOG_PARSER_HPP
 #define LOG_SURGEON_LOG_PARSER_HPP
 
-#include <cassert>
-#include <iostream>
+#include <cstdint>
 #include <memory>
+#include <optional>
+#include <string>
 
 #include <log_surgeon/Constants.hpp>
 #include <log_surgeon/LALR1Parser.hpp>
 #include <log_surgeon/LogEvent.hpp>
-#include <log_surgeon/LogParserOutputBuffer.hpp>
 #include <log_surgeon/Parser.hpp>
 #include <log_surgeon/ParserInputBuffer.hpp>
 #include <log_surgeon/SchemaParser.hpp>
 
+#include "finite_automata/RegexDFA.hpp"
+#include "finite_automata/RegexNFA.hpp"
+#include "Reader.hpp"
+#include "Token.hpp"
+
 namespace log_surgeon {
 // TODO: Compare c-array vs. vectors (its underlying array) for buffers
-class LogParser
+class LogParser final
         : public Parser<finite_automata::RegexNFAByteState, finite_automata::RegexDFAByteState> {
 public:
-    enum class ParsingAction {
+    enum class ParsingAction : uint8_t {
         None,
         Compress,
         CompressAndFinish
@@ -39,7 +44,7 @@ public:
      * @throw std::runtime_error from LALR1Parser, RegexAST, or Lexer
      * describing the failure processing the schema AST.
      */
-    explicit LogParser(std::unique_ptr<log_surgeon::SchemaAST> schema_ast);
+    explicit LogParser(std::unique_ptr<SchemaAST> const& schema_ast);
 
     /**
      * Returns the parser to its initial state, clearing any existing
@@ -91,7 +96,7 @@ public:
     /**
      * @return the current position inside the input buffer.
      */
-    auto get_input_pos() -> uint32_t { return m_input_buffer.storage().pos(); }
+    auto get_input_pos() const -> uint32_t { return m_input_buffer.storage().pos(); }
 
     /**
      * Reads into the input buffer if only consumed data will be overwritten.
@@ -112,7 +117,7 @@ public:
     /**
      * Resets the log event view to prepare for the next parse
      */
-    auto reset_log_event_view() -> void { m_log_event_view->reset(); }
+    auto reset_log_event_view() const -> void { m_log_event_view->reset(); }
 
     /**
      * @return the log event view based on the last parse
@@ -134,7 +139,7 @@ private:
      * Generates metadata for last parsed log event indicating occurrences of
      * each variable and if the log event is multiline
      */
-    auto generate_log_event_view_metadata() -> void;
+    auto generate_log_event_view_metadata() const -> void;
 
     /**
      * Requests the next token from the lexer.
@@ -158,7 +163,7 @@ private:
      * @param schema_ast The AST from which parsing and lexing rules are
      * generated.
      */
-    auto add_rules(std::unique_ptr<SchemaAST> schema_ast) -> void;
+    auto add_rules(std::unique_ptr<SchemaAST> const& schema_ast) -> void;
 
     // TODO: move ownership of the buffer to the lexer
     ParserInputBuffer m_input_buffer;

--- a/src/log_surgeon/Parser.hpp
+++ b/src/log_surgeon/Parser.hpp
@@ -1,7 +1,10 @@
 #ifndef LOG_SURGEON_PARSER_HPP
 #define LOG_SURGEON_PARSER_HPP
 
+#include <memory>
+#include <string>
 #include <log_surgeon/Lexer.hpp>
+#include "finite_automata/RegexAST.hpp"
 
 namespace log_surgeon {
 

--- a/src/log_surgeon/Parser.hpp
+++ b/src/log_surgeon/Parser.hpp
@@ -10,6 +10,13 @@ class Parser {
 public:
     Parser();
 
+    virtual ~Parser() = default;
+
+    Parser(Parser const&) = delete;
+    auto operator=(Parser const&) -> Parser& = delete;
+    Parser(Parser&&) noexcept = delete;
+    auto operator=(Parser&&) noexcept -> Parser& = delete;
+
     virtual auto add_rule(
             std::string const& name,
             std::unique_ptr<finite_automata::RegexAST<NFAStateType>> rule

--- a/src/log_surgeon/Parser.hpp
+++ b/src/log_surgeon/Parser.hpp
@@ -3,7 +3,9 @@
 
 #include <memory>
 #include <string>
+
 #include <log_surgeon/Lexer.hpp>
+
 #include "finite_automata/RegexAST.hpp"
 
 namespace log_surgeon {

--- a/src/log_surgeon/Parser.tpp
+++ b/src/log_surgeon/Parser.tpp
@@ -1,32 +1,30 @@
 #ifndef LOG_SURGEON_PARSER_TPP
 #define LOG_SURGEON_PARSER_TPP
 
-#include <memory>
-
-#include <log_surgeon/finite_automata/RegexAST.hpp>
-
 namespace log_surgeon {
 
 template <typename NFAStateType, typename DFAStateType>
 Parser<NFAStateType, DFAStateType>::Parser() {
     // TODO move clp-reserved symbols out of the parser
-    m_lexer.m_symbol_id[cTokenEnd] = (int)SymbolID::TokenEndID;
-    m_lexer.m_symbol_id[cTokenUncaughtString] = (int)SymbolID::TokenUncaughtStringID;
-    m_lexer.m_symbol_id[cTokenInt] = (int)SymbolID::TokenIntId;
-    m_lexer.m_symbol_id[cTokenFloat] = (int)SymbolID::TokenFloatId;
-    m_lexer.m_symbol_id[cTokenHex] = (int)SymbolID::TokenHexId;
-    m_lexer.m_symbol_id[cTokenFirstTimestamp] = (int)SymbolID::TokenFirstTimestampId;
-    m_lexer.m_symbol_id[cTokenNewlineTimestamp] = (int)SymbolID::TokenNewlineTimestampId;
-    m_lexer.m_symbol_id[cTokenNewline] = (int)SymbolID::TokenNewlineId;
+    m_lexer.m_symbol_id[cTokenEnd] = static_cast<int>(SymbolID::TokenEndID);
+    m_lexer.m_symbol_id[cTokenUncaughtString] = static_cast<int>(SymbolID::TokenUncaughtStringID);
+    m_lexer.m_symbol_id[cTokenInt] = static_cast<int>(SymbolID::TokenIntId);
+    m_lexer.m_symbol_id[cTokenFloat] = static_cast<int>(SymbolID::TokenFloatId);
+    m_lexer.m_symbol_id[cTokenHex] = static_cast<int>(SymbolID::TokenHexId);
+    m_lexer.m_symbol_id[cTokenFirstTimestamp] = static_cast<int>(SymbolID::TokenFirstTimestampId);
+    m_lexer.m_symbol_id[cTokenNewlineTimestamp]
+            = static_cast<int>(SymbolID::TokenNewlineTimestampId);
+    m_lexer.m_symbol_id[cTokenNewline] = static_cast<int>(SymbolID::TokenNewlineId);
 
-    m_lexer.m_id_symbol[(int)SymbolID::TokenEndID] = cTokenEnd;
-    m_lexer.m_id_symbol[(int)SymbolID::TokenUncaughtStringID] = cTokenUncaughtString;
-    m_lexer.m_id_symbol[(int)SymbolID::TokenIntId] = cTokenInt;
-    m_lexer.m_id_symbol[(int)SymbolID::TokenFloatId] = cTokenFloat;
-    m_lexer.m_id_symbol[(int)SymbolID::TokenHexId] = cTokenHex;
-    m_lexer.m_id_symbol[(int)SymbolID::TokenFirstTimestampId] = cTokenFirstTimestamp;
-    m_lexer.m_id_symbol[(int)SymbolID::TokenNewlineTimestampId] = cTokenNewlineTimestamp;
-    m_lexer.m_id_symbol[(int)SymbolID::TokenNewlineId] = cTokenNewline;
+    m_lexer.m_id_symbol[static_cast<int>(SymbolID::TokenEndID)] = cTokenEnd;
+    m_lexer.m_id_symbol[static_cast<int>(SymbolID::TokenUncaughtStringID)] = cTokenUncaughtString;
+    m_lexer.m_id_symbol[static_cast<int>(SymbolID::TokenIntId)] = cTokenInt;
+    m_lexer.m_id_symbol[static_cast<int>(SymbolID::TokenFloatId)] = cTokenFloat;
+    m_lexer.m_id_symbol[static_cast<int>(SymbolID::TokenHexId)] = cTokenHex;
+    m_lexer.m_id_symbol[static_cast<int>(SymbolID::TokenFirstTimestampId)] = cTokenFirstTimestamp;
+    m_lexer.m_id_symbol[static_cast<int>(SymbolID::TokenNewlineTimestampId)]
+            = cTokenNewlineTimestamp;
+    m_lexer.m_id_symbol[static_cast<int>(SymbolID::TokenNewlineId)] = cTokenNewline;
 }
 
 template <typename NFAStateType, typename DFAStateType>

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -30,7 +30,8 @@ public:
      * lexer rule
      * @param is_possible_input
      */
-    virtual auto set_possible_inputs_to_true(bool is_possible_input[]) const -> void = 0;
+    virtual auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax> is_possible_input
+    ) const -> void = 0;
 
     /**
      * transform '.' from any-character into any non-delimiter in a lexer rule
@@ -65,7 +66,8 @@ public:
      * lexer rule containing RegexASTLiteral at a leaf node in its AST
      * @param is_possible_input
      */
-    auto set_possible_inputs_to_true(bool is_possible_input[]) const -> void override {
+    auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax> is_possible_input
+    ) const -> void override {
         is_possible_input[m_character] = true;
     }
 
@@ -112,7 +114,8 @@ public:
      * lexer rule containing RegexASTInteger at a leaf node in its AST
      * @param is_possible_input
      */
-    auto set_possible_inputs_to_true(bool is_possible_input[]) const -> void override {
+    auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax> is_possible_input
+    ) const -> void override {
         for (uint32_t i : m_digits) {
             is_possible_input[i + '0'] = true;
         }
@@ -175,7 +178,8 @@ public:
      * lexer rule containing RegexASTGroup at a leaf node in its AST
      * @param is_possible_input
      */
-    auto set_possible_inputs_to_true(bool is_possible_input[]) const -> void override {
+    auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax> is_possible_input
+    ) const -> void override {
         if (!m_negate) {
             for (Range range : m_ranges) {
                 for (uint32_t i = range.first; i <= range.second; i++) {
@@ -291,7 +295,8 @@ public:
      * lexer rule containing RegexASTOr at a leaf node in its AST
      * @param is_possible_input
      */
-    auto set_possible_inputs_to_true(bool is_possible_input[]) const -> void override {
+    auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax> is_possible_input
+    ) const -> void override {
         m_left->set_possible_inputs_to_true(is_possible_input);
         m_right->set_possible_inputs_to_true(is_possible_input);
     }
@@ -342,7 +347,8 @@ public:
      * lexer rule containing RegexASTCat at a leaf node in its AST
      * @param is_possible_input
      */
-    auto set_possible_inputs_to_true(bool is_possible_input[]) const -> void override {
+    auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax> is_possible_input
+    ) const -> void override {
         m_left->set_possible_inputs_to_true(is_possible_input);
         m_right->set_possible_inputs_to_true(is_possible_input);
     }
@@ -405,7 +411,8 @@ public:
      * lexer rule containing RegexASTMultiplication at a leaf node in its AST
      * @param is_possible_input
      */
-    auto set_possible_inputs_to_true(bool is_possible_input[]) const -> void override {
+    auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax> is_possible_input
+    ) const -> void override {
         m_operand->set_possible_inputs_to_true(is_possible_input);
     }
 
@@ -469,7 +476,8 @@ public:
      * lexer rule containing `RegexASTCapture` at a leaf node in its AST.
      * @param is_possible_input
      */
-    auto set_possible_inputs_to_true(bool is_possible_input[]) const -> void override {
+    auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax> is_possible_input
+    ) const -> void override {
         m_group_regex_ast->set_possible_inputs_to_true(is_possible_input);
     }
 


### PR DESCRIPTION
Combine these classes' changes as they have a lot of overlap.
- Depends on PR#23 (will have to resolve conflicts once this PR is accepted)
- Use std::array in place of c-style array (copied changes from PR#23)
- Change `LogEventView` to contain `m_id_symbols` instead of a reference to `LogParser`
- Move `m_log_output_buffer` member to private and add accessor
- Add virtual destructor to `Parser` class and delete its move and copy constructors
- Replace c-style casts with `static_cast`
- Pass `unique_ptrs` that aren't having ownership transfer by const& instead of `std::move`
- Make LogParser final
- Make enum type uint8_t
- Add 'const' where possible
- Add [[nodiscard]] where possible
- Swap add_rules() to have trailing return type
- Remove redundant initializer
- Remove redundant namespaces before vars
- Remove unneeded using
- Add direct headers and remove indirect headers
Note yet changed:
- Need to reduce complexity of `add_rules()` and `parse()` functions in future PR
- Will merge tpp and hpp in future PR (should resolve remaining clang-tidy errors)
