### PR TITLE
refactor: Unify all types of NFA transitions into `NfaSpontaneousTransition`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ set(SOURCE_FILES
     src/log_surgeon/finite_automata/PrefixTree.hpp
     src/log_surgeon/finite_automata/RegexAST.hpp
     src/log_surgeon/finite_automata/RegisterHandler.hpp
-    src/log_surgeon/finite_automata/SpontaneousTransition.hpp
+    src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
     src/log_surgeon/finite_automata/StateType.hpp
     src/log_surgeon/finite_automata/TagOperation.hpp
     src/log_surgeon/finite_automata/UnicodeIntervalTree.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,12 +73,12 @@ set(SOURCE_FILES
     src/log_surgeon/finite_automata/DfaState.hpp
     src/log_surgeon/finite_automata/DfaStatePair.hpp
     src/log_surgeon/finite_automata/Nfa.hpp
+    src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
     src/log_surgeon/finite_automata/NfaState.hpp
     src/log_surgeon/finite_automata/PrefixTree.cpp
     src/log_surgeon/finite_automata/PrefixTree.hpp
     src/log_surgeon/finite_automata/RegexAST.hpp
     src/log_surgeon/finite_automata/RegisterHandler.hpp
-    src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
     src/log_surgeon/finite_automata/StateType.hpp
     src/log_surgeon/finite_automata/TagOperation.hpp
     src/log_surgeon/finite_automata/UnicodeIntervalTree.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,8 +78,9 @@ set(SOURCE_FILES
     src/log_surgeon/finite_automata/PrefixTree.hpp
     src/log_surgeon/finite_automata/RegexAST.hpp
     src/log_surgeon/finite_automata/RegisterHandler.hpp
+    src/log_surgeon/finite_automata/SpontaneousTransition.hpp
     src/log_surgeon/finite_automata/StateType.hpp
-    src/log_surgeon/finite_automata/TaggedTransition.hpp
+    src/log_surgeon/finite_automata/TagOperation.hpp
     src/log_surgeon/finite_automata/UnicodeIntervalTree.hpp
     src/log_surgeon/finite_automata/UnicodeIntervalTree.tpp
     src/log_surgeon/Lalr1Parser.cpp

--- a/src/log_surgeon/Lexer.hpp
+++ b/src/log_surgeon/Lexer.hpp
@@ -13,6 +13,7 @@
 #include <log_surgeon/Constants.hpp>
 #include <log_surgeon/finite_automata/Dfa.hpp>
 #include <log_surgeon/finite_automata/DfaState.hpp>
+#include <log_surgeon/finite_automata/NfaState.hpp>
 #include <log_surgeon/finite_automata/RegexAST.hpp>
 #include <log_surgeon/LexicalRule.hpp>
 #include <log_surgeon/ParserInputBuffer.hpp>

--- a/src/log_surgeon/finite_automata/Dfa.hpp
+++ b/src/log_surgeon/finite_automata/Dfa.hpp
@@ -5,6 +5,7 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <stack>
 #include <vector>
 
 #include <log_surgeon/finite_automata/DfaStatePair.hpp>

--- a/src/log_surgeon/finite_automata/Nfa.hpp
+++ b/src/log_surgeon/finite_automata/Nfa.hpp
@@ -60,8 +60,8 @@ public:
      * @return A pair of pointers to the two newly created NFA states:
      * - A state arrived at from a spontaneous transition out of `m_root` that sets a tag to track
      * the capture's start position.
-     * - A state with a spotaneous transition to `dest_state` that sets a tag to track the capture's
-     * end position
+     * - A state with a spontaneous transition to `dest_state` that sets a tag to track the
+     * capture's end position
      */
     [[nodiscard]] auto new_start_and_end_states_from_positive_capture(
             Capture const* capture,

--- a/src/log_surgeon/finite_automata/Nfa.hpp
+++ b/src/log_surgeon/finite_automata/Nfa.hpp
@@ -72,7 +72,7 @@ public:
     [[nodiscard]] auto get_bfs_traversal_order() const -> std::vector<TypedNfaState const*>;
 
     /**
-     * @return A string representation of the NFA.
+     * @return A string representation of the NFA on success.
      * @return Forwards `NfaState::serialize`'s return value (std::nullopt) on failure.
      */
     [[nodiscard]] auto serialize() const -> std::optional<std::string>;

--- a/src/log_surgeon/finite_automata/Nfa.hpp
+++ b/src/log_surgeon/finite_automata/Nfa.hpp
@@ -48,7 +48,7 @@ public:
      * @param dest_state
      * @return TypedNfaState*
      */
-    [[nodiscard]] auto new_state_for_negative_captures(
+    [[nodiscard]] auto new_state_from_negative_captures(
             std::vector<Capture const*> const& captures,
             TypedNfaState const* dest_state
     ) -> TypedNfaState*;
@@ -136,7 +136,7 @@ auto Nfa<TypedNfaState>::new_state() -> TypedNfaState* {
 }
 
 template <typename TypedNfaState>
-auto Nfa<TypedNfaState>::new_state_for_negative_captures(
+auto Nfa<TypedNfaState>::new_state_from_negative_captures(
         std::vector<Capture const*> const& captures,
         TypedNfaState const* dest_state
 ) -> TypedNfaState* {

--- a/src/log_surgeon/finite_automata/Nfa.hpp
+++ b/src/log_surgeon/finite_automata/Nfa.hpp
@@ -36,18 +36,15 @@ public:
     explicit Nfa(std::vector<LexicalRule<TypedNfaState>> const& rules);
 
     /**
-     * Creates a unique_ptr for an NFA state with no tagged transitions and adds it to `m_states`.
-     * @return TypedNfaState*
+     * @return A pointer to the newly created NFA state with no spontaneous transitions.
      */
     [[nodiscard]] auto new_state() -> TypedNfaState*;
 
     /**
-     * Adds an NFA state to `m_states` and sets an out-going edge negating the tags associated with
-     * alternate paths.
-     *
-     * @param captures The captures of all alternate paths.
-     * @param dest_state The destination state.
-     * @return TypedNfaState*
+     * @param captures A vector containing the captures of all alternate paths.
+     * @param dest_state The destination state to arrive at after negating the captures.
+     * @return A pointer to the newly created NFA state with a spontaneous transition to
+     * `dest_state`negating all the tags associated with `captures`.
      */
     [[nodiscard]] auto new_state_from_negative_captures(
             std::vector<Capture const*> const& captures,
@@ -55,12 +52,13 @@ public:
     ) -> TypedNfaState*;
 
     /**
-     * Creates the start and end states for a capture group.
-     * @param capture The capture associated with the capture group.
-     * @param dest_state
-     * @return A pair of states:
-     * - A state from `m_root` with an outgoing transition that sets the start tag for the capture.
-     * - A state with an outgoing transition to `dest_state` that sets the end tag for the capture.
+     * @param capture The positive capture to be tracked.
+     * @param dest_state The destination state to arrive at after tracking the capture.
+     * @return A pair of pointers to the two newly created NFA states:
+     * - A state arrived at from a spontaneous transition out of `m_root` that sets a tag to track
+     * the capture's start position.
+     * - A state with a spotaneous transition to `dest_state` that sets a tag to track the capture's
+     * end position
      */
     [[nodiscard]] auto new_start_and_end_states_from_positive_capture(
             Capture const* capture,

--- a/src/log_surgeon/finite_automata/Nfa.hpp
+++ b/src/log_surgeon/finite_automata/Nfa.hpp
@@ -62,7 +62,7 @@ public:
      * - A state from `m_root` with an outgoing transition that sets the start tag for the capture.
      * - A state with an outgoing transition to `dest_state` that sets the end tag for the capture.
      */
-    [[nodiscard]] auto new_start_and_end_states_for_capture(
+    [[nodiscard]] auto new_start_and_end_states_from_positive_capture(
             Capture const* capture,
             TypedNfaState const* dest_state
     ) -> std::pair<TypedNfaState*, TypedNfaState*>;
@@ -155,7 +155,7 @@ auto Nfa<TypedNfaState>::new_state_from_negative_captures(
 }
 
 template <typename TypedNfaState>
-auto Nfa<TypedNfaState>::new_start_and_end_states_for_capture(
+auto Nfa<TypedNfaState>::new_start_and_end_states_from_positive_capture(
         Capture const* capture,
         TypedNfaState const* dest_state
 ) -> std::pair<TypedNfaState*, TypedNfaState*> {

--- a/src/log_surgeon/finite_automata/Nfa.hpp
+++ b/src/log_surgeon/finite_automata/Nfa.hpp
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <queue>
 #include <string>
 #include <unordered_map>
@@ -11,10 +12,12 @@
 #include <vector>
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <log_surgeon/Constants.hpp>
-#include <log_surgeon/finite_automata/NfaState.hpp>
+#include <log_surgeon/finite_automata/Capture.hpp>
 #include <log_surgeon/finite_automata/TagOperation.hpp>
+#include <log_surgeon/finite_automata/UnicodeIntervalTree.hpp>
 #include <log_surgeon/LexicalRule.hpp>
 #include <log_surgeon/types.hpp>
 #include <log_surgeon/UniqueIdGenerator.hpp>
@@ -140,7 +143,7 @@ auto Nfa<TypedNfaState>::new_state_from_negative_captures(
         TypedNfaState const* dest_state
 ) -> TypedNfaState* {
     std::vector<tag_id_t> tags;
-    for (auto const capture : captures) {
+    for (auto const* capture : captures) {
         auto const [start_tag, end_tag]{get_or_create_capture_tag_pair(capture)};
         tags.push_back(start_tag);
         tags.push_back(end_tag);

--- a/src/log_surgeon/finite_automata/Nfa.hpp
+++ b/src/log_surgeon/finite_automata/Nfa.hpp
@@ -76,7 +76,7 @@ public:
 
     /**
      * @return A string representation of the NFA on success.
-     * @return Forwards `NfaState::serialize`'s return value (std::nullopt) on failure.
+     * @return Forwards `NfaState::serialize`'s return value (`std::nullopt`) on failure.
      */
     [[nodiscard]] auto serialize() const -> std::optional<std::string>;
 

--- a/src/log_surgeon/finite_automata/Nfa.hpp
+++ b/src/log_surgeon/finite_automata/Nfa.hpp
@@ -42,10 +42,11 @@ public:
     [[nodiscard]] auto new_state() -> TypedNfaState*;
 
     /**
-     * Creates a unique_ptr for an NFA state with a negative tagged transition and adds it to
-     * `m_states`.
-     * @param captures
-     * @param dest_state
+     * Adds an NFA state to `m_states` and sets an out-going edge negating the tags associated with
+     * alternate paths.
+     *
+     * @param captures The captures of all alternate paths.
+     * @param dest_state The destination state.
      * @return TypedNfaState*
      */
     [[nodiscard]] auto new_state_from_negative_captures(

--- a/src/log_surgeon/finite_automata/Nfa.hpp
+++ b/src/log_surgeon/finite_automata/Nfa.hpp
@@ -161,7 +161,7 @@ auto Nfa<TypedNfaState>::new_start_and_end_states_from_positive_capture(
         TypedNfaState const* dest_state
 ) -> std::pair<TypedNfaState*, TypedNfaState*> {
     auto const [start_tag, end_tag]{get_or_create_capture_tag_pair(capture)};
-    auto* start_state = new_state();
+    auto* start_state{new_state()};
     m_root->add_spontaneous_transition(TagOperationType::Set, {start_tag}, start_state);
     m_states.emplace_back(
             std::make_unique<TypedNfaState>(TagOperationType::Set, std::vector{end_tag}, dest_state)

--- a/src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
+++ b/src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
@@ -56,7 +56,7 @@ auto NfaSpontaneousTransition<TypedNfaState>::serialize(
 
     return fmt::format(
             "{}[{}]",
-            state_ids.at(m_dest_state)->second,
+            state_ids.at(m_dest_state),
             fmt::join(transformed_operations, ",")
     );
 }

--- a/src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
+++ b/src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
@@ -1,5 +1,5 @@
-#ifndef LOG_SURGEON_FINITE_AUTOMATA_SPONTANEOUS_TRANSITION_HPP
-#define LOG_SURGEON_FINITE_AUTOMATA_SPONTANEOUS_TRANSITION_HPP
+#ifndef LOG_SURGEON_FINITE_AUTOMATA_NFASPONTANEOUSTRANSITION_HPP
+#define LOG_SURGEON_FINITE_AUTOMATA_NFASPONTANEOUSTRANSITION_HPP
 
 #include <cstdint>
 #include <optional>
@@ -21,11 +21,11 @@ namespace log_surgeon::finite_automata {
  * @tparam TypedNfaState Specifies the type of transition (bytes or UTF-8 characters).
  */
 template <typename TypedNfaState>
-class SpontaneousTransition {
+class NfaSpontaneousTransition {
 public:
-    explicit SpontaneousTransition(TypedNfaState const* dest_state) : m_dest_state{dest_state} {}
+    explicit NfaSpontaneousTransition(TypedNfaState const* dest_state) : m_dest_state{dest_state} {}
 
-    SpontaneousTransition(std::vector<TagOperation> tag_ops, TypedNfaState const* dest_state)
+    NfaSpontaneousTransition(std::vector<TagOperation> tag_ops, TypedNfaState const* dest_state)
             : m_tag_ops{std::move(tag_ops)},
               m_dest_state{dest_state} {}
 
@@ -47,7 +47,7 @@ private:
 };
 
 template <typename TypedNfaState>
-auto SpontaneousTransition<TypedNfaState>::serialize(
+auto NfaSpontaneousTransition<TypedNfaState>::serialize(
         std::unordered_map<TypedNfaState const*, uint32_t> const& state_ids
 ) const -> std::optional<std::string> {
     if (false == state_ids.contains(m_dest_state)) {
@@ -67,4 +67,4 @@ auto SpontaneousTransition<TypedNfaState>::serialize(
 }
 }  // namespace log_surgeon::finite_automata
 
-#endif  // LOG_SURGEON_FINITE_AUTOMATA_SPONTANEOUS_TRANSITION_HPP
+#endif  // LOG_SURGEON_FINITE_AUTOMATA_NFASPONTANEOUSTRANSITION_HPP

--- a/src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
+++ b/src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
@@ -56,7 +56,7 @@ auto NfaSpontaneousTransition<TypedNfaState>::serialize(
 
     return fmt::format(
             "{}[{}]",
-            state_ids.find(m_dest_state)->second,
+            state_ids.at(m_dest_state)->second,
             fmt::join(transformed_operations, ",")
     );
 }

--- a/src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
+++ b/src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
@@ -51,11 +51,8 @@ auto NfaSpontaneousTransition<TypedNfaState>::serialize(
     if (false == state_ids.contains(m_dest_state)) {
         return std::nullopt;
     }
-    auto transformed_operations{
-            m_tag_ops | std::ranges::views::transform([](TagOperation const& tag_op) {
-                return tag_op.serialize();
-            })
-    };
+    auto transformed_operations
+            = m_tag_ops | std::ranges::views::transform(&TagOperation::serialize);
 
     return fmt::format(
             "{}[{}]",

--- a/src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
+++ b/src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
@@ -23,8 +23,6 @@ namespace log_surgeon::finite_automata {
 template <typename TypedNfaState>
 class NfaSpontaneousTransition {
 public:
-    explicit NfaSpontaneousTransition(TypedNfaState const* dest_state) : m_dest_state{dest_state} {}
-
     NfaSpontaneousTransition(std::vector<TagOperation> tag_ops, TypedNfaState const* dest_state)
             : m_tag_ops{std::move(tag_ops)},
               m_dest_state{dest_state} {}

--- a/src/log_surgeon/finite_automata/NfaState.hpp
+++ b/src/log_surgeon/finite_automata/NfaState.hpp
@@ -41,20 +41,16 @@ public:
 
     NfaState(
             TagOperationType const op_type,
-            std::vector<tag_id_t> tag_ids,
+            std::vector<tag_id_t> const& tag_ids,
             NfaState const* dest_state
     ) {
-        add_spontaneous_transition(op_type, std::move(tag_ids), dest_state);
+        add_spontaneous_transition(op_type, tag_ids, dest_state);
     }
 
-    auto set_accepting(bool accepting) -> void { m_accepting = accepting; }
+    auto set_accepting(bool const accepting) -> void { m_accepting = accepting; }
 
     auto set_matching_variable_id(uint32_t const variable_id) -> void {
         m_matching_variable_id = variable_id;
-    }
-
-    auto add_spontaneous_transition(NfaState* dest_state) -> void {
-        m_spontaneous_transitions.emplace_back(dest_state);
     }
 
     auto add_spontaneous_transition(

--- a/src/log_surgeon/finite_automata/NfaState.hpp
+++ b/src/log_surgeon/finite_automata/NfaState.hpp
@@ -187,8 +187,9 @@ auto NfaState<state_type>::epsilon_closure() -> std::set<NfaState const*> {
 template <StateType state_type>
 auto NfaState<state_type>::serialize(std::unordered_map<NfaState const*, uint32_t> const& state_ids
 ) const -> std::optional<std::string> {
-    auto const accepting_tag_string
-            = m_accepting ? fmt::format("accepting_tag={},", m_matching_variable_id) : "";
+    auto const accepting_tag_string{
+            m_accepting ? fmt::format("accepting_tag={},", m_matching_variable_id) : ""
+    };
 
     std::vector<std::string> byte_transitions;
     for (uint32_t idx{0}; idx < cSizeOfByte; ++idx) {
@@ -201,7 +202,7 @@ auto NfaState<state_type>::serialize(std::unordered_map<NfaState const*, uint32_
 
     std::vector<std::string> serialized_spontaneous_transitions;
     for (auto const& spontaneous_transition : m_spontaneous_transitions) {
-        auto const optional_serialized_transition = spontaneous_transition.serialize(state_ids);
+        auto const optional_serialized_transition{spontaneous_transition.serialize(state_ids)};
         if (false == optional_serialized_transition.has_value()) {
             return std::nullopt;
         }

--- a/src/log_surgeon/finite_automata/NfaState.hpp
+++ b/src/log_surgeon/finite_automata/NfaState.hpp
@@ -1,21 +1,29 @@
 #ifndef LOG_SURGEON_FINITE_AUTOMATA_NFA_STATE
 #define LOG_SURGEON_FINITE_AUTOMATA_NFA_STATE
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <set>
 #include <stack>
 #include <string>
 #include <tuple>
+#include <type_traits>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
+#include <fmt/core.h>
 #include <fmt/format.h>
 
+#include <log_surgeon/Constants.hpp>
 #include <log_surgeon/finite_automata/SpontaneousTransition.hpp>
 #include <log_surgeon/finite_automata/StateType.hpp>
+#include <log_surgeon/finite_automata/TagOperation.hpp>
 #include <log_surgeon/finite_automata/UnicodeIntervalTree.hpp>
+#include <log_surgeon/types.hpp>
 
 namespace log_surgeon::finite_automata {
 template <StateType state_type>

--- a/src/log_surgeon/finite_automata/NfaState.hpp
+++ b/src/log_surgeon/finite_automata/NfaState.hpp
@@ -53,6 +53,10 @@ public:
         m_matching_variable_id = variable_id;
     }
 
+    auto add_spontaneous_transition(NfaState const* dest_state) -> void {
+        m_spontaneous_transitions.emplace_back(std::vector<TagOperation>{}, dest_state);
+    }
+
     auto add_spontaneous_transition(
             TagOperationType const op_type,
             std::vector<tag_id_t> const& tag_ids,

--- a/src/log_surgeon/finite_automata/NfaState.hpp
+++ b/src/log_surgeon/finite_automata/NfaState.hpp
@@ -19,7 +19,7 @@
 #include <fmt/format.h>
 
 #include <log_surgeon/Constants.hpp>
-#include <log_surgeon/finite_automata/SpontaneousTransition.hpp>
+#include <log_surgeon/finite_automata/NfaSpontaneousTransition.hpp>
 #include <log_surgeon/finite_automata/StateType.hpp>
 #include <log_surgeon/finite_automata/TagOperation.hpp>
 #include <log_surgeon/finite_automata/UnicodeIntervalTree.hpp>
@@ -86,7 +86,8 @@ public:
     /**
      * @param state_ids A map of states to their unique identifiers.
      * @return A string representation of the NFA state on success.
-     * @return Forwards `SpontaneousTransition::serialize`'s return value (std::nullopt) on failure.
+     * @return Forwards `NfaSpontaneousTransition::serialize`'s return value (std::nullopt) on
+     * failure.
      */
     [[nodiscard]] auto serialize(std::unordered_map<NfaState const*, uint32_t> const& state_ids
     ) const -> std::optional<std::string>;
@@ -98,7 +99,7 @@ public:
     }
 
     [[nodiscard]] auto get_spontaneous_transitions(
-    ) const -> std::vector<SpontaneousTransition<NfaState>> const& {
+    ) const -> std::vector<NfaSpontaneousTransition<NfaState>> const& {
         return m_spontaneous_transitions;
     }
 
@@ -111,7 +112,7 @@ public:
 private:
     bool m_accepting{false};
     uint32_t m_matching_variable_id{0};
-    std::vector<SpontaneousTransition<NfaState>> m_spontaneous_transitions;
+    std::vector<NfaSpontaneousTransition<NfaState>> m_spontaneous_transitions;
     std::array<std::vector<NfaState*>, cSizeOfByte> m_bytes_transitions;
     // NOTE: We don't need m_tree_transitions for the `stateType ==
     // StateType::Byte` case, so we use an empty class (`std::tuple<>`)

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -116,7 +116,7 @@ public:
         // root --(regex)--> state_with_spontaneous_transition --(negate tags)--> end_state
         if (false == m_negative_captures.empty()) {
             auto* state_with_spontaneous_transition{
-                    nfa->new_state_for_negative_captures(m_negative_captures, end_state)
+                    nfa->new_state_from_negative_captures(m_negative_captures, end_state)
             };
             add_to_nfa(nfa, state_with_spontaneous_transition);
         } else {

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -863,7 +863,7 @@ void RegexASTMultiplication<TypedNfaState>::add_to_nfa(
     if (m_min == 0) {
         nfa->get_root()->add_spontaneous_transition(TagOperationType::None, {}, end_state);
     } else {
-        for (uint32_t i = 1; i < m_min; i++) {
+        for (uint32_t i{1}; i < m_min; ++i) {
             TypedNfaState* intermediate_state = nfa->new_state();
             m_operand->add_to_nfa_with_negative_captures(nfa, intermediate_state);
             nfa->set_root(intermediate_state);
@@ -938,8 +938,9 @@ auto RegexASTCapture<TypedNfaState>::add_to_nfa(Nfa<TypedNfaState>* nfa, TypedNf
     //         +---------------------+
     //         |     `dest_state`    |
     //         +---------------------+
-    auto [capture_start_state, capture_end_state]
-            = nfa->new_start_and_end_states_from_positive_capture(m_capture.get(), dest_state);
+    auto [capture_start_state, capture_end_state]{
+            nfa->new_start_and_end_states_from_positive_capture(m_capture.get(), dest_state)
+    };
 
     auto* initial_root = nfa->get_root();
     nfa->set_root(capture_start_state);

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -113,12 +113,12 @@ public:
     auto add_to_nfa_with_negative_captures(Nfa<TypedNfaState>* nfa, TypedNfaState* end_state) const
             -> void {
         // Handle negative captures as:
-        // root --(regex)--> state_with_spontaenous_transition --(negate tags)--> end_state
+        // root --(regex)--> state_with_spontaneous_transition --(negate tags)--> end_state
         if (false == m_negative_captures.empty()) {
-            auto* state_with_spontaenous_transition{
+            auto* state_with_spontaneous_transition{
                     nfa->new_state_for_negative_captures(m_negative_captures, end_state)
             };
-            add_to_nfa(nfa, state_with_spontaenous_transition);
+            add_to_nfa(nfa, state_with_spontaneous_transition);
         } else {
             add_to_nfa(nfa, end_state);
         }

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -21,6 +21,7 @@
 
 #include <log_surgeon/Constants.hpp>
 #include <log_surgeon/finite_automata/Capture.hpp>
+#include <log_surgeon/finite_automata/TagOperation.hpp>
 #include <log_surgeon/finite_automata/UnicodeIntervalTree.hpp>
 
 namespace log_surgeon::finite_automata {
@@ -860,7 +861,7 @@ void RegexASTMultiplication<TypedNfaState>::add_to_nfa(
 ) const {
     TypedNfaState* saved_root = nfa->get_root();
     if (m_min == 0) {
-        nfa->get_root()->add_spontaneous_transition(end_state);
+        nfa->get_root()->add_spontaneous_transition(TagOperationType::None, {}, end_state);
     } else {
         for (uint32_t i = 1; i < m_min; i++) {
             TypedNfaState* intermediate_state = nfa->new_state();

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -861,7 +861,7 @@ void RegexASTMultiplication<TypedNfaState>::add_to_nfa(
 ) const {
     TypedNfaState* saved_root = nfa->get_root();
     if (m_min == 0) {
-        nfa->get_root()->add_spontaneous_transition(TagOperationType::None, {}, end_state);
+        nfa->get_root()->add_spontaneous_transition(end_state);
     } else {
         for (uint32_t i{1}; i < m_min; ++i) {
             TypedNfaState* intermediate_state = nfa->new_state();

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -938,7 +938,7 @@ auto RegexASTCapture<TypedNfaState>::add_to_nfa(Nfa<TypedNfaState>* nfa, TypedNf
     //         |     `dest_state`    |
     //         +---------------------+
     auto [capture_start_state, capture_end_state]
-            = nfa->new_start_and_end_states_for_capture(m_capture.get(), dest_state);
+            = nfa->new_start_and_end_states_from_positive_capture(m_capture.get(), dest_state);
 
     auto* initial_root = nfa->get_root();
     nfa->set_root(capture_start_state);

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -908,8 +908,8 @@ template <typename TypedNfaState>
 auto RegexASTCapture<TypedNfaState>::add_to_nfa(Nfa<TypedNfaState>* nfa, TypedNfaState* dest_state)
         const -> void {
     // TODO: move this into a documentation file in the future, and reference it here.
-    // The NFA constructed for a capture group follows the structure below, with tagged transitions
-    // explicitly labeled for clarity:
+    // The NFA constructed for a capture group follows the structure below, with spontaneous
+    // transitions explicitly labeled for clarity:
     //         +---------------------+
     //         |       `m_root`      |
     //         +---------------------+

--- a/src/log_surgeon/finite_automata/SpontaneousTransition.hpp
+++ b/src/log_surgeon/finite_automata/SpontaneousTransition.hpp
@@ -16,7 +16,8 @@
 
 namespace log_surgeon::finite_automata {
 /**
- * Represents an NFA transition indicating a tag and an operation to perform on the tag.
+ * Represents an NFA transition with a collection of tag operations to be performed during the
+ * transition.
  * @tparam TypedNfaState Specifies the type of transition (bytes or UTF-8 characters).
  */
 template <typename TypedNfaState>
@@ -28,7 +29,7 @@ public:
             : m_tag_ops{std::move(tag_ops)},
               m_dest_state{dest_state} {}
 
-    [[nodiscard]] auto get_tag_ops() const -> std::vector<TagOperation> { return m_tag_ops; }
+    [[nodiscard]] auto get_tag_ops() const -> std::vector<TagOperation> const& { return m_tag_ops; }
 
     [[nodiscard]] auto get_dest_state() const -> TypedNfaState const* { return m_dest_state; }
 

--- a/src/log_surgeon/finite_automata/SpontaneousTransition.hpp
+++ b/src/log_surgeon/finite_automata/SpontaneousTransition.hpp
@@ -1,0 +1,68 @@
+#ifndef LOG_SURGEON_FINITE_AUTOMATA_SPONTANEOUS_TRANSITION_HPP
+#define LOG_SURGEON_FINITE_AUTOMATA_SPONTANEOUS_TRANSITION_HPP
+
+#include <cstdint>
+#include <optional>
+#include <ranges>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include <log_surgeon/finite_automata/TagOperation.hpp>
+
+namespace log_surgeon::finite_automata {
+/**
+ * Represents an NFA transition indicating a tag and an operation to perform on the tag.
+ * @tparam TypedNfaState Specifies the type of transition (bytes or UTF-8 characters).
+ */
+template <typename TypedNfaState>
+class SpontaneousTransition {
+public:
+    explicit SpontaneousTransition(TypedNfaState const* dest_state) : m_dest_state{dest_state} {}
+
+    SpontaneousTransition(std::vector<TagOperation> tag_ops, TypedNfaState const* dest_state)
+            : m_tag_ops{std::move(tag_ops)},
+              m_dest_state{dest_state} {}
+
+    [[nodiscard]] auto get_tag_ops() const -> std::vector<TagOperation> { return m_tag_ops; }
+
+    [[nodiscard]] auto get_dest_state() const -> TypedNfaState const* { return m_dest_state; }
+
+    /**
+     * @param state_ids A map of states to their unique identifiers.
+     * @return A string representation of the spontaneous transition on success.
+     * @return std::nullopt if `m_dest_state` is not in `state_ids`.
+     */
+    [[nodiscard]] auto serialize(std::unordered_map<TypedNfaState const*, uint32_t> const& state_ids
+    ) const -> std::optional<std::string>;
+
+private:
+    std::vector<TagOperation> m_tag_ops;
+    TypedNfaState const* m_dest_state;
+};
+
+template <typename TypedNfaState>
+auto SpontaneousTransition<TypedNfaState>::serialize(
+        std::unordered_map<TypedNfaState const*, uint32_t> const& state_ids
+) const -> std::optional<std::string> {
+    if (false == state_ids.contains(m_dest_state)) {
+        return std::nullopt;
+    }
+    auto transformed_operations
+            = m_tag_ops | std::ranges::views::transform([](TagOperation const& tag_op) {
+                  return tag_op.serialize();
+              });
+
+    return fmt::format(
+            "{}[{}]",
+            state_ids.find(m_dest_state)->second,
+            fmt::join(transformed_operations, ",")
+    );
+}
+}  // namespace log_surgeon::finite_automata
+
+#endif  // LOG_SURGEON_FINITE_AUTOMATA_SPONTANEOUS_TRANSITION_HPP

--- a/src/log_surgeon/finite_automata/SpontaneousTransition.hpp
+++ b/src/log_surgeon/finite_automata/SpontaneousTransition.hpp
@@ -53,10 +53,11 @@ auto SpontaneousTransition<TypedNfaState>::serialize(
     if (false == state_ids.contains(m_dest_state)) {
         return std::nullopt;
     }
-    auto transformed_operations
-            = m_tag_ops | std::ranges::views::transform([](TagOperation const& tag_op) {
-                  return tag_op.serialize();
-              });
+    auto transformed_operations{
+            m_tag_ops | std::ranges::views::transform([](TagOperation const& tag_op) {
+                return tag_op.serialize();
+            })
+    };
 
     return fmt::format(
             "{}[{}]",

--- a/src/log_surgeon/finite_automata/SpontaneousTransition.hpp
+++ b/src/log_surgeon/finite_automata/SpontaneousTransition.hpp
@@ -5,7 +5,6 @@
 #include <optional>
 #include <ranges>
 #include <string>
-#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -18,6 +17,7 @@ namespace log_surgeon::finite_automata {
 /**
  * Represents an NFA transition with a collection of tag operations to be performed during the
  * transition.
+ *
  * @tparam TypedNfaState Specifies the type of transition (bytes or UTF-8 characters).
  */
 template <typename TypedNfaState>

--- a/src/log_surgeon/finite_automata/TagOperation.hpp
+++ b/src/log_surgeon/finite_automata/TagOperation.hpp
@@ -22,11 +22,11 @@ public:
             : m_tag_id{tag_id},
               m_type{type} {}
 
-    auto operator<(TagOperation const& rhs) const noexcept -> bool {
+    auto operator<(TagOperation const& rhs) const -> bool {
         return std::tie(m_tag_id, m_type) < std::tie(rhs.m_tag_id, rhs.m_type);
     }
 
-    auto operator==(TagOperation const& rhs) const noexcept -> bool {
+    auto operator==(TagOperation const& rhs) const -> bool {
         return std::tie(m_tag_id, m_type) == std::tie(rhs.m_tag_id, rhs.m_type);
     }
 

--- a/src/log_surgeon/finite_automata/TagOperation.hpp
+++ b/src/log_surgeon/finite_automata/TagOperation.hpp
@@ -12,7 +12,8 @@
 namespace log_surgeon::finite_automata {
 enum class TagOperationType : uint8_t {
     Set,
-    Negate
+    Negate,
+    None
 };
 
 class TagOperation {

--- a/src/log_surgeon/finite_automata/TagOperation.hpp
+++ b/src/log_surgeon/finite_automata/TagOperation.hpp
@@ -1,0 +1,56 @@
+#ifndef LOG_SURGEON_FINITE_AUTOMATA_TAGOPERATION_HPP
+#define LOG_SURGEON_FINITE_AUTOMATA_TAGOPERATION_HPP
+
+#include <cstdint>
+#include <string>
+#include <tuple>
+
+#include <fmt/core.h>
+
+namespace log_surgeon::finite_automata {
+using tag_id_t = uint32_t;
+
+enum class TagOperationType : uint8_t {
+    Set,
+    Negate
+};
+
+class TagOperation {
+public:
+    TagOperation(tag_id_t const tag_id, TagOperationType const type)
+            : m_tag_id{tag_id},
+              m_type{type} {}
+
+    auto operator<(TagOperation const& rhs) const -> bool {
+        return std::tie(m_tag_id, m_type) < std::tie(rhs.m_tag_id, rhs.m_type);
+    }
+
+    auto operator==(TagOperation const& rhs) const -> bool {
+        return std::tie(m_tag_id, m_type) == std::tie(rhs.m_tag_id, rhs.m_type);
+    }
+
+    [[nodiscard]] auto get_tag_id() const -> tag_id_t { return m_tag_id; }
+
+    [[nodiscard]] auto get_type() const -> TagOperationType { return m_type; }
+
+    /**
+     * @return A string representation of the tag operation.
+     */
+    [[nodiscard]] auto serialize() const -> std::string {
+        switch (m_type) {
+            case TagOperationType::Set:
+                return fmt::format("{}{}", m_tag_id, "p");
+            case TagOperationType::Negate:
+                return fmt::format("{}{}", m_tag_id, "n");
+            default:
+                return fmt::format("{}{}", m_tag_id, "?");
+        }
+    }
+
+private:
+    tag_id_t m_tag_id;
+    TagOperationType m_type;
+};
+}  // namespace log_surgeon::finite_automata
+
+#endif  // LOG_SURGEON_FINITE_AUTOMATA_TAGOPERATION_HPP

--- a/src/log_surgeon/finite_automata/TagOperation.hpp
+++ b/src/log_surgeon/finite_automata/TagOperation.hpp
@@ -22,11 +22,11 @@ public:
             : m_tag_id{tag_id},
               m_type{type} {}
 
-    auto operator<(TagOperation const& rhs) const -> bool {
+    [[nodiscard]] auto operator<(TagOperation const& rhs) const -> bool {
         return std::tie(m_tag_id, m_type) < std::tie(rhs.m_tag_id, rhs.m_type);
     }
 
-    auto operator==(TagOperation const& rhs) const -> bool {
+    [[nodiscard]] auto operator==(TagOperation const& rhs) const -> bool {
         return std::tie(m_tag_id, m_type) == std::tie(rhs.m_tag_id, rhs.m_type);
     }
 

--- a/src/log_surgeon/finite_automata/TagOperation.hpp
+++ b/src/log_surgeon/finite_automata/TagOperation.hpp
@@ -12,8 +12,7 @@
 namespace log_surgeon::finite_automata {
 enum class TagOperationType : uint8_t {
     Set,
-    Negate,
-    None
+    Negate
 };
 
 class TagOperation {
@@ -43,8 +42,8 @@ public:
                 return fmt::format("{}{}", m_tag_id, "p");
             case TagOperationType::Negate:
                 return fmt::format("{}{}", m_tag_id, "n");
-            case TagOperationType::None:
-                return "none";
+            default:
+                return fmt::format("{}{}", m_tag_id, "?");
         }
     }
 

--- a/src/log_surgeon/finite_automata/TagOperation.hpp
+++ b/src/log_surgeon/finite_automata/TagOperation.hpp
@@ -22,11 +22,11 @@ public:
             : m_tag_id{tag_id},
               m_type{type} {}
 
-    auto operator<(TagOperation const& rhs) const -> bool {
+    auto operator<(TagOperation const& rhs) const noexcept -> bool {
         return std::tie(m_tag_id, m_type) < std::tie(rhs.m_tag_id, rhs.m_type);
     }
 
-    auto operator==(TagOperation const& rhs) const -> bool {
+    auto operator==(TagOperation const& rhs) const noexcept -> bool {
         return std::tie(m_tag_id, m_type) == std::tie(rhs.m_tag_id, rhs.m_type);
     }
 
@@ -43,8 +43,8 @@ public:
                 return fmt::format("{}{}", m_tag_id, "p");
             case TagOperationType::Negate:
                 return fmt::format("{}{}", m_tag_id, "n");
-            default:
-                return fmt::format("{}{}", m_tag_id, "?");
+            case TagOperationType::None:
+                return "none";
         }
     }
 

--- a/src/log_surgeon/finite_automata/TagOperation.hpp
+++ b/src/log_surgeon/finite_automata/TagOperation.hpp
@@ -7,9 +7,9 @@
 
 #include <fmt/core.h>
 
-namespace log_surgeon::finite_automata {
-using tag_id_t = uint32_t;
+#include <log_surgeon/types.hpp>
 
+namespace log_surgeon::finite_automata {
 enum class TagOperationType : uint8_t {
     Set,
     Negate

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,12 +4,12 @@ set(
         ../src/log_surgeon/FileReader.hpp
         ../src/log_surgeon/finite_automata/Capture.hpp
         ../src/log_surgeon/finite_automata/Nfa.hpp
+        ../src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
         ../src/log_surgeon/finite_automata/NfaState.hpp
         ../src/log_surgeon/finite_automata/PrefixTree.cpp
         ../src/log_surgeon/finite_automata/PrefixTree.hpp
         ../src/log_surgeon/finite_automata/RegexAST.hpp
         ../src/log_surgeon/finite_automata/RegisterHandler.hpp
-        ../src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
         ../src/log_surgeon/finite_automata/StateType.hpp
         ../src/log_surgeon/finite_automata/TagOperation.hpp
         ../src/log_surgeon/Lalr1Parser.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,8 +9,9 @@ set(
         ../src/log_surgeon/finite_automata/PrefixTree.hpp
         ../src/log_surgeon/finite_automata/RegexAST.hpp
         ../src/log_surgeon/finite_automata/RegisterHandler.hpp
+        ../src/log_surgeon/finite_automata/SpontaneousTransition.hpp
         ../src/log_surgeon/finite_automata/StateType.hpp
-        ../src/log_surgeon/finite_automata/TaggedTransition.hpp
+        ../src/log_surgeon/finite_automata/TagOperation.hpp
         ../src/log_surgeon/Lalr1Parser.cpp
         ../src/log_surgeon/Lalr1Parser.hpp
         ../src/log_surgeon/Lalr1Parser.tpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ set(
         ../src/log_surgeon/finite_automata/PrefixTree.hpp
         ../src/log_surgeon/finite_automata/RegexAST.hpp
         ../src/log_surgeon/finite_automata/RegisterHandler.hpp
-        ../src/log_surgeon/finite_automata/SpontaneousTransition.hpp
+        ../src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
         ../src/log_surgeon/finite_automata/StateType.hpp
         ../src/log_surgeon/finite_automata/TagOperation.hpp
         ../src/log_surgeon/Lalr1Parser.cpp

--- a/tests/test-nfa.cpp
+++ b/tests/test-nfa.cpp
@@ -39,7 +39,7 @@ TEST_CASE("Test NFA", "[NFA]") {
 
     // Compare against expected output
     // capture order(tags in brackets): letter1(0,1), letter2(2,3), letter(4,5), containerID(6,7)
-    string expected_serialized_nfa{
+    string const expected_serialized_nfa{
             "0:byte_transitions={A-->1,Z-->2},spontaneous_transition={}\n"
             "1:byte_transitions={},spontaneous_transition={3[4p]}\n"
             "2:byte_transitions={},spontaneous_transition={4[0n,1n,2n,3n,4n,5n,6n,7n]}\n"

--- a/tests/test-nfa.cpp
+++ b/tests/test-nfa.cpp
@@ -1,4 +1,3 @@
-#include <cstdint>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -6,13 +5,12 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include <log_surgeon/Constants.hpp>
 #include <log_surgeon/finite_automata/Nfa.hpp>
-#include <log_surgeon/finite_automata/RegexAST.hpp>
+#include <log_surgeon/finite_automata/NfaState.hpp>
+#include <log_surgeon/LexicalRule.hpp>
 #include <log_surgeon/Schema.hpp>
 #include <log_surgeon/SchemaParser.hpp>
 
-using log_surgeon::cSizeOfByte;
 using log_surgeon::finite_automata::ByteNfaState;
 using log_surgeon::Schema;
 using log_surgeon::SchemaVarAST;
@@ -22,13 +20,6 @@ using std::vector;
 
 using ByteLexicalRule = log_surgeon::LexicalRule<ByteNfaState>;
 using ByteNfa = log_surgeon::finite_automata::Nfa<ByteNfaState>;
-using RegexASTCatByte = log_surgeon::finite_automata::RegexASTCat<ByteNfaState>;
-using RegexASTCaptureByte = log_surgeon::finite_automata::RegexASTCapture<ByteNfaState>;
-using RegexASTGroupByte = log_surgeon::finite_automata::RegexASTGroup<ByteNfaState>;
-using RegexASTLiteralByte = log_surgeon::finite_automata::RegexASTLiteral<ByteNfaState>;
-using RegexASTMultiplicationByte
-        = log_surgeon::finite_automata::RegexASTMultiplication<ByteNfaState>;
-using RegexASTOrByte = log_surgeon::finite_automata::RegexASTOr<ByteNfaState>;
 
 TEST_CASE("Test NFA", "[NFA]") {
     Schema schema;
@@ -49,101 +40,51 @@ TEST_CASE("Test NFA", "[NFA]") {
     // Compare against expected output
     // capture order(tags in brackets): letter1(0,1), letter2(2,3), letter(4,5), containerID(6,7)
     string expected_serialized_nfa = "0:byte_transitions={A-->1,Z-->2},"
-                                     "epsilon_transitions={},"
-                                     "positive_tagged_start_transitions={},"
-                                     "positive_tagged_end_transitions={},"
-                                     "negative_tagged_transition={}\n";
+                                     "spontaneous_transition={}\n";
     expected_serialized_nfa += "1:byte_transitions={},"
-                               "epsilon_transitions={},"
-                               "positive_tagged_start_transitions={3[4]},"
-                               "positive_tagged_end_transitions={},"
-                               "negative_tagged_transition={}\n";
+                               "spontaneous_transition={3[4p]}\n";
     expected_serialized_nfa += "2:byte_transitions={},"
-                               "epsilon_transitions={},"
-                               "positive_tagged_start_transitions={},"
-                               "positive_tagged_end_transitions={},"
-                               "negative_tagged_transition={4[0,1,2,3,4,5,6,7]}\n";
+                               "spontaneous_transition={4[0n,1n,2n,3n,4n,5n,6n,7n]}\n";
     expected_serialized_nfa += "3:byte_transitions={},"
-                               "epsilon_transitions={},"
-                               "positive_tagged_start_transitions={5[0],6[2]},"
-                               "positive_tagged_end_transitions={},"
-                               "negative_tagged_transition={}\n";
+                               "spontaneous_transition={5[0p],6[2p]}\n";
     expected_serialized_nfa += "4:accepting_tag=0,byte_transitions={},"
-                               "epsilon_transitions={},"
-                               "positive_tagged_start_transitions={},"
-                               "positive_tagged_end_transitions={},"
-                               "negative_tagged_transition={}\n";
+                               "spontaneous_transition={}\n";
     expected_serialized_nfa += "5:byte_transitions={a-->7,b-->7},"
-                               "epsilon_transitions={},"
-                               "positive_tagged_start_transitions={},"
-                               "positive_tagged_end_transitions={},"
-                               "negative_tagged_transition={}\n";
+                               "spontaneous_transition={}\n";
     expected_serialized_nfa += "6:byte_transitions={c-->8,d-->8},"
-                               "epsilon_transitions={},"
-                               "positive_tagged_start_transitions={},"
-                               "positive_tagged_end_transitions={},"
-                               "negative_tagged_transition={}\n";
+                               "spontaneous_transition={}\n";
     expected_serialized_nfa += "7:byte_transitions={},"
-                               "epsilon_transitions={},"
-                               "positive_tagged_start_transitions={},"
-                               "positive_tagged_end_transitions={9[1]},"
-                               "negative_tagged_transition={}\n";
+                               "spontaneous_transition={9[1p]}\n";
     expected_serialized_nfa += "8:byte_transitions={},"
-                               "epsilon_transitions={},"
-                               "positive_tagged_start_transitions={},"
-                               "positive_tagged_end_transitions={10[3]},"
-                               "negative_tagged_transition={}\n";
+                               "spontaneous_transition={10[3p]}\n";
     expected_serialized_nfa += "9:byte_transitions={},"
-                               "epsilon_transitions={},"
-                               "positive_tagged_start_transitions={},"
-                               "positive_tagged_end_transitions={},"
-                               "negative_tagged_transition={11[2,3]}\n";
+                               "spontaneous_transition={11[2n,3n]}\n";
     expected_serialized_nfa += "10:byte_transitions={},"
-                               "epsilon_transitions={},"
-                               "positive_tagged_start_transitions={},"
-                               "positive_tagged_end_transitions={},"
-                               "negative_tagged_transition={11[0,1]}\n";
+                               "spontaneous_transition={11[0n,1n]}\n";
     expected_serialized_nfa += "11:byte_transitions={},"
-                               "epsilon_transitions={},"
-                               "positive_tagged_start_transitions={},"
-                               "positive_tagged_end_transitions={12[5]},"
-                               "negative_tagged_transition={}\n";
+                               "spontaneous_transition={12[5p]}\n";
     expected_serialized_nfa += "12:byte_transitions={B-->13},"
-                               "epsilon_transitions={},"
-                               "positive_tagged_start_transitions={},"
-                               "positive_tagged_end_transitions={},"
-                               "negative_tagged_transition={}\n";
+                               "spontaneous_transition={}\n";
     expected_serialized_nfa += "13:byte_transitions={},"
-                               "epsilon_transitions={},"
-                               "positive_tagged_start_transitions={14[6]},"
-                               "positive_tagged_end_transitions={},"
-                               "negative_tagged_transition={}\n";
+                               "spontaneous_transition={14[6p]}\n";
     expected_serialized_nfa += "14:byte_transitions={0-->15,1-->15,2-->15,3-->15,4-->15,5-->15,6-->"
                                "15,7-->15,8-->15,9-->15},"
-                               "epsilon_transitions={},"
-                               "positive_tagged_start_transitions={},"
-                               "positive_tagged_end_transitions={},"
-                               "negative_tagged_transition={}\n";
+                               "spontaneous_transition={}\n";
     expected_serialized_nfa += "15:byte_transitions={0-->15,1-->15,2-->15,3-->15,4-->15,5-->15,6-->"
                                "15,7-->15,8-->15,9-->15},"
-                               "epsilon_transitions={},"
-                               "positive_tagged_start_transitions={},"
-                               "positive_tagged_end_transitions={16[7]},"
-                               "negative_tagged_transition={}\n";
+                               "spontaneous_transition={16[7p]}\n";
     expected_serialized_nfa += "16:byte_transitions={C-->4},"
-                               "epsilon_transitions={},"
-                               "positive_tagged_start_transitions={},"
-                               "positive_tagged_end_transitions={},"
-                               "negative_tagged_transition={}\n";
+                               "spontaneous_transition={}\n";
 
     // Compare expected and actual line-by-line
-    auto const actual_serialized_nfa = nfa.serialize();
-    stringstream ss_actual{actual_serialized_nfa};
+    auto const optional_actual_serialized_nfa = nfa.serialize();
+    REQUIRE(optional_actual_serialized_nfa.has_value());
+    stringstream ss_actual{optional_actual_serialized_nfa.value()};
     stringstream ss_expected{expected_serialized_nfa};
     string actual_line;
     string expected_line;
 
-    CAPTURE(actual_serialized_nfa);
+    CAPTURE(optional_actual_serialized_nfa.value());
     CAPTURE(expected_serialized_nfa);
     while (getline(ss_actual, actual_line) && getline(ss_expected, expected_line)) {
         REQUIRE(actual_line == expected_line);

--- a/tests/test-nfa.cpp
+++ b/tests/test-nfa.cpp
@@ -39,45 +39,30 @@ TEST_CASE("Test NFA", "[NFA]") {
 
     // Compare against expected output
     // capture order(tags in brackets): letter1(0,1), letter2(2,3), letter(4,5), containerID(6,7)
-    string expected_serialized_nfa = "0:byte_transitions={A-->1,Z-->2},"
-                                     "spontaneous_transition={}\n";
-    expected_serialized_nfa += "1:byte_transitions={},"
-                               "spontaneous_transition={3[4p]}\n";
-    expected_serialized_nfa += "2:byte_transitions={},"
-                               "spontaneous_transition={4[0n,1n,2n,3n,4n,5n,6n,7n]}\n";
-    expected_serialized_nfa += "3:byte_transitions={},"
-                               "spontaneous_transition={5[0p],6[2p]}\n";
-    expected_serialized_nfa += "4:accepting_tag=0,byte_transitions={},"
-                               "spontaneous_transition={}\n";
-    expected_serialized_nfa += "5:byte_transitions={a-->7,b-->7},"
-                               "spontaneous_transition={}\n";
-    expected_serialized_nfa += "6:byte_transitions={c-->8,d-->8},"
-                               "spontaneous_transition={}\n";
-    expected_serialized_nfa += "7:byte_transitions={},"
-                               "spontaneous_transition={9[1p]}\n";
-    expected_serialized_nfa += "8:byte_transitions={},"
-                               "spontaneous_transition={10[3p]}\n";
-    expected_serialized_nfa += "9:byte_transitions={},"
-                               "spontaneous_transition={11[2n,3n]}\n";
-    expected_serialized_nfa += "10:byte_transitions={},"
-                               "spontaneous_transition={11[0n,1n]}\n";
-    expected_serialized_nfa += "11:byte_transitions={},"
-                               "spontaneous_transition={12[5p]}\n";
-    expected_serialized_nfa += "12:byte_transitions={B-->13},"
-                               "spontaneous_transition={}\n";
-    expected_serialized_nfa += "13:byte_transitions={},"
-                               "spontaneous_transition={14[6p]}\n";
-    expected_serialized_nfa += "14:byte_transitions={0-->15,1-->15,2-->15,3-->15,4-->15,5-->15,6-->"
-                               "15,7-->15,8-->15,9-->15},"
-                               "spontaneous_transition={}\n";
-    expected_serialized_nfa += "15:byte_transitions={0-->15,1-->15,2-->15,3-->15,4-->15,5-->15,6-->"
-                               "15,7-->15,8-->15,9-->15},"
-                               "spontaneous_transition={16[7p]}\n";
-    expected_serialized_nfa += "16:byte_transitions={C-->4},"
-                               "spontaneous_transition={}\n";
+    string expected_serialized_nfa{
+            "0:byte_transitions={A-->1,Z-->2},spontaneous_transition={}\n"
+            "1:byte_transitions={},spontaneous_transition={3[4p]}\n"
+            "2:byte_transitions={},spontaneous_transition={4[0n,1n,2n,3n,4n,5n,6n,7n]}\n"
+            "3:byte_transitions={},spontaneous_transition={5[0p],6[2p]}\n"
+            "4:accepting_tag=0,byte_transitions={},spontaneous_transition={}\n"
+            "5:byte_transitions={a-->7,b-->7},spontaneous_transition={}\n"
+            "6:byte_transitions={c-->8,d-->8},spontaneous_transition={}\n"
+            "7:byte_transitions={},spontaneous_transition={9[1p]}\n"
+            "8:byte_transitions={},spontaneous_transition={10[3p]}\n"
+            "9:byte_transitions={},spontaneous_transition={11[2n,3n]}\n"
+            "10:byte_transitions={},spontaneous_transition={11[0n,1n]}\n"
+            "11:byte_transitions={},spontaneous_transition={12[5p]}\n"
+            "12:byte_transitions={B-->13},spontaneous_transition={}\n"
+            "13:byte_transitions={},spontaneous_transition={14[6p]}\n"
+            "14:byte_transitions={0-->15,1-->15,2-->15,3-->15,4-->15,5-->15,6-->15,7-->15,8-->15,9-"
+            "->15},spontaneous_transition={}\n"
+            "15:byte_transitions={0-->15,1-->15,2-->15,3-->15,4-->15,5-->15,6-->15,7-->15,8-->15,9-"
+            "->15},spontaneous_transition={16[7p]}\n"
+            "16:byte_transitions={C-->4},spontaneous_transition={}\n"
+    };
 
     // Compare expected and actual line-by-line
-    auto const optional_actual_serialized_nfa = nfa.serialize();
+    auto const optional_actual_serialized_nfa{nfa.serialize()};
     REQUIRE(optional_actual_serialized_nfa.has_value());
     stringstream ss_actual{optional_actual_serialized_nfa.value()};
     stringstream ss_expected{expected_serialized_nfa};


### PR DESCRIPTION
# References
- Depends on #72 .
- To review in parallel with PR#72, diff against PR#72 locally. In the repo run:
```
git fetch upstream pull/72/head:pr-72
git fetch upstream pull/76/head:pr-76
git diff pr-72 pr-77
```

# Description
- Previously we distinguished between epsilon transitions, positive start transitions, negative start transition, and negative transitions. This distinction doesn't provide any theoretical or practical benefit.
- Combining the different types of spontaneous transitions into a single type reduces code bloat, makes the code more intuitive, and allows for easier implementation of the following determinization PR.

# Validation performed
- Modified transition tests to match refactor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced spontaneous transitions and tag operations to enhance state and capture handling.
  
- **Refactor**
  - Streamlined state transition and capture processing with improved error handling and clearer naming.
  
- **Tests**
  - Updated tests to match the new transition structure and serialization format, ensuring increased robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->