### PR TITLE
ci: Add GH workflow to validate PR titles follow Conventional Commits.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,7 @@
 Set the PR title to a meaningful commit message that:
 - follows the Conventional Commits specification (https://www.conventionalcommits.org).
 - is in imperative form.
+
 Example:
 fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
 -->

--- a/.github/workflows/pr-title-checks.yaml
+++ b/.github/workflows/pr-title-checks.yaml
@@ -5,6 +5,8 @@ on:
     types: ["edited", "opened", "reopened"]
     branches: ["main"]
 
+permissions: {}
+
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
 

--- a/src/log_surgeon/finite_automata/RegexDFA.hpp
+++ b/src/log_surgeon/finite_automata/RegexDFA.hpp
@@ -55,11 +55,15 @@ private:
 };
 
 /**
- * This class represents a pair of regex states. The intended use is for the two states in the pair
- * to belong to unique DFAs. A pair is considered accepting if both states are accepting in
- * their respective DFA. A different pair is considered reachable if both its states are reachable
- * in their respective DFAs from this pair's states. The first state in the pair contains the
- * variable types the pair matches.
+ * Class for a pair of DFA states, where each state in the pair belongs to a different DFA.
+ * This class is used to facilitate the construction of an intersection DFA from two separate DFAs.
+ * Each instance represents a state in the intersection DFA and follows these rules:
+ *
+ * - A pair is considered accepting if both states are accepting in their respective DFAs.
+ * - A pair is considered reachable if both its states are reachable in their respective DFAs
+ *   from this pair's states.
+ *
+ * NOTE: Only the first state in the pair contains the variable types matched by the pair.
  */
 template <typename DFAState>
 class RegexDFAStatePair {


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
[Convention Commits](https://www.conventionalcommits.org) is a specification for writing commit messages (or in our case, PR titles) that makes it easy to see at a glance what change the commit makes which in turn makes it easier to generate release notes.

This PR adds a workflow to check PR titles match the spec.

# Validation performed
<!-- What tests and validation you performed on the change -->
- Merge this PR into my fork and test:
  - PR title check passed: https://github.com/LinZhihao-723/log-surgeon/actions/runs/11922734783
  - PR title check failed: https://github.com/LinZhihao-723/log-surgeon/actions/runs/11922710961



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new GitHub Actions workflow to enforce meaningful pull request titles based on Conventional Commits.
	- Updated the pull request template to guide users on writing effective commit messages.

- **Chores**
	- Enhanced pull request management with a new concurrency setting to improve workflow efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->