### PR TITLE
Update Catch2 install script to use C++17. 

### DIFF
--- a/tools/deps-install/ubuntu/install-catch2.sh
+++ b/tools/deps-install/ubuntu/install-catch2.sh
@@ -69,7 +69,7 @@ fi
 
 # Build
 cd "$extracted_dir"
-cmake -B build -S . -DBUILD_TESTING=OFF
+cmake -B build -S . -DBUILD_TESTING=OFF -DCMAKE_CXX_STANDARD=17
 cmake --build build --parallel "$num_cpus"
 
 # Check if checkinstall is installed


### PR DESCRIPTION
# Description
- When using c++17 functionality with Catch2 it was previously failing to link in Ubuntu 20.04 and lower. E.g., test cases using `string_view` comparisons fail to link.
- Modify install-catch2.sh to use c++17 when building Catch2.

# Validation performed
- Unit-tests now correctly link and run on Ubuntu 20.04.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the installation script to specify C++17 as the standard version during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->