### PR TITLE
fix: Create an NFA transition for `RegexASTEmpty` nodes.

### DIFF
--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -187,7 +187,7 @@ public:
             [[maybe_unused]] Nfa<TypedNfaState>* nfa,
             [[maybe_unused]] TypedNfaState* end_state
     ) const -> void override {
-        // Do nothing as adding an empty node to the NFA is a null operation.
+        nfa->get_root()->add_spontaneous_transition(end_state);
     }
 
     [[nodiscard]] auto serialize() const -> std::u32string override;


### PR DESCRIPTION
# Description
- Previously the NFA generation behavior for handling an empty regex AST node was to do nothing. This causes the NFA to treat it as failure state as no path exists to an accepting state.
- Instead, we now treat it as a spontaneous transition with no tag operations (I.E., an epsilon transition). This is the desired behavior as it effects nothing, while allowing for a path to an accepting state.

# Validation performed
- Existing tests still pass.
- Unit-tests in simulation branch show that a lexer generated from an AST containing an empty node works.