### PR TITLE
fix(clang-tidy): Fix violations in files relevant to TDFA determinization.

### DIFF
--- a/src/log_surgeon/Lexer.hpp
+++ b/src/log_surgeon/Lexer.hpp
@@ -3,9 +3,9 @@
 
 #include <array>
 #include <cstdint>
-#include <map>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/src/log_surgeon/Lexer.hpp
+++ b/src/log_surgeon/Lexer.hpp
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>

--- a/src/log_surgeon/LexicalRule.hpp
+++ b/src/log_surgeon/LexicalRule.hpp
@@ -2,7 +2,9 @@
 #define LOG_SURGEON_LEXICAL_RULE_HPP
 #include <cstdint>
 #include <memory>
+#include <vector>
 
+#include <log_surgeon/finite_automata/Capture.hpp>
 #include <log_surgeon/finite_automata/RegexAST.hpp>
 
 namespace log_surgeon {

--- a/src/log_surgeon/SchemaParser.cpp
+++ b/src/log_surgeon/SchemaParser.cpp
@@ -1,18 +1,25 @@
 #include "SchemaParser.hpp"
 
+#include <cerrno>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
 #include <memory>
 #include <span>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <tuple>
+#include <type_traits>
 
 #include <log_surgeon/Constants.hpp>
 #include <log_surgeon/FileReader.hpp>
 #include <log_surgeon/finite_automata/Capture.hpp>
+#include <log_surgeon/finite_automata/NfaState.hpp>
 #include <log_surgeon/finite_automata/RegexAST.hpp>
 #include <log_surgeon/Lalr1Parser.hpp>
-#include <log_surgeon/Lexer.hpp>
+#include <log_surgeon/Reader.hpp>
 #include <log_surgeon/utils.hpp>
 
 using ParserValueRegex = log_surgeon::ParserValue<std::unique_ptr<

--- a/src/log_surgeon/finite_automata/DfaStatePair.hpp
+++ b/src/log_surgeon/finite_automata/DfaStatePair.hpp
@@ -69,11 +69,11 @@ auto DfaStatePair<TypedDfaState>::get_reachable_pairs(
 ) const -> void {
     // TODO: Handle UTF-8 (multi-byte transitions) as well
     for (uint32_t i = 0; i < cSizeOfByte; i++) {
-        auto next_state1 = m_state1->next(i);
-        auto next_state2 = m_state2->next(i);
-        if (next_state1 != nullptr && next_state2 != nullptr) {
+        auto next_state1{m_state1->next(i)};
+        auto next_state2{m_state2->next(i)};
+        if (nullptr != next_state1 && nullptr != next_state2) {
             DfaStatePair const reachable_pair{next_state1, next_state2};
-            if (visited_pairs.count(reachable_pair) == 0) {
+            if (false == visited_pairs.contains(reachable_pair)) {
                 unvisited_pairs.insert(reachable_pair);
             }
         }

--- a/src/log_surgeon/finite_automata/Nfa.hpp
+++ b/src/log_surgeon/finite_automata/Nfa.hpp
@@ -1,6 +1,7 @@
 #ifndef LOG_SURGEON_FINITE_AUTOMATA_NFA_HPP
 #define LOG_SURGEON_FINITE_AUTOMATA_NFA_HPP
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -86,7 +87,7 @@ public:
 
     auto set_root(TypedNfaState* root) -> void { m_root = root; }
 
-    auto get_root() -> TypedNfaState* { return m_root; }
+    auto get_root() const -> TypedNfaState* { return m_root; }
 
     [[nodiscard]] auto get_capture_to_tag_id_pair(
     ) const -> std::unordered_map<Capture const*, std::pair<tag_id_t, tag_id_t>> const& {

--- a/tests/test-register-handler.cpp
+++ b/tests/test-register-handler.cpp
@@ -35,7 +35,7 @@ TEST_CASE("`RegisterHandler` tests", "[RegisterHandler]") {
     constexpr size_t cRegId2{1};
 
     SECTION("Initial state is empty") {
-        RegisterHandler empty_handler{handler_init(0)};
+        RegisterHandler const empty_handler{handler_init(0)};
         REQUIRE_THROWS_AS(empty_handler.get_reversed_positions(cRegId1), std::out_of_range);
     }
 


### PR DESCRIPTION
# Description
- Cleanup for the following files:
  - src/log_surgeon/Lexer.hpp
  - src/log_surgeon/LexicalRule.hpp
  - src/log_surgeon/SchemaParser.cpp
  - src/log_surgeon/finite_automata/DfaStatePair.hpp
  - src/log_surgeon/finite_automata/Nfa.hpp
  - src/log_surgeon/finite_automata/NfaState.hpp
  - tests/test-register-handler.cpp


# Validation performed
- Existing tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded schema parsing with support for additional tokens and productions.
  - Enhanced error reporting with detailed error codes for schema processing.

- **Refactor**
  - Improved state serialization to handle potential failures.
  - Upgraded internal mechanisms for managing unique type identifiers and streamlining state creation.

- **Style**
  - Adopted consistent initialisation and membership-check patterns.

- **Tests**
  - Enforced immutability in register handler tests for stricter validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->