### PR TITLE
Constrain NFA states to contain only one negative transition.

### DIFF
--- a/examples/intersect-test.cpp
+++ b/examples/intersect-test.cpp
@@ -40,7 +40,7 @@ auto get_intersect_for_query(
         auto* schema_var_ast = dynamic_cast<SchemaVarAST*>(parser_ast.get());
         rules.emplace_back(0, std::move(schema_var_ast->m_regex_ptr));
     }
-    RegexNFA<RegexNFAByteState> nfa(rules);
+    RegexNFA<RegexNFAByteState> nfa(move(rules));
     auto dfa2 = ByteLexer::nfa_to_dfa(nfa);
     auto schema_types = dfa1->get_intersect(dfa2);
     std::cout << search_string << ":";
@@ -78,7 +78,7 @@ auto main() -> int {
             rules.emplace_back(m_id_symbol.size(), std::move(var_ast->m_regex_ptr));
             m_id_symbol[m_id_symbol.size()] = var_ast->m_name;
         }
-        RegexNFA<RegexNFAByteState> nfa(rules);
+        RegexNFA<RegexNFAByteState> nfa(move(rules));
         auto dfa = ByteLexer::nfa_to_dfa(nfa);
         get_intersect_for_query(m_id_symbol, dfa, "*1*");
         get_intersect_for_query(m_id_symbol, dfa, "*a*");

--- a/examples/intersect-test.cpp
+++ b/examples/intersect-test.cpp
@@ -13,6 +13,7 @@ using log_surgeon::lexers::ByteLexer;
 using log_surgeon::LexicalRule;
 using log_surgeon::ParserAST;
 using log_surgeon::SchemaVarAST;
+using std::move;
 using std::string;
 using std::unique_ptr;
 using std::vector;

--- a/examples/intersect-test.cpp
+++ b/examples/intersect-test.cpp
@@ -13,7 +13,6 @@ using log_surgeon::lexers::ByteLexer;
 using log_surgeon::LexicalRule;
 using log_surgeon::ParserAST;
 using log_surgeon::SchemaVarAST;
-using std::move;
 using std::string;
 using std::unique_ptr;
 using std::vector;
@@ -41,7 +40,7 @@ auto get_intersect_for_query(
         auto* schema_var_ast = dynamic_cast<SchemaVarAST*>(parser_ast.get());
         rules.emplace_back(0, std::move(schema_var_ast->m_regex_ptr));
     }
-    RegexNFA<RegexNFAByteState> nfa(move(rules));
+    RegexNFA<RegexNFAByteState> nfa(std::move(rules));
     auto dfa2 = ByteLexer::nfa_to_dfa(nfa);
     auto schema_types = dfa1->get_intersect(dfa2);
     std::cout << search_string << ":";
@@ -79,7 +78,7 @@ auto main() -> int {
             rules.emplace_back(m_id_symbol.size(), std::move(var_ast->m_regex_ptr));
             m_id_symbol[m_id_symbol.size()] = var_ast->m_name;
         }
-        RegexNFA<RegexNFAByteState> nfa(move(rules));
+        RegexNFA<RegexNFAByteState> nfa(std::move(rules));
         auto dfa = ByteLexer::nfa_to_dfa(nfa);
         get_intersect_for_query(m_id_symbol, dfa, "*1*");
         get_intersect_for_query(m_id_symbol, dfa, "*a*");

--- a/src/log_surgeon/Lexer.tpp
+++ b/src/log_surgeon/Lexer.tpp
@@ -411,7 +411,7 @@ auto Lexer<NFAStateType, DFAStateType>::epsilon_closure(NFAStateType const* stat
             stack.push(positive_tagged_transition.get_dest_state());
         }
         auto const& optional_negative_tagged_transition
-                = current_state->get_optional_negative_tagged_transition();
+                = current_state->get_negative_tagged_transition();
         if (optional_negative_tagged_transition.has_value()) {
             stack.push(optional_negative_tagged_transition.value().get_dest_state());
         }

--- a/src/log_surgeon/Lexer.tpp
+++ b/src/log_surgeon/Lexer.tpp
@@ -394,20 +394,23 @@ auto Lexer<NFAStateType, DFAStateType>::epsilon_closure(NFAStateType const* stat
     std::stack<NFAStateType const*> stack;
     stack.push(state_ptr);
     while (!stack.empty()) {
-        NFAStateType const* t = stack.top();
+        NFAStateType const* curr_state = stack.top();
         stack.pop();
-        if (closure_set.insert(t).second) {
-            for (NFAStateType* const u : t->get_epsilon_transitions()) {
-                stack.push(u);
+        if (closure_set.insert(curr_state).second) {
+            for (NFAStateType* const dest_state : curr_state->get_epsilon_transitions()) {
+                stack.push(dest_state);
             }
 
             // TODO: currently treat tagged transitions as epsilon transitions
-            for (auto const& positive_tagged_transition : t->get_positive_tagged_transitions()) {
+            for (auto const& positive_tagged_transition :
+                 curr_state->get_positive_tagged_transitions())
+            {
                 stack.push(positive_tagged_transition.get_dest_state());
             }
-            auto const* negative_dest_state = t->get_negative_tagged_transition().get_dest_state();
+            auto const* negative_dest_state
+                    = curr_state->get_negative_tagged_transition().get_dest_state();
             if (nullptr != negative_dest_state) {
-                stack.push(t->get_negative_tagged_transition().get_dest_state());
+                stack.push(curr_state->get_negative_tagged_transition().get_dest_state());
             }
         }
     }

--- a/src/log_surgeon/Lexer.tpp
+++ b/src/log_surgeon/Lexer.tpp
@@ -2,6 +2,7 @@
 #define LOG_SURGEON_LEXER_TPP
 
 #include <cassert>
+#include <stack>
 #include <string>
 #include <vector>
 

--- a/src/log_surgeon/Lexer.tpp
+++ b/src/log_surgeon/Lexer.tpp
@@ -405,8 +405,9 @@ auto Lexer<NFAStateType, DFAStateType>::epsilon_closure(NFAStateType const* stat
             for (auto const& positive_tagged_transition : t->get_positive_tagged_transitions()) {
                 stack.push(positive_tagged_transition.get_dest_state());
             }
-            for (auto const& negative_tagged_transition : t->get_negative_tagged_transitions()) {
-                stack.push(negative_tagged_transition.get_dest_state());
+            auto const* negative_dest_state = t->get_negative_tagged_transition().get_dest_state();
+            if (nullptr != negative_dest_state) {
+                stack.push(t->get_negative_tagged_transition().get_dest_state());
             }
         }
     }

--- a/src/log_surgeon/Lexer.tpp
+++ b/src/log_surgeon/Lexer.tpp
@@ -394,23 +394,23 @@ auto Lexer<NFAStateType, DFAStateType>::epsilon_closure(NFAStateType const* stat
     std::stack<NFAStateType const*> stack;
     stack.push(state_ptr);
     while (!stack.empty()) {
-        NFAStateType const* curr_state = stack.top();
+        NFAStateType const* current_state = stack.top();
         stack.pop();
-        if (closure_set.insert(curr_state).second) {
-            for (NFAStateType* const dest_state : curr_state->get_epsilon_transitions()) {
+        if (closure_set.insert(current_state).second) {
+            for (NFAStateType* const dest_state : current_state->get_epsilon_transitions()) {
                 stack.push(dest_state);
             }
 
             // TODO: currently treat tagged transitions as epsilon transitions
             for (auto const& positive_tagged_transition :
-                 curr_state->get_positive_tagged_transitions())
+                 current_state->get_positive_tagged_transitions())
             {
                 stack.push(positive_tagged_transition.get_dest_state());
             }
             auto const* negative_dest_state
-                    = curr_state->get_negative_tagged_transition().get_dest_state();
+                    = current_state->get_negative_tagged_transition().get_dest_state();
             if (nullptr != negative_dest_state) {
-                stack.push(curr_state->get_negative_tagged_transition().get_dest_state());
+                stack.push(negative_dest_state);
             }
         }
     }

--- a/src/log_surgeon/Lexer.tpp
+++ b/src/log_surgeon/Lexer.tpp
@@ -374,7 +374,7 @@ auto Lexer<NFAStateType, DFAStateType>::get_rule(uint32_t const variable_id
 
 template <typename NFAStateType, typename DFAStateType>
 void Lexer<NFAStateType, DFAStateType>::generate() {
-    finite_automata::RegexNFA<NFAStateType> nfa(std::move(m_rules));
+    finite_automata::RegexNFA<NFAStateType> nfa{std::move(m_rules)};
     // TODO: DFA ignores tags. E.g., treats "capture:user=(?<user_id>\d+)" as "capture:user=\d+"
     m_dfa = nfa_to_dfa(nfa);
     DFAStateType const* state = m_dfa->get_root();

--- a/src/log_surgeon/Lexer.tpp
+++ b/src/log_surgeon/Lexer.tpp
@@ -409,7 +409,7 @@ auto Lexer<NFAStateType, DFAStateType>::epsilon_closure(NFAStateType const* stat
         {
             stack.push(positive_tagged_transition.get_dest_state());
         }
-        auto const optional_negative_tagged_transition
+        auto const& optional_negative_tagged_transition
                 = current_state->get_optional_negative_tagged_transition();
         if (optional_negative_tagged_transition.has_value()) {
             stack.push(optional_negative_tagged_transition.value().get_dest_state());

--- a/src/log_surgeon/Lexer.tpp
+++ b/src/log_surgeon/Lexer.tpp
@@ -409,10 +409,10 @@ auto Lexer<NFAStateType, DFAStateType>::epsilon_closure(NFAStateType const* stat
         {
             stack.push(positive_tagged_transition.get_dest_state());
         }
-        auto const* negative_dest_state
-                = current_state->get_negative_tagged_transition().get_dest_state();
-        if (nullptr != negative_dest_state) {
-            stack.push(negative_dest_state);
+        auto const optional_negative_tagged_transition
+                = current_state->get_optional_negative_tagged_transition();
+        if (optional_negative_tagged_transition.has_value()) {
+            stack.push(optional_negative_tagged_transition.value().get_dest_state());
         }
     }
     return closure_set;

--- a/src/log_surgeon/Lexer.tpp
+++ b/src/log_surgeon/Lexer.tpp
@@ -394,10 +394,10 @@ auto Lexer<NFAStateType, DFAStateType>::epsilon_closure(NFAStateType const* stat
     std::stack<NFAStateType const*> stack;
     stack.push(state_ptr);
     while (!stack.empty()) {
-        NFAStateType const* current_state = stack.top();
+        auto const* current_state = stack.top();
         stack.pop();
         if (closure_set.insert(current_state).second) {
-            for (NFAStateType* const dest_state : current_state->get_epsilon_transitions()) {
+            for (auto const* dest_state : current_state->get_epsilon_transitions()) {
                 stack.push(dest_state);
             }
 

--- a/src/log_surgeon/Lexer.tpp
+++ b/src/log_surgeon/Lexer.tpp
@@ -374,7 +374,7 @@ auto Lexer<NFAStateType, DFAStateType>::get_rule(uint32_t const variable_id
 
 template <typename NFAStateType, typename DFAStateType>
 void Lexer<NFAStateType, DFAStateType>::generate() {
-    finite_automata::RegexNFA<NFAStateType> nfa(m_rules);
+    finite_automata::RegexNFA<NFAStateType> nfa(std::move(m_rules));
     // TODO: DFA ignores tags. E.g., treats "capture:user=(?<user_id>\d+)" as "capture:user=\d+"
     m_dfa = nfa_to_dfa(nfa);
     DFAStateType const* state = m_dfa->get_root();

--- a/src/log_surgeon/Lexer.tpp
+++ b/src/log_surgeon/Lexer.tpp
@@ -396,22 +396,23 @@ auto Lexer<NFAStateType, DFAStateType>::epsilon_closure(NFAStateType const* stat
     while (!stack.empty()) {
         auto const* current_state = stack.top();
         stack.pop();
-        if (closure_set.insert(current_state).second) {
-            for (auto const* dest_state : current_state->get_epsilon_transitions()) {
-                stack.push(dest_state);
-            }
+        if (false == closure_set.insert(current_state).second) {
+            continue;
+        }
+        for (auto const* dest_state : current_state->get_epsilon_transitions()) {
+            stack.push(dest_state);
+        }
 
-            // TODO: currently treat tagged transitions as epsilon transitions
-            for (auto const& positive_tagged_transition :
-                 current_state->get_positive_tagged_transitions())
-            {
-                stack.push(positive_tagged_transition.get_dest_state());
-            }
-            auto const* negative_dest_state
-                    = current_state->get_negative_tagged_transition().get_dest_state();
-            if (nullptr != negative_dest_state) {
-                stack.push(negative_dest_state);
-            }
+        // TODO: currently treat tagged transitions as epsilon transitions
+        for (auto const& positive_tagged_transition :
+             current_state->get_positive_tagged_transitions())
+        {
+            stack.push(positive_tagged_transition.get_dest_state());
+        }
+        auto const* negative_dest_state
+                = current_state->get_negative_tagged_transition().get_dest_state();
+        if (nullptr != negative_dest_state) {
+            stack.push(negative_dest_state);
         }
     }
     return closure_set;

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -98,7 +98,7 @@ public:
     }
 
     /**
-     * Handles the addition of an intermediate state with negative transitions if needed.
+     * Handles the addition of an intermediate state with a negative transition if needed.
      * @param nfa
      * @param end_state
      */

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -105,11 +105,11 @@ public:
     auto add_to_nfa_with_negative_tags(RegexNFA<NFAStateType>* nfa, NFAStateType* end_state) const
             -> void {
         // Handle negative tags as:
-        // root --(regex)--> state_with_negative_tagged_transitions --(negative tags)--> end_state
+        // root --(regex)--> state_with_negative_tagged_transition --(negative tags)--> end_state
         if (false == m_negative_tags.empty()) {
-            auto* state_with_negative_tagged_transitions
-                    = nfa->new_state_with_negative_tagged_transitions(m_negative_tags, end_state);
-            add_to_nfa(nfa, state_with_negative_tagged_transitions);
+            auto* state_with_negative_tagged_transition
+                    = nfa->new_state_with_negative_tagged_transition(m_negative_tags, end_state);
+            add_to_nfa(nfa, state_with_negative_tagged_transition);
         } else {
             add_to_nfa(nfa, end_state);
         }

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -154,8 +154,8 @@ public:
     /**
      * @param state_ids A map of states to their unique identifiers.
      * @return A string representation of the NFA state on success.
-     * @return Forwards `PositiveTaggedTransition::serialize`'s return values on failure.
-     * @return Forwards `NegativeTaggedTransition::serialize`'s return values on failure.
+     * @return Forwards `PositiveTaggedTransition::serialize`'s or
+     * `NegativeTaggedTransition::serialize`'s return value (std::nullopt) on failure.
      */
     [[nodiscard]] auto serialize(
             std::unordered_map<RegexNFAByteState const*, uint32_t> const& state_ids

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -94,13 +94,11 @@ public:
 
     RegexNFAState() = default;
 
-    RegexNFAState(uint32_t const tag, RegexNFAState const* dest_state) {
-        m_positive_tagged_transitions.emplace_back(tag, dest_state);
-    }
+    RegexNFAState(uint32_t const tag, RegexNFAState const* dest_state)
+            : m_positive_tagged_transitions{{tag, dest_state}} {}
 
-    RegexNFAState(std::set<uint32_t> tags, RegexNFAState const* dest_state) {
-        m_negative_tagged_transitions.emplace_back(std::move(tags), dest_state);
-    }
+    RegexNFAState(std::set<uint32_t> tags, RegexNFAState const* dest_state)
+            : m_negative_tagged_transitions{{std::move(tags), dest_state}} {}
 
     auto set_accepting(bool accepting) -> void { m_accepting = accepting; }
 

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -319,6 +319,7 @@ auto RegexNFAState<state_type>::serialize(
             );
         }
     }
+
     std::vector<std::string> epsilon_transitions;
     for (auto const* dest_state : m_epsilon_transitions) {
         epsilon_transitions.push_back(std::to_string(state_ids.at(dest_state)));

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -46,7 +46,6 @@ public:
     }
 
     /**
-     * Serialize the positive tagged transition into a string.
      * @param state_ids A map of states to their unique identifiers.
      * @return A string representation of the positive tagged transitions.
      */

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -148,7 +148,7 @@ public:
     /**
      * @param state_ids A map of states to their unique identifiers.
      * @return A string representation of the NFA state on success.
-     * @return Forwards `PositiveTaggedTransition::serialize`'s return value (std::nullopt) on *
+     * @return Forwards `PositiveTaggedTransition::serialize`'s return value (std::nullopt) on
      * failure.
      * @return Forwards `NegativeTaggedTransition::serialize`'s return value (std::nullopt) on
      * failure.
@@ -341,6 +341,7 @@ auto RegexNFAState<state_type>::serialize(
 
     auto const accepting_tag_string
             = m_accepting ? fmt::format("accepting_tag={},", m_matching_variable_id) : "";
+
     return fmt::format(
             "{}:{}byte_transitions={{{}}},epsilon_transitions={{{}}},positive_tagged_transitions={{"
             "{}}},negative_tagged_transition={{{}}}",

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -332,7 +332,7 @@ auto RegexNFAState<state_type>::serialize(
 
     std::vector<std::string> negative_tagged_transitions;
     for (auto const& negative_tagged_transition : m_negative_tagged_transitions) {
-        negative_tagged_transitions.push_back(negative_tagged_transition.serialize(state_ids));
+        negative_tagged_transitions.emplace_back(negative_tagged_transition.serialize(state_ids));
     }
 
     auto accepting_tag_string

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -323,22 +323,22 @@ auto RegexNFAState<state_type>::serialize(
 
     std::vector<std::string> positive_tagged_transitions;
     for (auto const& positive_tagged_transition : m_positive_tagged_transitions) {
-        auto const serialized_positive_transition_it
+        auto const optional_serialized_positive_transition
                 = positive_tagged_transition.serialize(state_ids);
-        if (false == serialized_positive_transition_it.has_value()) {
+        if (false == optional_serialized_positive_transition.has_value()) {
             return std::nullopt;
         }
-        positive_tagged_transitions.emplace_back(serialized_positive_transition_it.value());
+        positive_tagged_transitions.emplace_back(optional_serialized_positive_transition.value());
     }
 
     std::vector<std::string> negative_tagged_transitions;
     for (auto const& negative_tagged_transition : m_negative_tagged_transitions) {
-        auto const serialized_negative_transition_it
+        auto const optional_serialized_negative_transition
                 = negative_tagged_transition.serialize(state_ids);
-        if (false == serialized_negative_transition_it.has_value()) {
+        if (false == optional_serialized_negative_transition.has_value()) {
             return std::nullopt;
         }
-        negative_tagged_transitions.emplace_back(serialized_negative_transition_it.value());
+        negative_tagged_transitions.emplace_back(optional_serialized_negative_transition.value());
     }
 
     auto const accepting_tag_string

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -93,9 +93,7 @@ public:
             : m_positive_tagged_transitions{{tag, dest_state}} {}
 
     RegexNFAState(std::set<uint32_t> tags, RegexNFAState const* dest_state)
-            : m_optional_negative_tagged_transition{
-                      NegativeTaggedTransition{std::move(tags), dest_state}
-              } {}
+            : m_negative_tagged_transition{NegativeTaggedTransition{std::move(tags), dest_state}} {}
 
     auto set_accepting(bool accepting) -> void { m_accepting = accepting; }
 
@@ -114,9 +112,9 @@ public:
         return m_positive_tagged_transitions;
     }
 
-    [[nodiscard]] auto get_optional_negative_tagged_transition(
+    [[nodiscard]] auto get_negative_tagged_transition(
     ) const -> std::optional<NegativeTaggedTransition<RegexNFAState>> const& {
-        return m_optional_negative_tagged_transition;
+        return m_negative_tagged_transition;
     }
 
     auto add_epsilon_transition(RegexNFAState* epsilon_transition) -> void {
@@ -161,7 +159,7 @@ private:
     bool m_accepting{false};
     uint32_t m_matching_variable_id{0};
     std::vector<PositiveTaggedTransition<RegexNFAState>> m_positive_tagged_transitions;
-    std::optional<NegativeTaggedTransition<RegexNFAState>> m_optional_negative_tagged_transition;
+    std::optional<NegativeTaggedTransition<RegexNFAState>> m_negative_tagged_transition;
     std::vector<RegexNFAState*> m_epsilon_transitions;
     std::array<std::vector<RegexNFAState*>, cSizeOfByte> m_bytes_transitions;
     // NOTE: We don't need m_tree_transitions for the `stateType ==
@@ -331,9 +329,9 @@ auto RegexNFAState<state_type>::serialize(
     }
 
     std::string negative_tagged_transition_string;
-    if (m_optional_negative_tagged_transition.has_value()) {
+    if (m_negative_tagged_transition.has_value()) {
         auto const optional_serialized_negative_transition
-                = m_optional_negative_tagged_transition.value().serialize(state_ids);
+                = m_negative_tagged_transition.value().serialize(state_ids);
         if (false == optional_serialized_negative_transition.has_value()) {
             return std::nullopt;
         }
@@ -422,7 +420,7 @@ auto RegexNFA<NFAStateType>::get_bfs_traversal_order() const -> std::vector<NFAS
             add_to_queue_and_visited(positive_tagged_transition.get_dest_state());
         }
         auto const& optional_negative_tagged_transition
-                = current_state->get_optional_negative_tagged_transition();
+                = current_state->get_negative_tagged_transition();
         if (optional_negative_tagged_transition.has_value()) {
             add_to_queue_and_visited(optional_negative_tagged_transition.value().get_dest_state());
         }

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -329,14 +329,14 @@ auto RegexNFAState<state_type>::serialize(
         positive_tagged_transitions.emplace_back(optional_serialized_positive_transition.value());
     }
 
-    std::string negative_tagged_transition;
+    std::string negative_tagged_transition_string;
     if (nullptr != m_negative_tagged_transition.get_dest_state()) {
         auto const optional_serialized_negative_transition
                 = m_negative_tagged_transition.serialize(state_ids);
         if (false == optional_serialized_negative_transition.has_value()) {
             return std::nullopt;
         }
-        negative_tagged_transition = optional_serialized_negative_transition.value();
+        negative_tagged_transition_string = optional_serialized_negative_transition.value();
     }
 
     auto const accepting_tag_string
@@ -350,7 +350,7 @@ auto RegexNFAState<state_type>::serialize(
             fmt::join(byte_transitions, ","),
             fmt::join(epsilon_transitions, ","),
             fmt::join(positive_tagged_transitions, ","),
-            negative_tagged_transition
+            negative_tagged_transition_string
     );
 }
 

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -328,7 +328,8 @@ auto RegexNFAState<state_type>::serialize(
 
     std::vector<std::string> positive_tagged_transitions;
     for (auto const& positive_tagged_transition : m_positive_tagged_transitions) {
-        auto const serialized_positive_transition_it = positive_tagged_transition.serialize(state_ids);
+        auto const serialized_positive_transition_it
+                = positive_tagged_transition.serialize(state_ids);
         if (serialized_positive_transition_it.has_value()) {
             positive_tagged_transitions.emplace_back(serialized_positive_transition_it.value());
         } else {
@@ -338,7 +339,8 @@ auto RegexNFAState<state_type>::serialize(
 
     std::vector<std::string> negative_tagged_transitions;
     for (auto const& negative_tagged_transition : m_negative_tagged_transitions) {
-        auto const serialized_negative_transition_it = negative_tagged_transition.serialize(state_ids);
+        auto const serialized_negative_transition_it
+                = negative_tagged_transition.serialize(state_ids);
         if (serialized_negative_transition_it.has_value()) {
             negative_tagged_transitions.emplace_back(serialized_negative_transition_it.value());
         } else {
@@ -399,6 +401,8 @@ auto RegexNFA<NFAStateType>::get_bfs_traversal_order(
     std::queue<RegexNFAByteState const*> state_queue;
     std::unordered_set<RegexNFAByteState const*> visited_states;
     std::vector<RegexNFAByteState const*> visited_order;
+    visited_states.reserve(m_states.size());
+    visited_order.reserve(m_states.size());
 
     auto add_to_queue_and_visited
             = [&state_queue, &visited_states](RegexNFAByteState const* dest_state) {

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -257,7 +257,7 @@ template <RegexNFAStateType state_type>
 auto NegativeTaggedTransition<state_type>::serialize(
         std::unordered_map<RegexNFAByteState const*, uint32_t> const& state_ids
 ) const -> std::string {
-    return fmt::format("{}[{}]", state_ids.at(get_dest_state()), fmt::join(get_tags(), ","));
+    return fmt::format("{}[{}]", state_ids.at(m_dest_state), fmt::join(m_tags, ","));
 }
 
 template <RegexNFAStateType state_type>

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -197,7 +197,7 @@ public:
     ) -> NFAStateType*;
 
     /**
-     * Creates a unique_ptr for an NFA state with negative tagged transitions and adds it to
+     * Creates a unique_ptr for an NFA state with negative tagged transition and adds it to
      * `m_states`.
      * @param tags
      * @param dest_state

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -327,22 +327,20 @@ auto RegexNFAState<state_type>::serialize(
     for (auto const& positive_tagged_transition : m_positive_tagged_transitions) {
         auto const serialized_positive_transition_it
                 = positive_tagged_transition.serialize(state_ids);
-        if (serialized_positive_transition_it.has_value()) {
-            positive_tagged_transitions.emplace_back(serialized_positive_transition_it.value());
-        } else {
+        if (false == serialized_positive_transition_it.has_value()) {
             return std::nullopt;
         }
+        positive_tagged_transitions.emplace_back(serialized_positive_transition_it.value());
     }
 
     std::vector<std::string> negative_tagged_transitions;
     for (auto const& negative_tagged_transition : m_negative_tagged_transitions) {
         auto const serialized_negative_transition_it
                 = negative_tagged_transition.serialize(state_ids);
-        if (serialized_negative_transition_it.has_value()) {
-            negative_tagged_transitions.emplace_back(serialized_negative_transition_it.value());
-        } else {
+        if (false == serialized_negative_transition_it.has_value()) {
             return std::nullopt;
         }
+        negative_tagged_transitions.emplace_back(serialized_negative_transition_it.value());
     }
 
     auto const accepting_tag_string

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -443,7 +443,7 @@ auto RegexNFA<NFAStateType>::get_bfs_traversal_order(
 
 template <typename NFAStateType>
 auto RegexNFA<NFAStateType>::serialize() const -> std::string {
-    auto traversal_order = get_bfs_traversal_order();
+    auto const traversal_order = get_bfs_traversal_order();
 
     std::unordered_map<RegexNFAByteState const*, uint32_t> state_ids;
     for (auto const* state : traversal_order) {

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -314,7 +314,7 @@ auto RegexNFAState<state_type>::serialize(
     std::vector<std::string> byte_transitions;
     for (uint32_t idx{0}; idx < cSizeOfByte; ++idx) {
         for (auto const* dest_state : m_bytes_transitions[idx]) {
-            byte_transitions.push_back(
+            byte_transitions.emplace_back(
                     fmt::format("{}-->{}", static_cast<char>(idx), state_ids.at(dest_state))
             );
         }

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -322,7 +322,7 @@ auto RegexNFAState<state_type>::serialize(
 
     std::vector<std::string> epsilon_transitions;
     for (auto const* dest_state : m_epsilon_transitions) {
-        epsilon_transitions.push_back(std::to_string(state_ids.at(dest_state)));
+        epsilon_transitions.emplace_back(std::to_string(state_ids.at(dest_state)));
     }
     std::vector<std::string> positive_tagged_transitions;
     for (auto const& positive_tagged_transition : m_positive_tagged_transitions) {

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -80,7 +80,7 @@ public:
 
 private:
     std::set<uint32_t> m_tags;
-    NFAStateType const* m_dest_state;
+    NFAStateType const* m_dest_state{nullptr};
 };
 
 template <RegexNFAStateType state_type>

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -75,9 +75,8 @@ public:
 
     /**
      * @param state_ids A map of states to their unique identifiers.
-     * @return A string representation of the negative tagged transitions if `m_dest_state` is in
-     *         `state_ids`;
-     *         nullopt otherwise.
+     * @return A string representation of the negative tagged transitions on success.
+     * @return std::nullopt if `m_dest_state` is not in `state_ids`.
      */
     [[nodiscard]] auto serialize(
             std::unordered_map<RegexNFAByteState const*, uint32_t> const& state_ids

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -56,8 +56,8 @@ public:
     ) const -> std::optional<std::string>;
 
 private:
-    uint32_t m_tag{};
-    RegexNFAState<state_type> const* m_dest_state{};
+    uint32_t m_tag;
+    RegexNFAState<state_type> const* m_dest_state;
 };
 
 template <RegexNFAStateType state_type>
@@ -84,7 +84,7 @@ public:
 
 private:
     std::set<uint32_t> m_tags;
-    RegexNFAState<state_type> const* m_dest_state{};
+    RegexNFAState<state_type> const* m_dest_state;
 };
 
 template <RegexNFAStateType state_type>

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -177,7 +177,7 @@ class RegexNFA {
 public:
     using StateVec = std::vector<NFAStateType*>;
 
-    explicit RegexNFA(std::vector<LexicalRule<NFAStateType>> const& m_rules);
+    explicit RegexNFA(std::vector<LexicalRule<NFAStateType>> rules);
 
     /**
      * Creates a unique_ptr for an NFA state with no tagged transitions and adds it to `m_states`.
@@ -351,9 +351,9 @@ auto RegexNFAState<state_type>::serialize(
 }
 
 template <typename NFAStateType>
-RegexNFA<NFAStateType>::RegexNFA(std::vector<LexicalRule<NFAStateType>> const& m_rules)
+RegexNFA<NFAStateType>::RegexNFA(std::vector<LexicalRule<NFAStateType>> rules)
         : m_root{new_state()} {
-    for (auto const& rule : m_rules) {
+    for (auto const& rule : rules) {
         rule.add_to_nfa(this);
     }
 }

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -48,9 +48,8 @@ public:
 
     /**
      * @param state_ids A map of states to their unique identifiers.
-     * @return A string representation of the positive tagged transitions if `m_dest_state` is in
-     *         `state_ids`;
-     *         nullopt otherwise.
+     * @return A string representation of the positive tagged transitions on success.
+     * @return std::nullopt if `m_dest_state` is not in `state_ids`.
      */
     [[nodiscard]] auto serialize(
             std::unordered_map<RegexNFAByteState const*, uint32_t> const& state_ids

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -46,7 +46,7 @@ public:
 
     /**
      * @param state_ids A map of states to their unique identifiers.
-     * @return A string representation of the positive tagged transitions on success.
+     * @return A string representation of the positive tagged transition on success.
      * @return std::nullopt if `m_dest_state` is not in `state_ids`.
      */
     [[nodiscard]] auto serialize(std::unordered_map<NFAStateType const*, uint32_t> const& state_ids
@@ -72,7 +72,7 @@ public:
 
     /**
      * @param state_ids A map of states to their unique identifiers.
-     * @return A string representation of the negative tagged transitions on success.
+     * @return A string representation of the negative tagged transition on success.
      * @return std::nullopt if `m_dest_state` is not in `state_ids`.
      */
     [[nodiscard]] auto serialize(std::unordered_map<NFAStateType const*, uint32_t> const& state_ids

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -149,7 +149,6 @@ public:
     auto add_interval(Interval interval, RegexNFAState* dest_state) -> void;
 
     /**
-     * Serialize the NFA state into a string.
      * @param state_ids A map of states to their unique identifiers.
      * @return A string representation of the NFA state.
      */

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -209,11 +209,11 @@ public:
     ) -> NFAStateType*;
 
     /**
-     * Traverse the NFA using a BFS and keep track of the order states are visited in.
-     * @return A vector representing the traversal order of the NFA states using breadth-first
-     * search.
+     * Traverse the NFA using a breadth-first search (BFS) and keep track of the order states are
+     * visited in.
+     * @return A vector representing the traversal order of the NFA states using BFS.
      */
-    [[nodiscard]] auto get_traversal_order() const -> std::vector<RegexNFAByteState const*>;
+    [[nodiscard]] auto get_bfs_traversal_order() const -> std::vector<RegexNFAByteState const*>;
 
     /**
      * @return A string representation of the NFA.
@@ -397,7 +397,8 @@ auto RegexNFA<NFAStateType>::add_to_queue_and_visited(
 }
 
 template <typename NFAStateType>
-auto RegexNFA<NFAStateType>::get_traversal_order() const -> std::vector<RegexNFAByteState const*> {
+auto RegexNFA<NFAStateType>::get_bfs_traversal_order(
+) const -> std::vector<RegexNFAByteState const*> {
     std::queue<RegexNFAByteState const*> state_queue;
     std::unordered_set<RegexNFAByteState const*> visited_states;
     std::vector<RegexNFAByteState const*> visited_order;
@@ -439,7 +440,7 @@ auto RegexNFA<NFAStateType>::get_traversal_order() const -> std::vector<RegexNFA
 
 template <typename NFAStateType>
 auto RegexNFA<NFAStateType>::serialize() const -> std::string {
-    auto traversal_order = get_traversal_order();
+    auto traversal_order = get_bfs_traversal_order();
 
     std::unordered_map<RegexNFAByteState const*, uint32_t> state_ids;
     for (auto const* state : traversal_order) {

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -329,6 +329,7 @@ auto RegexNFAState<state_type>::serialize(
     for (auto const& positive_tagged_transition : m_positive_tagged_transitions) {
         positive_tagged_transitions.emplace_back(positive_tagged_transition.serialize(state_ids));
     }
+
     std::vector<std::string> negative_tagged_transitions;
     for (auto const& negative_tagged_transition : m_negative_tagged_transitions) {
         negative_tagged_transitions.push_back(negative_tagged_transition.serialize(state_ids));

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -421,7 +421,7 @@ auto RegexNFA<NFAStateType>::get_bfs_traversal_order() const -> std::vector<NFAS
         {
             add_to_queue_and_visited(positive_tagged_transition.get_dest_state());
         }
-        auto const optional_negative_tagged_transition
+        auto const& optional_negative_tagged_transition
                 = current_state->get_optional_negative_tagged_transition();
         if (optional_negative_tagged_transition.has_value()) {
             add_to_queue_and_visited(optional_negative_tagged_transition.value().get_dest_state());

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -406,6 +406,7 @@ auto RegexNFA<NFAStateType>::get_bfs_traversal_order() const -> std::vector<NFAS
         auto const* current_state = state_queue.front();
         visited_order.push_back(current_state);
         state_queue.pop();
+        // TODO: handle the utf8 case
         for (uint32_t idx{0}; idx < cSizeOfByte; ++idx) {
             for (auto const* dest_state : current_state->get_byte_transitions(idx)) {
                 add_to_queue_and_visited(dest_state);

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -198,7 +198,7 @@ public:
     ) -> NFAStateType*;
 
     /**
-     * Creates a unique_ptr for an NFA state with negative tagged transition and adds it to
+     * Creates a unique_ptr for an NFA state with a negative tagged transition and adds it to
      * `m_states`.
      * @param tags
      * @param dest_state

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -324,6 +324,7 @@ auto RegexNFAState<state_type>::serialize(
     for (auto const* dest_state : m_epsilon_transitions) {
         epsilon_transitions.emplace_back(std::to_string(state_ids.at(dest_state)));
     }
+
     std::vector<std::string> positive_tagged_transitions;
     for (auto const& positive_tagged_transition : m_positive_tagged_transitions) {
         positive_tagged_transitions.push_back(positive_tagged_transition.serialize(state_ids));

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -8,7 +8,8 @@
 #include <memory>
 #include <optional>
 #include <queue>
-#include <stack>
+#include <set>
+#include <string>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -153,9 +153,9 @@ public:
 
     /**
      * @param state_ids A map of states to their unique identifiers.
-     * @return A string representation of the NFA state if `m_positive_tagged_transitions` and
-     *         `m_negative_tagged_transitions` can be serialized with `state_ids`;
-     *         nullopt otherwise.
+     * @return A string representation of the NFA state on success.
+     * @return Forwards `PositiveTaggedTransition::serialize`'s return values on failure.
+     * @return Forwards `NegativeTaggedTransition::serialize`'s return values on failure.
      */
     [[nodiscard]] auto serialize(
             std::unordered_map<RegexNFAByteState const*, uint32_t> const& state_ids

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -347,10 +347,8 @@ RegexNFA<NFAStateType>::RegexNFA(std::vector<LexicalRule<NFAStateType>> rules)
 
 template <typename NFAStateType>
 auto RegexNFA<NFAStateType>::new_state() -> NFAStateType* {
-    std::unique_ptr<NFAStateType> ptr = std::make_unique<NFAStateType>();
-    NFAStateType* state = ptr.get();
-    m_states.push_back(std::move(ptr));
-    return state;
+    m_states.emplace_back(std::make_unique<NFAStateType>());
+    return m_states.back().get();
 }
 
 template <typename NFAStateType>

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -218,7 +218,7 @@ public:
     [[nodiscard]] auto get_bfs_traversal_order() const -> std::vector<RegexNFAByteState const*>;
 
     /**
-     * @return A string representation of the NFA. This function should always succeeed.
+     * @return A string representation of the NFA.
      */
     [[nodiscard]] auto serialize() const -> std::string;
 

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -312,7 +312,7 @@ auto RegexNFAState<state_type>::serialize(
         std::unordered_map<RegexNFAByteState const*, uint32_t> const& state_ids
 ) const -> std::string {
     std::vector<std::string> byte_transitions;
-    for (uint32_t idx = 0; idx < cSizeOfByte; idx++) {
+    for (uint32_t idx{0}; idx < cSizeOfByte; ++idx) {
         for (auto const* dest_state : m_bytes_transitions[idx]) {
             byte_transitions.push_back(
                     fmt::format("{}-->{}", static_cast<char>(idx), state_ids.at(dest_state))

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -335,7 +335,7 @@ auto RegexNFAState<state_type>::serialize(
         negative_tagged_transitions.emplace_back(negative_tagged_transition.serialize(state_ids));
     }
 
-    auto accepting_tag_string
+    auto const accepting_tag_string
             = m_accepting ? fmt::format("accepting_tag={},", m_matching_variable_id) : "";
 
     return fmt::format(

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -240,7 +240,7 @@ template <RegexNFAStateType state_type>
 auto PositiveTaggedTransition<state_type>::serialize(
         std::unordered_map<RegexNFAByteState const*, uint32_t> const& state_ids
 ) const -> std::optional<std::string> {
-    auto state_id_it = state_ids.find(m_dest_state);
+    auto const state_id_it = state_ids.find(m_dest_state);
     if (state_id_it == state_ids.end()) {
         return std::nullopt;
     }

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -446,6 +446,7 @@ auto RegexNFA<NFAStateType>::serialize() const -> std::string {
     for (auto const* state : traversal_order) {
         // `state_ids` is well-formed as its generated from `get_bfs_traversal_order` so we can
         // safely assume `state->serialize(state_ids)` will return a valid value.
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
         serialized_states.emplace_back(state->serialize(state_ids).value());
     }
     return fmt::format("{}\n", fmt::join(serialized_states, "\n"));

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -250,7 +250,7 @@ template <RegexNFAStateType state_type>
 auto PositiveTaggedTransition<state_type>::serialize(
         std::unordered_map<RegexNFAByteState const*, uint32_t> const& state_ids
 ) const -> std::string {
-    return fmt::format("{}[{}]", state_ids.at(get_dest_state()), get_tag());
+    return fmt::format("{}[{}]", state_ids.at(m_dest_state), m_tag);
 }
 
 template <RegexNFAStateType state_type>

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -181,7 +181,7 @@ class RegexNFA {
 public:
     using StateVec = std::vector<NFAStateType*>;
 
-    explicit RegexNFA(std::vector<LexicalRule<NFAStateType>> rules);
+    explicit RegexNFA(std::vector<LexicalRule<NFAStateType>> const& rules);
 
     /**
      * Creates a unique_ptr for an NFA state with no tagged transitions and adds it to `m_states`.
@@ -359,7 +359,7 @@ auto RegexNFAState<state_type>::serialize(
 }
 
 template <typename NFAStateType>
-RegexNFA<NFAStateType>::RegexNFA(std::vector<LexicalRule<NFAStateType>> rules)
+RegexNFA<NFAStateType>::RegexNFA(std::vector<LexicalRule<NFAStateType>> const& rules)
         : m_root{new_state()} {
     for (auto const& rule : rules) {
         rule.add_to_nfa(this);

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -327,7 +327,7 @@ auto RegexNFAState<state_type>::serialize(
 
     std::vector<std::string> positive_tagged_transitions;
     for (auto const& positive_tagged_transition : m_positive_tagged_transitions) {
-        positive_tagged_transitions.push_back(positive_tagged_transition.serialize(state_ids));
+        positive_tagged_transitions.emplace_back(positive_tagged_transition.serialize(state_ids));
     }
     std::vector<std::string> negative_tagged_transitions;
     for (auto const& negative_tagged_transition : m_negative_tagged_transitions) {

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -213,8 +213,6 @@ public:
     ) -> NFAStateType*;
 
     /**
-     * Traverse the NFA using a breadth-first search (BFS) and keep track of the order states are
-     * visited in.
      * @return A vector representing the traversal order of the NFA states using BFS.
      */
     [[nodiscard]] auto get_bfs_traversal_order() const -> std::vector<RegexNFAByteState const*>;

--- a/src/log_surgeon/finite_automata/RegexNFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexNFA.hpp
@@ -213,7 +213,8 @@ public:
     ) -> NFAStateType*;
 
     /**
-     * @return A vector representing the traversal order of the NFA states using BFS.
+     * @return A vector representing the traversal order of the NFA states using breadth-first
+     * search (BFS).
      */
     [[nodiscard]] auto get_bfs_traversal_order() const -> std::vector<RegexNFAByteState const*>;
 

--- a/tests/test-NFA.cpp
+++ b/tests/test-NFA.cpp
@@ -16,7 +16,6 @@ using log_surgeon::cSizeOfByte;
 using log_surgeon::finite_automata::RegexNFAByteState;
 using log_surgeon::Schema;
 using log_surgeon::SchemaVarAST;
-using std::move;
 using std::string;
 using std::stringstream;
 using std::vector;
@@ -44,8 +43,8 @@ TEST_CASE("Test NFA", "[NFA]") {
     auto const schema_ast = schema.release_schema_ast_ptr();
     auto& capture_rule_ast = dynamic_cast<SchemaVarAST&>(*schema_ast->m_schema_vars[0]);
     vector<ByteLexicalRule> rules;
-    rules.emplace_back(0, move(capture_rule_ast.m_regex_ptr));
-    ByteNFA const nfa(move(rules));
+    rules.emplace_back(0, std::move(capture_rule_ast.m_regex_ptr));
+    ByteNFA const nfa(std::move(rules));
 
     // Compare against expected output
     string expected_serialized_nfa = "0:byte_transitions={A-->1,Z-->2},"

--- a/tests/test-NFA.cpp
+++ b/tests/test-NFA.cpp
@@ -30,10 +30,6 @@ using RegexASTMultiplicationByte
         = log_surgeon::finite_automata::RegexASTMultiplication<RegexNFAByteState>;
 using RegexASTOrByte = log_surgeon::finite_automata::RegexASTOr<RegexNFAByteState>;
 
-namespace {
-
-}  // namespace
-
 TEST_CASE("Test NFA", "[NFA]") {
     Schema schema;
     string const var_name{"capture"};

--- a/tests/test-NFA.cpp
+++ b/tests/test-NFA.cpp
@@ -50,57 +50,57 @@ TEST_CASE("Test NFA", "[NFA]") {
     string expected_serialized_nfa = "0:byte_transitions={A-->1,Z-->2},"
                                      "epsilon_transitions={},"
                                      "positive_tagged_transitions={},"
-                                     "negative_tagged_transitions={}\n";
+                                     "negative_tagged_transition={}\n";
     expected_serialized_nfa += "1:byte_transitions={a-->3,b-->3,c-->4,d-->4},"
                                "epsilon_transitions={},"
                                "positive_tagged_transitions={},"
-                               "negative_tagged_transitions={}\n";
+                               "negative_tagged_transition={}\n";
     expected_serialized_nfa += "2:byte_transitions={},"
                                "epsilon_transitions={},"
                                "positive_tagged_transitions={},"
-                               "negative_tagged_transitions={5[0,1,2,3]}\n";
+                               "negative_tagged_transition={5[0,1,2,3]}\n";
     expected_serialized_nfa += "3:byte_transitions={},"
                                "epsilon_transitions={},"
                                "positive_tagged_transitions={6[0]},"
-                               "negative_tagged_transitions={}\n";
+                               "negative_tagged_transition={}\n";
     expected_serialized_nfa += "4:byte_transitions={},"
                                "epsilon_transitions={},"
                                "positive_tagged_transitions={7[1]},"
-                               "negative_tagged_transitions={}\n";
+                               "negative_tagged_transition={}\n";
     expected_serialized_nfa += "5:accepting_tag=0,byte_transitions={},"
                                "epsilon_transitions={},"
                                "positive_tagged_transitions={},"
-                               "negative_tagged_transitions={}\n";
+                               "negative_tagged_transition={}\n";
     expected_serialized_nfa += "6:byte_transitions={},"
                                "epsilon_transitions={},"
                                "positive_tagged_transitions={},"
-                               "negative_tagged_transitions={8[1]}\n";
+                               "negative_tagged_transition={8[1]}\n";
     expected_serialized_nfa += "7:byte_transitions={},"
                                "epsilon_transitions={},"
                                "positive_tagged_transitions={},"
-                               "negative_tagged_transitions={8[0]}\n";
+                               "negative_tagged_transition={8[0]}\n";
     expected_serialized_nfa += "8:byte_transitions={},"
                                "epsilon_transitions={},"
                                "positive_tagged_transitions={9[2]},"
-                               "negative_tagged_transitions={}\n";
+                               "negative_tagged_transition={}\n";
     expected_serialized_nfa += "9:byte_transitions={B-->10},"
                                "epsilon_transitions={},"
                                "positive_tagged_transitions={},"
-                               "negative_tagged_transitions={}\n";
+                               "negative_tagged_transition={}\n";
     expected_serialized_nfa += "10:byte_transitions={0-->11,1-->11,2-->11,3-->11,4-->11,5-->11,6-->"
                                "11,7-->11,8-->11,9-->11},"
                                "epsilon_transitions={},"
                                "positive_tagged_transitions={},"
-                               "negative_tagged_transitions={}\n";
+                               "negative_tagged_transition={}\n";
     expected_serialized_nfa += "11:byte_transitions={0-->11,1-->11,2-->11,3-->11,4-->11,5-->11,6-->"
                                "11,7-->11,8-->11,9-->11},"
                                "epsilon_transitions={},"
                                "positive_tagged_transitions={12[3]},"
-                               "negative_tagged_transitions={}\n";
+                               "negative_tagged_transition={}\n";
     expected_serialized_nfa += "12:byte_transitions={C-->5},"
                                "epsilon_transitions={},"
                                "positive_tagged_transitions={},"
-                               "negative_tagged_transitions={}\n";
+                               "negative_tagged_transition={}\n";
 
     // Compare expected and actual line-by-line
     auto const actual_serialized_nfa = nfa.serialize();

--- a/tests/test-NFA.cpp
+++ b/tests/test-NFA.cpp
@@ -18,7 +18,6 @@ using log_surgeon::Schema;
 using log_surgeon::SchemaVarAST;
 using std::string;
 using std::stringstream;
-using std::to_string;
 using std::vector;
 
 using ByteLexicalRule = log_surgeon::LexicalRule<RegexNFAByteState>;

--- a/tests/test-NFA.cpp
+++ b/tests/test-NFA.cpp
@@ -49,7 +49,7 @@ TEST_CASE("Test NFA", "[NFA]") {
     auto& capture_rule_ast = dynamic_cast<SchemaVarAST&>(*schema_ast->m_schema_vars[0]);
     vector<ByteLexicalRule> rules;
     rules.emplace_back(0, move(capture_rule_ast.m_regex_ptr));
-    ByteNFA nfa(rules);
+    ByteNFA const nfa(rules);
 
     // Compare against expected output
     string expected_serialized_nfa = "0:byte_transitions={A-->1,Z-->2},"

--- a/tests/test-NFA.cpp
+++ b/tests/test-NFA.cpp
@@ -45,7 +45,7 @@ TEST_CASE("Test NFA", "[NFA]") {
     auto& capture_rule_ast = dynamic_cast<SchemaVarAST&>(*schema_ast->m_schema_vars[0]);
     vector<ByteLexicalRule> rules;
     rules.emplace_back(0, move(capture_rule_ast.m_regex_ptr));
-    ByteNFA const nfa(rules);
+    ByteNFA const nfa(move(rules));
 
     // Compare against expected output
     string expected_serialized_nfa = "0:byte_transitions={A-->1,Z-->2},"

--- a/tests/test-NFA.cpp
+++ b/tests/test-NFA.cpp
@@ -108,9 +108,9 @@ TEST_CASE("Test NFA", "[NFA]") {
                                "negative_tagged_transitions={}\n";
 
     // Compare expected and actual line-by-line
-    auto actual_serialized_nfa = nfa.serialize();
-    stringstream ss_actual(actual_serialized_nfa);
-    stringstream ss_expected(expected_serialized_nfa);
+    auto const actual_serialized_nfa = nfa.serialize();
+    stringstream ss_actual{actual_serialized_nfa};
+    stringstream ss_expected{expected_serialized_nfa};
     string actual_line;
     string expected_line;
 

--- a/tests/test-NFA.cpp
+++ b/tests/test-NFA.cpp
@@ -44,7 +44,7 @@ TEST_CASE("Test NFA", "[NFA]") {
     auto& capture_rule_ast = dynamic_cast<SchemaVarAST&>(*schema_ast->m_schema_vars[0]);
     vector<ByteLexicalRule> rules;
     rules.emplace_back(0, std::move(capture_rule_ast.m_regex_ptr));
-    ByteNFA const nfa(std::move(rules));
+    ByteNFA const nfa{std::move(rules)};
 
     // Compare against expected output
     string expected_serialized_nfa = "0:byte_transitions={A-->1,Z-->2},"

--- a/tests/test-NFA.cpp
+++ b/tests/test-NFA.cpp
@@ -16,6 +16,7 @@ using log_surgeon::cSizeOfByte;
 using log_surgeon::finite_automata::RegexNFAByteState;
 using log_surgeon::Schema;
 using log_surgeon::SchemaVarAST;
+using std::move;
 using std::string;
 using std::stringstream;
 using std::vector;


### PR DESCRIPTION
# Description
- Previously NFA states were designed to have a vector of out-going negative transitions.
- After farther consideration, it is only possible for an NFA state to have a singular out-going negative transition. This is due to the fact that when a path is taken in the NFA, all alternate paths are not taken, and therefore a single negative transition can contain all negative tags needed to represent all untaken alternate paths.

# Validation performed
- Existing unit-tests still work. 
- Existing example still work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a default constructor for the `NegativeTaggedTransition` class, allowing for more flexible instance creation.

- **Bug Fixes**
	- Updated test cases to reflect changes in the naming convention for negative tagged transitions, ensuring consistency in expected serialized output.

- **Documentation**
	- Enhanced comments in the code for better understanding of transition handling and logic.

- **Refactor**
	- Improved variable naming for clarity in the `RegexAST` and `RegexNFA` classes, streamlining the handling of negative tagged transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->