### PR TITLE
build(cmake): Remove unused `SOURCE_PATH_SIZE` definition.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,14 +162,6 @@ target_compile_options(log_surgeon PRIVATE
     $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
     )
 
-# Macro providing the length of the absolute source directory path so we can
-# create a relative (rather than absolute) __FILE__ macro
-string(LENGTH "${CMAKE_SOURCE_DIR}/" SOURCE_PATH_SIZE)
-target_compile_definitions(log_surgeon
-    PUBLIC
-    SOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}
-    )
-
 # Make off_t 64-bit
 target_compile_definitions(log_surgeon
     PRIVATE


### PR DESCRIPTION
# Description

As title says. Previously, `SOURCE_PATH_SIZE` was used to print relative file paths, but this feature has since been removed.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Tests and linting passing.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

These changes include an update to our build configuration to streamline internal processes. Obsolete internal references for file path handling were removed, enhancing internal consistency and maintainability. End-user functionality remains unaffected.

- **Chores**
  - Refined build configuration by removing unused internal references for file path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->