### PR TITLE
ci(gh-workflow): Print unit-test logs on failure executions.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,3 +52,7 @@ jobs:
 
       - name: "Run Unit Tests"
         run: "ctest --test-dir ./build"
+
+      - name: "Print test log on failure"
+        if: "failure()"
+        run: "cat ./build/Testing/Temporary/LastTest.log"


### PR DESCRIPTION
# References
- Depends on #80 in order to compile on Git.

# Description
- Modified `build.yaml` to output the unit-test logs when a unit-test fails on Git.

# Validation performed
- Tested that the logs print when a unit-test fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the build workflow by adding an automated step that outputs detailed test logs when tests fail, improving the diagnosis of issues during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->