### PR TITLE
Bug-fix: Use the correct size for creating Unicode arrays.

### DIFF
--- a/src/log_surgeon/Constants.hpp
+++ b/src/log_surgeon/Constants.hpp
@@ -6,6 +6,7 @@
 
 namespace log_surgeon {
 constexpr uint32_t cUnicodeMax = 0x10'FFFF;
+constexpr uint32_t cSizeOfUnicode = cUnicodeMax + 1;
 constexpr uint32_t cSizeOfByte = 256;
 constexpr uint32_t cSizeOfAllChildren = 10'000;
 constexpr uint32_t cNullSymbol = 10'000'000;

--- a/src/log_surgeon/LogParser.cpp
+++ b/src/log_surgeon/LogParser.cpp
@@ -96,7 +96,7 @@ void LogParser::add_rules(std::unique_ptr<SchemaAST> schema_ast) {
         rule->m_regex_ptr->remove_delimiters_from_wildcard(delimiters);
         // currently, error out if non-timestamp pattern contains a delimiter
         // check if regex contains a delimiter
-        std::array<bool, cUnicodeMax> is_possible_input{};
+        std::array<bool, cSizeOfUnicode> is_possible_input{};
         rule->m_regex_ptr->set_possible_inputs_to_true(is_possible_input);
         bool contains_delimiter = false;
         uint32_t delimiter_name = 0;

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -35,7 +35,7 @@ public:
      * lexer rule
      * @param is_possible_input
      */
-    virtual auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax>& is_possible_input
+    virtual auto set_possible_inputs_to_true(std::array<bool, cSizeOfUnicode>& is_possible_input
     ) const -> void = 0;
 
     /**
@@ -77,7 +77,7 @@ public:
      * lexer rule containing RegexASTLiteral at a leaf node in its AST
      * @param is_possible_input
      */
-    auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax>& is_possible_input
+    auto set_possible_inputs_to_true(std::array<bool, cSizeOfUnicode>& is_possible_input
     ) const -> void override {
         is_possible_input[m_character] = true;
     }
@@ -126,7 +126,7 @@ public:
      * lexer rule containing RegexASTInteger at a leaf node in its AST
      * @param is_possible_input
      */
-    auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax>& is_possible_input
+    auto set_possible_inputs_to_true(std::array<bool, cSizeOfUnicode>& is_possible_input
     ) const -> void override {
         for (uint32_t const i : m_digits) {
             is_possible_input.at('0' + i) = true;
@@ -196,7 +196,7 @@ public:
      * lexer rule containing RegexASTGroup at a leaf node in its AST
      * @param is_possible_input
      */
-    auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax>& is_possible_input
+    auto set_possible_inputs_to_true(std::array<bool, cSizeOfUnicode>& is_possible_input
     ) const -> void override {
         if (!m_negate) {
             for (auto const& [begin, end] : m_ranges) {
@@ -205,7 +205,7 @@ public:
                 }
             }
         } else {
-            std::vector<char> inputs(cUnicodeMax, 1);
+            std::vector<char> inputs(cSizeOfUnicode, 1);
             for (auto const& [begin, end] : m_ranges) {
                 for (uint32_t i = begin; i <= end; i++) {
                     inputs[i] = 0;
@@ -321,7 +321,7 @@ public:
      * lexer rule containing RegexASTOr at a leaf node in its AST
      * @param is_possible_input
      */
-    auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax>& is_possible_input
+    auto set_possible_inputs_to_true(std::array<bool, cSizeOfUnicode>& is_possible_input
     ) const -> void override {
         m_left->set_possible_inputs_to_true(is_possible_input);
         m_right->set_possible_inputs_to_true(is_possible_input);
@@ -381,7 +381,7 @@ public:
      * lexer rule containing RegexASTCat at a leaf node in its AST
      * @param is_possible_input
      */
-    auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax>& is_possible_input
+    auto set_possible_inputs_to_true(std::array<bool, cSizeOfUnicode>& is_possible_input
     ) const -> void override {
         m_left->set_possible_inputs_to_true(is_possible_input);
         m_right->set_possible_inputs_to_true(is_possible_input);
@@ -451,7 +451,7 @@ public:
      * lexer rule containing RegexASTMultiplication at a leaf node in its AST
      * @param is_possible_input
      */
-    auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax>& is_possible_input
+    auto set_possible_inputs_to_true(std::array<bool, cSizeOfUnicode>& is_possible_input
     ) const -> void override {
         m_operand->set_possible_inputs_to_true(is_possible_input);
     }
@@ -522,7 +522,7 @@ public:
      * lexer rule containing `RegexASTCapture` at a leaf node in its AST.
      * @param is_possible_input
      */
-    auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax>& is_possible_input
+    auto set_possible_inputs_to_true(std::array<bool, cSizeOfUnicode>& is_possible_input
     ) const -> void override {
         m_group_regex_ast->set_possible_inputs_to_true(is_possible_input);
     }


### PR DESCRIPTION
# Description
- Switch from c-style arrays to `std::array` resulted in an out-of-bounds crash as `cUnicodeMax` was being incorrectly used as the size of Unicode arrays.
- Fix bug by introducing `cUnicodeSize=cUnicodeMax+1`.

# Validation performed
- Examples now run without crashing.
