### PR TITLE
refactor: Use default register position in `PrefixTree`; Add `RegisterHandler` constructor for multiple registers; Add `register_id_t type` alias.

### DIFF
--- a/src/log_surgeon/finite_automata/PrefixTree.hpp
+++ b/src/log_surgeon/finite_automata/PrefixTree.hpp
@@ -24,6 +24,7 @@ public:
     using position_t = int32_t;
 
     static constexpr id_t cRootId{0};
+    static constexpr position_t cDefaultPos{0};
 
     PrefixTree() : m_nodes{{std::nullopt, -1}} {}
 

--- a/src/log_surgeon/finite_automata/RegisterHandler.hpp
+++ b/src/log_surgeon/finite_automata/RegisterHandler.hpp
@@ -7,6 +7,8 @@
 #include <log_surgeon/finite_automata/PrefixTree.hpp>
 
 namespace log_surgeon::finite_automata {
+using register_id_t = uint32_t;
+
 /**
  * The register handler maintains a prefix tree that is sufficient to represent all registers.
  * The register handler also contains a vector of registers, and performs the set, copy, and append

--- a/src/log_surgeon/finite_automata/RegisterHandler.hpp
+++ b/src/log_surgeon/finite_automata/RegisterHandler.hpp
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include <log_surgeon/finite_automata/PrefixTree.hpp>
-#include <log_surgeon/finite_automata/Register.hpp>
 
 namespace log_surgeon::finite_automata {
 /**

--- a/src/log_surgeon/finite_automata/RegisterHandler.hpp
+++ b/src/log_surgeon/finite_automata/RegisterHandler.hpp
@@ -1,10 +1,11 @@
 #ifndef LOG_SURGEON_FINITE_AUTOMATA_REGISTER_HANDLER_HPP
 #define LOG_SURGEON_FINITE_AUTOMATA_REGISTER_HANDLER_HPP
 
-#include <cstddef>
+#include <cstdint>
 #include <vector>
 
 #include <log_surgeon/finite_automata/PrefixTree.hpp>
+#include <log_surgeon/finite_automata/Register.hpp>
 
 namespace log_surgeon::finite_automata {
 /**
@@ -17,28 +18,45 @@ namespace log_surgeon::finite_automata {
  */
 class RegisterHandler {
 public:
-    auto add_register(
-            PrefixTree::id_t const prefix_tree_parent_node_id,
-            PrefixTree::position_t const position
-    ) -> void {
-        auto const prefix_tree_node_id{m_prefix_tree.insert(prefix_tree_parent_node_id, position)};
-        m_registers.emplace_back(prefix_tree_node_id);
+    auto add_registers(uint32_t const num_reg_to_add) -> std::vector<uint32_t> {
+        std::vector<uint32_t> added_registers;
+        for (uint32_t i{0}; i < num_reg_to_add; ++i) {
+            added_registers.emplace_back(add_register());
+        }
+        return added_registers;
     }
 
-    auto set_register(size_t const reg_id, PrefixTree::position_t const position) -> void {
+    auto add_register() -> register_id_t {
+        auto const prefix_tree_node_id{
+                m_prefix_tree.insert(PrefixTree::cRootId, PrefixTree::cDefaultPos)
+        };
+        m_registers.emplace_back(prefix_tree_node_id);
+        return m_registers.size() - 1;
+    }
+
+    auto add_register(PrefixTree::id_t const prefix_tree_parent_node_id) -> register_id_t {
+        auto const prefix_tree_node_id{
+                m_prefix_tree.insert(prefix_tree_parent_node_id, PrefixTree::cDefaultPos)
+        };
+        m_registers.emplace_back(prefix_tree_node_id);
+        return m_registers.size() - 1;
+    }
+
+    auto set_register(register_id_t const reg_id, PrefixTree::position_t const position) -> void {
         m_prefix_tree.set(m_registers.at(reg_id), position);
     }
 
-    auto copy_register(size_t const dest_reg_id, size_t const source_reg_id) -> void {
+    auto copy_register(register_id_t const dest_reg_id, register_id_t const source_reg_id) -> void {
         m_registers.at(dest_reg_id) = m_registers.at(source_reg_id);
     }
 
-    auto append_position(size_t const reg_id, PrefixTree::position_t const position) -> void {
+    auto
+    append_position(register_id_t const reg_id, PrefixTree::position_t const position) -> void {
         auto const node_id{m_registers.at(reg_id)};
         m_registers.at(reg_id) = m_prefix_tree.insert(node_id, position);
     }
 
-    [[nodiscard]] auto get_reversed_positions(size_t const reg_id
+    [[nodiscard]] auto get_reversed_positions(register_id_t const reg_id
     ) const -> std::vector<PrefixTree::position_t> {
         return m_prefix_tree.get_reversed_positions(m_registers.at(reg_id));
     }

--- a/tests/test-register-handler.cpp
+++ b/tests/test-register-handler.cpp
@@ -19,6 +19,10 @@ namespace {
 
 auto handler_init(size_t const num_registers) -> RegisterHandler {
     RegisterHandler handler;
+    if (0 == num_registers) {
+        return handler;
+    }
+
     handler.add_register();
     for (size_t i{1}; i < num_registers; ++i) {
         handler.add_register(i);

--- a/tests/test-register-handler.cpp
+++ b/tests/test-register-handler.cpp
@@ -19,12 +19,9 @@ namespace {
 
 auto handler_init(size_t const num_registers) -> RegisterHandler {
     RegisterHandler handler;
-    for (size_t i{0}; i < num_registers; ++i) {
-        if (0 == i) {
-            handler.add_register();
-        } else {
-            handler.add_register(i);
-        }
+    handler.add_register();
+    for (size_t i{1}; i < num_registers; ++i) {
+        handler.add_register(i);
     }
     return handler;
 }

--- a/tests/test-register-handler.cpp
+++ b/tests/test-register-handler.cpp
@@ -18,11 +18,13 @@ namespace {
 [[nodiscard]] auto handler_init(size_t num_registers) -> RegisterHandler;
 
 auto handler_init(size_t const num_registers) -> RegisterHandler {
-    constexpr position_t cDefaultPos{0};
-
     RegisterHandler handler;
     for (size_t i{0}; i < num_registers; ++i) {
-        handler.add_register(i, cDefaultPos);
+        if (0 == i) {
+            handler.add_register();
+        } else {
+            handler.add_register(i);
+        }
     }
     return handler;
 }


### PR DESCRIPTION
# Description
- Instead of the user arbitrarily providing a starting ID when creating registers, prefix tree now uses a default id.
- Register handler updated to use new prefix tree constructor, this also allows register handler to create several registers at once.
- Introduce `register_id_t` instead of using `size_t`.

# Validation performed
- Update `test-register-handler.cpp`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to add multiple registers at once, streamlining register management.

- **Refactor**
  - Enhanced register management with improved type safety and updated method signatures.
  - Added a default position constant for improved clarity in position-related operations.

- **Tests**
  - Revised the initialization testing to accurately handle register creation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->