### PR TITLE
fix: Include test files in C++ linter dependencies; Exclude `build` directories from clang-format task.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-22.04"]
         build_type: ["Debug", "Release"]
     runs-on: "${{matrix.os}}"
     steps:
@@ -39,7 +39,7 @@ jobs:
         run: "brew install catch2"
 
       - name: "Install Catch2 on Ubuntu"
-        if: "matrix.os == 'ubuntu-latest'"
+        if: "matrix.os == 'ubuntu-22.04'"
         run: "./tools/deps-install/ubuntu/install-catch2.sh 3.6.0"
 
       - name: "Build Executables"

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -69,7 +69,7 @@ tasks:
         find src examples tests \
           -type f \
           \( -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" -o -iname "*.tpp" \) \
-          ! -path "*/*build*/*" \
+          ! -path "examples/*build*/*" \
           -print0 | \
             xargs -0 clang-format {{.FLAGS}} -Werror
 

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -26,6 +26,10 @@ tasks:
       - "src/**/*.h"
       - "src/**/*.hpp"
       - "src/**/*.tpp"
+      - "tests/**/*.cpp"
+      - "tests/**/*.h"
+      - "tests/**/*.hpp"
+      - "tests/**/*.tpp"
     cmds:
       - task: "cpp"
         vars:
@@ -65,6 +69,7 @@ tasks:
         find src examples tests \
           -type f \
           \( -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" -o -iname "*.tpp" \) \
+          ! -path "*/*build*/*" \
           -print0 | \
             xargs -0 clang-format {{.FLAGS}} -Werror
 


### PR DESCRIPTION
# References
- Depends on #80 in order to compile on Git.

# Description
- Add `tests`  folders to the `cpp_source_files` such that if code files in `tests` change clang-format will be run.
- Ignore `*build*` subdirectories in folders when running clang-format to avoid erroneous clang-format errors.

# Validation performed
- `task lint:cpp-check` locally prints errors when `tests/*.cpp` are changed
- `task lint:cpp-check` passes locally instead of printing warnings for files in build directories.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - The continuous integration build process has been updated to target a specific Ubuntu release, ensuring a more stable and consistent build environment.
  - Linting has been improved by expanding checks to include additional test files while excluding build-related directories, enhancing overall code quality and streamlining automated reviews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->