### PR TITLE
Add method to determine if an AST contains a capture group.

### DIFF
--- a/examples/intersect-test.cpp
+++ b/examples/intersect-test.cpp
@@ -9,6 +9,7 @@ using log_surgeon::finite_automata::RegexDFAByteState;
 using log_surgeon::finite_automata::RegexNFA;
 using log_surgeon::finite_automata::RegexNFAByteState;
 using log_surgeon::lexers::ByteLexer;
+using log_surgeon::LexicalRule;
 using log_surgeon::ParserAST;
 using log_surgeon::SchemaVarAST;
 using std::string;
@@ -33,7 +34,7 @@ auto get_intersect_for_query(
     auto schema_ast = schema.release_schema_ast_ptr();
     for (unique_ptr<ParserAST> const& parser_ast : schema_ast->m_schema_vars) {
         auto* schema_var_ast = dynamic_cast<SchemaVarAST*>(parser_ast.get());
-        ByteLexer::Rule rule(0, std::move(schema_var_ast->m_regex_ptr));
+        LexicalRule rule(0, std::move(schema_var_ast->m_regex_ptr));
         rule.add_ast(&nfa);
     }
     auto dfa2 = ByteLexer::nfa_to_dfa(nfa);
@@ -70,7 +71,7 @@ auto main() -> int {
         auto schema_ast = schema.release_schema_ast_ptr();
         for (unique_ptr<ParserAST> const& parser_ast : schema_ast->m_schema_vars) {
             auto* var_ast = dynamic_cast<SchemaVarAST*>(parser_ast.get());
-            ByteLexer::Rule rule(m_id_symbol.size(), std::move(var_ast->m_regex_ptr));
+            LexicalRule rule(m_id_symbol.size(), std::move(var_ast->m_regex_ptr));
             m_id_symbol[m_id_symbol.size()] = var_ast->m_name;
             rule.add_ast(&nfa);
         }

--- a/src/log_surgeon/Constants.hpp
+++ b/src/log_surgeon/Constants.hpp
@@ -6,6 +6,7 @@
 
 namespace log_surgeon {
 constexpr uint32_t cUnicodeMax = 0x10'FFFF;
+constexpr uint32_t cSizeOfUnicode = cUnicodeMax + 1;
 constexpr uint32_t cSizeOfByte = 256;
 constexpr uint32_t cSizeOfAllChildren = 10'000;
 constexpr uint32_t cNullSymbol = 10'000'000;

--- a/src/log_surgeon/LogEvent.hpp
+++ b/src/log_surgeon/LogEvent.hpp
@@ -47,11 +47,11 @@ public:
      * NOTE: Currently, the returned Token(s) cannot be const as calling
      * Token::to_string or Token::to_string_view may mutate Token (to handle the
      * case where a token is wraps from the end to the beginning of a buffer).
-     * @param var_id
-     * @return The tokens corresponding to var_id
+     * @param variable_id
+     * @return The tokens corresponding to variable_id
      */
-    [[nodiscard]] auto get_variables(size_t var_id) const -> std::vector<Token*> const& {
-        return m_log_var_occurrences[var_id];
+    [[nodiscard]] auto get_variables(size_t variable_id) const -> std::vector<Token*> const& {
+        return m_log_var_occurrences[variable_id];
     }
 
     /**

--- a/src/log_surgeon/LogParser.cpp
+++ b/src/log_surgeon/LogParser.cpp
@@ -53,7 +53,8 @@ void LogParser::add_rules(std::unique_ptr<SchemaAST> schema_ast) {
             delimiters.push_back(i);
         }
     }
-    // Currently, required to have delimiters
+
+    // Required to have delimiters
     if (delimiters.empty()) {
         throw runtime_error("When using --schema-path, \"delimiters:\" line must be used.");
     }
@@ -94,7 +95,7 @@ void LogParser::add_rules(std::unique_ptr<SchemaAST> schema_ast) {
         }
         // transform '.' from any-character into any non-delimiter character
         rule->m_regex_ptr->remove_delimiters_from_wildcard(delimiters);
-        // currently, error out if non-timestamp pattern contains a delimiter
+
         // check if regex contains a delimiter
         std::array<bool, cSizeOfUnicode> is_possible_input{};
         rule->m_regex_ptr->set_possible_inputs_to_true(is_possible_input);
@@ -107,6 +108,8 @@ void LogParser::add_rules(std::unique_ptr<SchemaAST> schema_ast) {
                 break;
             }
         }
+
+        // Error out if non-timestamp pattern contains a delimiter
         if (contains_delimiter) {
             FileReader schema_reader;
             ErrorCode error_code = schema_reader.try_open(schema_ast->m_file_path);
@@ -141,6 +144,8 @@ void LogParser::add_rules(std::unique_ptr<SchemaAST> schema_ast) {
                     + arrows + "\n"
             );
         }
+
+        // Add delimiters as prefix to regex as variables require preceeding delimiters
         unique_ptr<RegexASTGroup<RegexNFAByteState>> delimiter_group
                 = make_unique<RegexASTGroup<RegexNFAByteState>>(
                         RegexASTGroup<RegexNFAByteState>(delimiters)
@@ -149,6 +154,7 @@ void LogParser::add_rules(std::unique_ptr<SchemaAST> schema_ast) {
                 std::move(delimiter_group),
                 std::move(rule->m_regex_ptr)
         );
+
         add_rule(rule->m_name, std::move(rule->m_regex_ptr));
     }
 }

--- a/src/log_surgeon/LogParser.cpp
+++ b/src/log_surgeon/LogParser.cpp
@@ -145,7 +145,7 @@ void LogParser::add_rules(std::unique_ptr<SchemaAST> schema_ast) {
             );
         }
 
-        // Add delimiters as prefix to regex as variables require preceeding delimiters
+        // To make lexing log-specific: modify variable regex to contain a delimiter at the start.
         unique_ptr<RegexASTGroup<RegexNFAByteState>> delimiter_group
                 = make_unique<RegexASTGroup<RegexNFAByteState>>(
                         RegexASTGroup<RegexNFAByteState>(delimiters)

--- a/src/log_surgeon/LogParser.cpp
+++ b/src/log_surgeon/LogParser.cpp
@@ -96,7 +96,7 @@ void LogParser::add_rules(std::unique_ptr<SchemaAST> schema_ast) {
         rule->m_regex_ptr->remove_delimiters_from_wildcard(delimiters);
         // currently, error out if non-timestamp pattern contains a delimiter
         // check if regex contains a delimiter
-        std::array<bool, cUnicodeMax> is_possible_input{};
+        std::array<bool, cSizeOfUnicode> is_possible_input{};
         rule->m_regex_ptr->set_possible_inputs_to_true(is_possible_input);
         bool contains_delimiter = false;
         uint32_t delimiter_name = 0;

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -35,7 +35,7 @@ public:
      * lexer rule
      * @param is_possible_input
      */
-    virtual auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax>& is_possible_input
+    virtual auto set_possible_inputs_to_true(std::array<bool, cSizeOfUnicode>& is_possible_input
     ) const -> void = 0;
 
     /**
@@ -77,7 +77,7 @@ public:
      * lexer rule containing RegexASTLiteral at a leaf node in its AST
      * @param is_possible_input
      */
-    auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax>& is_possible_input
+    auto set_possible_inputs_to_true(std::array<bool, cSizeOfUnicode>& is_possible_input
     ) const -> void override {
         is_possible_input[m_character] = true;
     }
@@ -126,7 +126,7 @@ public:
      * lexer rule containing RegexASTInteger at a leaf node in its AST
      * @param is_possible_input
      */
-    auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax>& is_possible_input
+    auto set_possible_inputs_to_true(std::array<bool, cSizeOfUnicode>& is_possible_input
     ) const -> void override {
         for (uint32_t const i : m_digits) {
             is_possible_input.at('0' + i) = true;
@@ -196,7 +196,7 @@ public:
      * lexer rule containing RegexASTGroup at a leaf node in its AST
      * @param is_possible_input
      */
-    auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax>& is_possible_input
+    auto set_possible_inputs_to_true(std::array<bool, cSizeOfUnicode>& is_possible_input
     ) const -> void override {
         if (!m_negate) {
             for (auto const& [begin, end] : m_ranges) {
@@ -205,7 +205,7 @@ public:
                 }
             }
         } else {
-            std::vector<char> inputs(cUnicodeMax, 1);
+            std::vector<char> inputs(cSizeOfUnicode, 1);
             for (auto const& [begin, end] : m_ranges) {
                 for (uint32_t i = begin; i <= end; i++) {
                     inputs[i] = 0;
@@ -321,7 +321,7 @@ public:
      * lexer rule containing RegexASTOr at a leaf node in its AST
      * @param is_possible_input
      */
-    auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax>& is_possible_input
+    auto set_possible_inputs_to_true(std::array<bool, cSizeOfUnicode>& is_possible_input
     ) const -> void override {
         m_left->set_possible_inputs_to_true(is_possible_input);
         m_right->set_possible_inputs_to_true(is_possible_input);
@@ -381,7 +381,7 @@ public:
      * lexer rule containing RegexASTCat at a leaf node in its AST
      * @param is_possible_input
      */
-    auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax>& is_possible_input
+    auto set_possible_inputs_to_true(std::array<bool, cSizeOfUnicode>& is_possible_input
     ) const -> void override {
         m_left->set_possible_inputs_to_true(is_possible_input);
         m_right->set_possible_inputs_to_true(is_possible_input);
@@ -451,7 +451,7 @@ public:
      * lexer rule containing RegexASTMultiplication at a leaf node in its AST
      * @param is_possible_input
      */
-    auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax>& is_possible_input
+    auto set_possible_inputs_to_true(std::array<bool, cSizeOfUnicode>& is_possible_input
     ) const -> void override {
         m_operand->set_possible_inputs_to_true(is_possible_input);
     }
@@ -522,7 +522,7 @@ public:
      * lexer rule containing `RegexASTCapture` at a leaf node in its AST.
      * @param is_possible_input
      */
-    auto set_possible_inputs_to_true(std::array<bool, cUnicodeMax>& is_possible_input
+    auto set_possible_inputs_to_true(std::array<bool, cSizeOfUnicode>& is_possible_input
     ) const -> void override {
         m_group_regex_ast->set_possible_inputs_to_true(is_possible_input);
     }

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -53,6 +53,12 @@ public:
     virtual auto add(RegexNFA<NFAStateType>* nfa, NFAStateType* end_state) -> void = 0;
 
     /**
+     * Traverse the AST and check if it contains a capture group
+     * @return true if the AST contains a capture group, false otherwise
+     */
+    virtual auto has_capture_groups() -> bool = 0;
+
+    /**
      * Serialize the AST into a string
      * @param with_tags
      * @return string representing the AST
@@ -136,6 +142,12 @@ public:
     auto add(RegexNFA<NFAStateType>* nfa, NFAStateType* end_state) -> void override;
 
     /**
+     * Return false as RegexASTLiteral is a leaf node that is not a capture group
+     * @return false
+     */
+    auto has_capture_groups() -> bool override { return false; }
+
+    /**
      * serialize the RegexASTLiteral into a string
      * @param with_tags
      * @return string representing the AST
@@ -200,6 +212,12 @@ public:
      * @param end_state
      */
     auto add(RegexNFA<NFAStateType>* nfa, NFAStateType* end_state) -> void override;
+
+    /**
+     * Return false as RegexASTInteger is a leaf node that is not a capture group
+     * @return false
+     */
+    auto has_capture_groups() -> bool override { return false; }
 
     /**
      * serialize the RegexASTInteger into a string
@@ -323,6 +341,12 @@ public:
     auto add(RegexNFA<NFAStateType>* nfa, NFAStateType* end_state) -> void override;
 
     /**
+     * Return false as RegexASTGroup is a leaf node that is not a capture group
+     * @return false
+     */
+    auto has_capture_groups() -> bool override { return false; }
+
+    /**
      * serialize the RegexASTGroup into a string
      * @param with_tags
      * @return string representing the AST
@@ -426,6 +450,12 @@ public:
     auto add(RegexNFA<NFAStateType>* nfa, NFAStateType* end_state) -> void override;
 
     /**
+     * Traverse the AST and check if RegexASTOr contains a capture group
+     * @return true if the AST contains a capture group, false otherwise
+     */
+    auto has_capture_groups() -> bool override;
+
+    /**
      * serialize the RegexASTOr into a string
      * @param with_tags
      * @return string representing the AST
@@ -504,6 +534,12 @@ public:
      * @param end_state
      */
     auto add(RegexNFA<NFAStateType>* nfa, NFAStateType* end_state) -> void override;
+
+    /**
+     * Traverse the AST and check if it contains a capture group
+     * @return true if the AST contains a capture group, false otherwise
+     */
+    auto has_capture_groups() -> bool override;
 
     /**
      * serialize the RegexASTCat into a string
@@ -587,6 +623,12 @@ public:
     auto add(RegexNFA<NFAStateType>* nfa, NFAStateType* end_state) -> void override;
 
     /**
+     * Traverse the AST and check if RegexASTMultiplication contains a capture group
+     * @return true if the AST contains a capture group, false otherwise
+     */
+    auto has_capture_groups() -> bool override;
+
+    /**
      * serialize the RegexASTMultiplication into a string
      * @param with_tags
      * @return string representing the AST
@@ -667,6 +709,12 @@ public:
      * @param end_state
      */
     auto add(RegexNFA<NFAStateType>* nfa, NFAStateType* end_state) -> void override;
+
+    /**
+     * Return true as RegexASTCapture is a capture group
+     * @return true
+     */
+    auto has_capture_groups() -> bool override { return true; }
 
     /**
      * serialize the RegexASTCapture into a string
@@ -760,6 +808,11 @@ void RegexASTOr<NFAStateType>::add(RegexNFA<NFAStateType>* nfa, NFAStateType* en
 }
 
 template <typename NFAStateType>
+auto RegexASTOr<NFAStateType>::has_capture_groups() -> bool {
+    return m_left->has_capture_groups() || m_right->has_capture_groups();
+}
+
+template <typename NFAStateType>
 auto RegexASTOr<NFAStateType>::add_tags(std::vector<uint32_t>& all_tags) -> std::vector<uint32_t> {
     auto positive_left_tags = m_left->add_tags(all_tags);
     auto positive_right_tags = m_right->add_tags(all_tags);
@@ -799,6 +852,11 @@ void RegexASTCat<NFAStateType>::add(RegexNFA<NFAStateType>* nfa, NFAStateType* e
     nfa->set_root(intermediate_state);
     m_right->add(nfa, end_state);
     nfa->set_root(saved_root);
+}
+
+template <typename NFAStateType>
+auto RegexASTCat<NFAStateType>::has_capture_groups() -> bool {
+    return m_left->has_capture_groups() || m_right->has_capture_groups();
 }
 
 template <typename NFAStateType>
@@ -866,6 +924,11 @@ void RegexASTMultiplication<NFAStateType>::add(
         m_operand->add(nfa, end_state);
     }
     nfa->set_root(saved_root);
+}
+
+template <typename NFAStateType>
+auto RegexASTMultiplication<NFAStateType>::has_capture_groups() -> bool {
+    return m_operand->has_capture_groups();
 }
 
 template <typename NFAStateType>

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -46,7 +46,7 @@ public:
 
     /**
      * Add the needed RegexNFA::states to the passed in nfa to handle the
-     * current node before transitioning to a pre-tagged end_state
+     * current node before transitioning to an accepting end_state
      * @param nfa
      * @param end_state
      */

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -94,7 +94,7 @@ public:
 
     /**
      * Add the needed RegexNFA::states to the passed in nfa to handle a
-     * RegexASTLiteral before transitioning to a pre-tagged end_state
+     * RegexASTLiteral before transitioning to an accepting end_state
      * @param nfa
      * @param end_state
      */
@@ -145,7 +145,7 @@ public:
 
     /**
      * Add the needed RegexNFA::states to the passed in nfa to handle a
-     * RegexASTInteger before transitioning to a pre-tagged end_state
+     * RegexASTInteger before transitioning to an accepting end_state
      * @param nfa
      * @param end_state
      */
@@ -251,7 +251,7 @@ public:
 
     /**
      * Add the needed RegexNFA::states to the passed in nfa to handle a
-     * RegexASTGroup before transitioning to a pre-tagged end_state
+     * RegexASTGroup before transitioning to an accepting end_state
      * @param nfa
      * @param end_state
      */
@@ -339,7 +339,7 @@ public:
 
     /**
      * Add the needed RegexNFA::states to the passed in nfa to handle a
-     * RegexASTOr before transitioning to a pre-tagged end_state
+     * RegexASTOr before transitioning to an accepting end_state
      * @param nfa
      * @param end_state
      */
@@ -399,7 +399,7 @@ public:
 
     /**
      * Add the needed RegexNFA::states to the passed in nfa to handle a
-     * RegexASTCat before transitioning to a pre-tagged end_state
+     * RegexASTCat before transitioning to an accepting end_state
      * @param nfa
      * @param end_state
      */

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -468,7 +468,7 @@ public:
 
     /**
      * Add the needed RegexNFA::states to the passed in nfa to handle a
-     * RegexASTMultiplication before transitioning to a pre-tagged end_state
+     * RegexASTMultiplication before transitioning to an accepting end_state
      * @param nfa
      * @param end_state
      */
@@ -538,7 +538,7 @@ public:
 
     /**
      * Adds the needed `RegexNFA::states` to the passed in nfa to handle a
-     * `RegexASTCapture` before transitioning to a pre-tagged `end_state`.
+     * `RegexASTCapture` before transitioning to an accepting `end_state`.
      * @param nfa
      * @param end_state
      */

--- a/src/log_surgeon/finite_automata/RegexDFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.hpp
@@ -23,11 +23,15 @@ class RegexDFAState {
 public:
     using Tree = UnicodeIntervalTree<RegexDFAState<stateType>*>;
 
-    auto add_tag(int const& rule_name_id) -> void { m_tags.push_back(rule_name_id); }
+    auto add_matching_variable_id(int const& variable_id) -> void {
+        m_matching_variable_ids.push_back(variable_id);
+    }
 
-    [[nodiscard]] auto get_tags() const -> std::vector<int> const& { return m_tags; }
+    [[nodiscard]] auto get_matching_variable_ids() const -> std::vector<int> const& {
+        return m_matching_variable_ids;
+    }
 
-    [[nodiscard]] auto is_accepting() const -> bool { return !m_tags.empty(); }
+    [[nodiscard]] auto is_accepting() const -> bool { return !m_matching_variable_ids.empty(); }
 
     auto add_byte_transition(uint8_t const& byte, RegexDFAState<stateType>* dest_state) -> void {
         m_bytes_transition[byte] = dest_state;
@@ -42,7 +46,7 @@ public:
     [[nodiscard]] auto next(uint32_t character) const -> RegexDFAState<stateType>*;
 
 private:
-    std::vector<int> m_tags;
+    std::vector<int> m_matching_variable_ids;
     RegexDFAState<stateType>* m_bytes_transition[cSizeOfByte];
     // NOTE: We don't need m_tree_transitions for the `stateType ==
     // RegexDFAStateType::Byte` case, so we use an empty class (`std::tuple<>`)
@@ -89,10 +93,10 @@ public:
     }
 
     /**
-     * @return The tags of the first state of the pair
+     * @return The matching variable ids of the first state of the pair
      */
-    [[nodiscard]] auto get_first_tags() const -> std::vector<int> const& {
-        return m_state1->get_tags();
+    [[nodiscard]] auto get_first_matching_variable_ids() const -> std::vector<int> const& {
+        return m_state1->get_matching_variable_ids();
     }
 
 private:

--- a/src/log_surgeon/finite_automata/RegexDFA.tpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.tpp
@@ -40,16 +40,17 @@ auto RegexDFAStatePair<DFAState>::get_reachable_pairs(
 
 template <typename DFAStateType>
 template <typename NFAStateType>
-auto RegexDFA<DFAStateType>::new_state(std::set<NFAStateType*> const& set) -> DFAStateType* {
+auto RegexDFA<DFAStateType>::new_state(std::set<NFAStateType*> const& nfa_state_set
+) -> DFAStateType* {
     std::unique_ptr<DFAStateType> ptr = std::make_unique<DFAStateType>();
     m_states.push_back(std::move(ptr));
-    DFAStateType* state = m_states.back().get();
-    for (NFAStateType const* s : set) {
-        if (s->is_accepting()) {
-            state->add_tag(s->get_tag());
+    DFAStateType* dfa_state = m_states.back().get();
+    for (NFAStateType const* nfa_state : nfa_state_set) {
+        if (nfa_state->is_accepting()) {
+            dfa_state->add_matching_variable_id(nfa_state->get_matching_variable_id());
         }
     }
-    return state;
+    return dfa_state;
 }
 
 template <typename DFAStateType>
@@ -63,8 +64,8 @@ auto RegexDFA<DFAStateType>::get_intersect(std::unique_ptr<RegexDFA> const& dfa_
     while (false == unvisited_pairs.empty()) {
         auto current_pair_it = unvisited_pairs.begin();
         if (current_pair_it->is_accepting()) {
-            auto& tags = current_pair_it->get_first_tags();
-            schema_types.insert(tags.begin(), tags.end());
+            auto& matching_variable_ids = current_pair_it->get_first_matching_variable_ids();
+            schema_types.insert(matching_variable_ids.begin(), matching_variable_ids.end());
         }
         visited_pairs.insert(*current_pair_it);
         current_pair_it->get_reachable_pairs(visited_pairs, unvisited_pairs);

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -95,6 +95,7 @@ private:
 using RegexNFAByteState = RegexNFAState<RegexNFAStateType::Byte>;
 using RegexNFAUTF8State = RegexNFAState<RegexNFAStateType::UTF8>;
 
+// TODO: rename RegexNFA to NFA and RegexDFA to DFA
 template <typename NFAStateType>
 class RegexNFA {
 public:

--- a/tests/test-lexer.cpp
+++ b/tests/test-lexer.cpp
@@ -9,6 +9,9 @@
 #include <log_surgeon/Schema.hpp>
 #include <log_surgeon/SchemaParser.hpp>
 
+using std::string;
+using std::vector;
+
 using RegexASTCatByte = log_surgeon::finite_automata::RegexASTCat<
         log_surgeon::finite_automata::RegexNFAByteState>;
 using RegexASTCaptureByte = log_surgeon::finite_automata::RegexASTCapture<
@@ -19,27 +22,29 @@ using RegexASTLiteralByte = log_surgeon::finite_automata::RegexASTLiteral<
         log_surgeon::finite_automata::RegexNFAByteState>;
 using RegexASTMultiplicationByte = log_surgeon::finite_automata::RegexASTMultiplication<
         log_surgeon::finite_automata::RegexNFAByteState>;
+using RegexASTOrByte
+        = log_surgeon::finite_automata::RegexASTOr<log_surgeon::finite_automata::RegexNFAByteState>;
+using log_surgeon::SchemaVarAST;
 
 TEST_CASE("Test the Schema class", "[Schema]") {
-    log_surgeon::Schema schema;
-
     SECTION("Add a number variable to schema") {
-        schema.add_variable("myNumber", "123", -1);
+        log_surgeon::Schema schema;
+        string const var_name = "myNumber";
+        schema.add_variable(var_name, "123", -1);
         auto const schema_ast = schema.release_schema_ast_ptr();
         REQUIRE(schema_ast->m_schema_vars.size() == 1);
         REQUIRE(schema.release_schema_ast_ptr()->m_schema_vars.empty());
 
         auto& schema_var_ast_ptr = schema_ast->m_schema_vars[0];
         REQUIRE(nullptr != schema_var_ast_ptr);
-        auto& schema_var_ast = dynamic_cast<log_surgeon::SchemaVarAST&>(*schema_var_ast_ptr);
-        REQUIRE("myNumber" == schema_var_ast.m_name);
+        auto& schema_var_ast = dynamic_cast<SchemaVarAST&>(*schema_var_ast_ptr);
+        REQUIRE(var_name == schema_var_ast.m_name);
 
-        REQUIRE_NOTHROW([&]() {
-            auto& regex_ast_cat = dynamic_cast<RegexASTCatByte&>(*schema_var_ast.m_regex_ptr);
-        }());
+        REQUIRE_NOTHROW([&]() { dynamic_cast<RegexASTCatByte&>(*schema_var_ast.m_regex_ptr); }());
     }
 
     SECTION("Add a capture variable to schema") {
+        log_surgeon::Schema schema;
         std::string const var_name = "capture";
         schema.add_variable(var_name, "u(?<uID>[0-9]+)", -1);
         auto const schema_ast = schema.release_schema_ast_ptr();
@@ -48,7 +53,7 @@ TEST_CASE("Test the Schema class", "[Schema]") {
 
         auto& schema_var_ast_ptr = schema_ast->m_schema_vars[0];
         REQUIRE(nullptr != schema_var_ast_ptr);
-        auto& schema_var_ast = dynamic_cast<log_surgeon::SchemaVarAST&>(*schema_var_ast_ptr);
+        auto& schema_var_ast = dynamic_cast<SchemaVarAST&>(*schema_var_ast_ptr);
         REQUIRE(var_name == schema_var_ast.m_name);
 
         auto* regex_ast_cat_ptr = dynamic_cast<RegexASTCatByte*>(schema_var_ast.m_regex_ptr.get());
@@ -84,23 +89,22 @@ TEST_CASE("Test the Schema class", "[Schema]") {
     }
 
     SECTION("Test AST with tags") {
+        log_surgeon::Schema schema;
         schema.add_variable(
                 "capture",
                 "Z|(A(?<letter>((?<letter1>(a)|(b))|(?<letter2>(c)|(d))))B(?<containerID>\\d+)C)",
                 -1
         );
         auto const schema_ast = schema.release_schema_ast_ptr();
-        auto& capture_rule_ast
-                = dynamic_cast<log_surgeon::SchemaVarAST&>(*schema_ast->m_schema_vars[0]);
-        std::vector<uint32_t> all_tags;
+        auto& capture_rule_ast = dynamic_cast<SchemaVarAST&>(*schema_ast->m_schema_vars[0]);
+        vector<uint32_t> all_tags;
         capture_rule_ast.m_regex_ptr->add_tags(all_tags);
 
-        std::string expected_serialized_string
-                = "(Z)|(A(?<letter>((?<letter1>(a)|(b)))|((?<letter2>(c)|"
-                  "(d))))B(?<containerID>[0-9]{1,inf})C)";
+        string expected_serialized_string = "(Z)|(A(?<letter>((?<letter1>(a)|(b)))|((?<letter2>(c)|"
+                                            "(d))))B(?<containerID>[0-9]{1,inf})C)";
         REQUIRE(capture_rule_ast.m_regex_ptr->serialize(false) == expected_serialized_string);
 
-        std::string expected_serialized_string_with_tags
+        string expected_serialized_string_with_tags
                 = "(Z<~0><~1><~2><~3>)|(A((((a)|(b))<1><~2>)|(((c)|(d))<2><~1>))<0>B([0-9]{1,inf})<"
                   "3>C)";
         REQUIRE(capture_rule_ast.m_regex_ptr->serialize(true)

--- a/tests/test-lexer.cpp
+++ b/tests/test-lexer.cpp
@@ -1,3 +1,7 @@
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include <catch2/catch_test_macros.hpp>
 
 #include <log_surgeon/finite_automata/RegexAST.hpp>
@@ -77,5 +81,29 @@ TEST_CASE("Test the Schema class", "[Schema]") {
         REQUIRE(1 == regex_ast_group_ast->get_ranges().size());
         REQUIRE('0' == regex_ast_group_ast->get_ranges()[0].first);
         REQUIRE('9' == regex_ast_group_ast->get_ranges()[0].second);
+    }
+
+    SECTION("Test AST with tags") {
+        schema.add_variable(
+                "capture",
+                "Z|(A(?<letter>((?<letter1>(a)|(b))|(?<letter2>(c)|(d))))B(?<containerID>\\d+)C)",
+                -1
+        );
+        auto const schema_ast = schema.release_schema_ast_ptr();
+        auto& capture_rule_ast
+                = dynamic_cast<log_surgeon::SchemaVarAST&>(*schema_ast->m_schema_vars[0]);
+        std::vector<uint32_t> all_tags;
+        capture_rule_ast.m_regex_ptr->add_tags(all_tags);
+
+        std::string expected_serialized_string
+                = "(Z)|(A(?<letter>((?<letter1>(a)|(b)))|((?<letter2>(c)|"
+                  "(d))))B(?<containerID>[0-9]{1,inf})C)";
+        REQUIRE(capture_rule_ast.m_regex_ptr->serialize(false) == expected_serialized_string);
+
+        std::string expected_serialized_string_with_tags
+                = "(Z<~0><~1><~2><~3>)|(A((((a)|(b))<1><~2>)|(((c)|(d))<2><~1>))<0>B([0-9]{1,inf})<"
+                  "3>C)";
+        REQUIRE(capture_rule_ast.m_regex_ptr->serialize(true)
+                == expected_serialized_string_with_tags);
     }
 }

--- a/tests/test-lexer.cpp
+++ b/tests/test-lexer.cpp
@@ -88,6 +88,17 @@ TEST_CASE("Test the Schema class", "[Schema]") {
         REQUIRE('9' == regex_ast_group_ast->get_ranges()[0].second);
     }
 
+    SECTION("Test has_capture_groups()") {
+        log_surgeon::Schema schema;
+        schema.add_variable("number", "123", -1);
+        schema.add_variable("capture", "user_id=(?<userID>[0-9]+)", -1);
+        auto const schema_ast = schema.release_schema_ast_ptr();
+        auto& number_var_ast = dynamic_cast<SchemaVarAST&>(*schema_ast->m_schema_vars[0]);
+        REQUIRE(false == number_var_ast.m_regex_ptr->has_capture_groups());
+        auto& capture_var_ast = dynamic_cast<SchemaVarAST&>(*schema_ast->m_schema_vars[1]);
+        REQUIRE(capture_var_ast.m_regex_ptr->has_capture_groups());
+    }
+
     SECTION("Test AST with tags") {
         log_surgeon::Schema schema;
         schema.add_variable(


### PR DESCRIPTION
# References
- Depends on PR#39
 
# Description
- `has_capture_groups()` recursively searches the AST for a capture group node.

# Validation performed
Added unit-test which runs successfully.
