### PR TITLE
refactor: Template `Dfa` on both DFA and NFA state; Update `Dfa` to take `Nfa` by reference rather than value.

### DIFF
--- a/examples/intersect-test.cpp
+++ b/examples/intersect-test.cpp
@@ -21,7 +21,7 @@ using ByteLexicalRule = log_surgeon::LexicalRule<ByteNfaState>;
 
 auto get_intersect_for_query(
         std::map<uint32_t, std::string>& m_id_symbol,
-        Dfa<ByteDfaState> const& dfa1,
+        Dfa<ByteDfaState, ByteNfaState> const& dfa1,
         std::string const& search_string
 ) -> void {
     std::string processed_search_string;
@@ -41,7 +41,7 @@ auto get_intersect_for_query(
         rules.emplace_back(0, std::move(schema_var_ast->m_regex_ptr));
     }
     Nfa<ByteNfaState> nfa(std::move(rules));
-    Dfa<ByteDfaState> dfa2(std::move(nfa));
+    Dfa<ByteDfaState, ByteNfaState> dfa2(nfa);
     auto schema_types = dfa1.get_intersect(&dfa2);
     std::cout << search_string << ":";
     for (auto const& schema_type : schema_types) {
@@ -79,7 +79,7 @@ auto main() -> int {
             m_id_symbol[m_id_symbol.size()] = var_ast->m_name;
         }
         Nfa<ByteNfaState> nfa(std::move(rules));
-        Dfa<ByteDfaState> dfa(std::move(nfa));
+        Dfa<ByteDfaState, ByteNfaState> dfa(nfa);
         get_intersect_for_query(m_id_symbol, dfa, "*1*");
         get_intersect_for_query(m_id_symbol, dfa, "*a*");
         get_intersect_for_query(m_id_symbol, dfa, "*a1*");

--- a/src/log_surgeon/Lexer.hpp
+++ b/src/log_surgeon/Lexer.hpp
@@ -118,7 +118,7 @@ public:
     }
 
     [[nodiscard]] auto get_dfa(
-    ) const -> std::unique_ptr<finite_automata::Dfa<TypedDfaState>> const& {
+    ) const -> std::unique_ptr<finite_automata::Dfa<TypedDfaState, TypedNfaState>> const& {
         return m_dfa;
     }
 
@@ -212,7 +212,7 @@ private:
     std::vector<LexicalRule<TypedNfaState>> m_rules;
     uint32_t m_line{0};
     bool m_has_delimiters{false};
-    std::unique_ptr<finite_automata::Dfa<TypedDfaState>> m_dfa;
+    std::unique_ptr<finite_automata::Dfa<TypedDfaState, TypedNfaState>> m_dfa;
     bool m_asked_for_more_data{false};
     TypedDfaState const* m_prev_state{nullptr};
     std::unordered_map<rule_id_t, std::vector<capture_id_t>> m_rule_id_to_capture_ids;

--- a/src/log_surgeon/Lexer.tpp
+++ b/src/log_surgeon/Lexer.tpp
@@ -404,7 +404,7 @@ void Lexer<TypedNfaState, TypedDfaState>::generate() {
     }
 
     // TODO: DFA ignores captures. E.g., treats "capture:user=(?<user_id>\d+)" as "capture:user=\d+"
-    m_dfa = std::make_unique<finite_automata::Dfa<TypedDfaState>>(std::move(nfa));
+    m_dfa = std::make_unique<finite_automata::Dfa<TypedDfaState, TypedNfaState>>(nfa);
     auto const* state = m_dfa->get_root();
     for (uint32_t i = 0; i < cSizeOfByte; i++) {
         if (state->next(i) != nullptr) {

--- a/src/log_surgeon/finite_automata/Dfa.hpp
+++ b/src/log_surgeon/finite_automata/Dfa.hpp
@@ -12,19 +12,17 @@
 #include <log_surgeon/finite_automata/Nfa.hpp>
 
 namespace log_surgeon::finite_automata {
-template <typename TypedDfaState>
+template <typename TypedDfaState, typename TypedNfaState>
 class Dfa {
 public:
-    template <typename NfaStateType>
-    explicit Dfa(Nfa<NfaStateType> nfa);
+    explicit Dfa(Nfa<TypedNfaState> const& nfa);
 
     /**
      * Creates a new DFA state based on a set of NFA states and adds it to `m_states`.
      * @param nfa_state_set The set of NFA states represented by this DFA state.
      * @return A pointer to the new DFA state.
      */
-    template <typename TypedNfaState>
-    auto new_state(std::set<TypedNfaState*> const& nfa_state_set) -> TypedDfaState*;
+    auto new_state(std::set<TypedNfaState const*> const& nfa_state_set) -> TypedDfaState*;
 
     auto get_root() const -> TypedDfaState const* { return m_states.at(0).get(); }
 
@@ -33,6 +31,7 @@ public:
      * reachable by any type in `dfa_in`. A type is considered reachable if there is at least one
      * string for which: (1) this dfa returns a set of types containing the type, and (2) `dfa_in`
      * returns any non-empty set of types.
+     *
      * @param dfa_in The dfa with which to take the intersect.
      * @return The set of schema types reachable by `dfa_in`.
      */
@@ -42,9 +41,8 @@ private:
     std::vector<std::unique_ptr<TypedDfaState>> m_states;
 };
 
-template <typename TypedDfaState>
-template <typename TypedNfaState>
-Dfa<TypedDfaState>::Dfa(Nfa<TypedNfaState> nfa) {
+template <typename TypedDfaState, typename TypedNfaState>
+Dfa<TypedDfaState, TypedNfaState>::Dfa(Nfa<TypedNfaState> const& nfa) {
     using StateSet = std::set<TypedNfaState const*>;
 
     std::map<StateSet, TypedDfaState*> dfa_states;
@@ -93,9 +91,9 @@ Dfa<TypedDfaState>::Dfa(Nfa<TypedNfaState> nfa) {
     }
 }
 
-template <typename TypedDfaState>
-template <typename TypedNfaState>
-auto Dfa<TypedDfaState>::new_state(std::set<TypedNfaState*> const& nfa_state_set
+template <typename TypedDfaState, typename TypedNfaState>
+auto Dfa<TypedDfaState, TypedNfaState>::new_state(
+        std::set<TypedNfaState const*> const& nfa_state_set
 ) -> TypedDfaState* {
     m_states.emplace_back(std::make_unique<TypedDfaState>());
     auto* dfa_state = m_states.back().get();
@@ -107,8 +105,9 @@ auto Dfa<TypedDfaState>::new_state(std::set<TypedNfaState*> const& nfa_state_set
     return dfa_state;
 }
 
-template <typename TypedDfaState>
-auto Dfa<TypedDfaState>::get_intersect(Dfa const* dfa_in) const -> std::set<uint32_t> {
+template <typename TypedDfaState, typename TypedNfaState>
+auto Dfa<TypedDfaState, TypedNfaState>::get_intersect(Dfa const* dfa_in
+) const -> std::set<uint32_t> {
     std::set<uint32_t> schema_types;
     std::set<DfaStatePair<TypedDfaState>> unvisited_pairs;
     std::set<DfaStatePair<TypedDfaState>> visited_pairs;

--- a/src/log_surgeon/finite_automata/Nfa.hpp
+++ b/src/log_surgeon/finite_automata/Nfa.hpp
@@ -86,7 +86,7 @@ public:
 
     auto set_root(TypedNfaState* root) -> void { m_root = root; }
 
-    auto get_root() -> TypedNfaState* { return m_root; }
+    auto get_root() const -> TypedNfaState* { return m_root; }
 
     [[nodiscard]] auto get_capture_to_tag_id_pair(
     ) const -> std::unordered_map<Capture const*, std::pair<tag_id_t, tag_id_t>> const& {


### PR DESCRIPTION
# Description
- Instead of having member functions templated on the NFA state type, it makes more sense for the DFA itself to be templated on the NFA state type.
- Also, now that the DFA doesn't need to keep a copy of the NFA, ownership isn't transferred. Instead, the DFA can take a const reference to the NFA and move semantics aren't needed.
- Made `get_root()` `const`.
- The NFA state pointers passed into `new_state()` can also be `const`.

# Validation performed
- Existing tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced internal state management and processing consistency for improved reliability.
- **Chore**
	- Updated internal interfaces to boost type safety and maintainability without affecting user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->