### PR TITLE
Temporarily lock clang-format to v18.x to resolve lint failures.

### DIFF
--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,2 +1,3 @@
+# Lock to v18.x until we can upgrade our code to meet v19's formatting standards.
 clang-format~=18.1
 yamllint>=1.35.1

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,2 +1,2 @@
-clang-format>=18.1.5
+clang-format~=18.1
 yamllint>=1.35.1


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#45 

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This PR locks the clang-format version to 18.1.8 (which is the latest version 18 release in PyPI) as a temporary solution to fix the lint workflow failure due to the new major release of clang-format (version 19). We will fix this properly later by adapting clang-format version 19.

# Validation performed
<!-- What tests and validation you performed on the change -->
Ensure the workflow passed after locking clang-format version: https://github.com/LinZhihao-723/log-surgeon/actions/runs/11040699328



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version specification for `clang-format` to lock it to the 18.x series for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->