### PR TITLE
fix(gh-workflow): Lock Ubuntu runner to 22.04 as a temporary workaround for #75.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-22.04"]
         build_type: ["Debug", "Release"]
     runs-on: "${{matrix.os}}"
     steps:
@@ -39,7 +39,7 @@ jobs:
         run: "brew install catch2"
 
       - name: "Install Catch2 on Ubuntu"
-        if: "matrix.os == 'ubuntu-latest'"
+        if: "matrix.os == 'ubuntu-22.04'"
         run: "./tools/deps-install/ubuntu/install-catch2.sh 3.6.0"
 
       - name: "Build Executables"


### PR DESCRIPTION
# Description
- Lock Ubuntu to 22.04 to avoid 24.04 compiler errors related to `fmt` library.
- Issue to fix this error is:  #75.

# Validation performed
- Existing tests pass on Git.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the continuous integration workflow to specify Ubuntu 22.04 for build tasks, ensuring improved build consistency and accurate environment handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->