### PR TITLE
build(cmake): Remove unused `SOURCE_PATH_SIZE` definition from `ubuntu24.04-support` branch.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,14 +81,6 @@ target_compile_options(log_surgeon PRIVATE
     $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
     )
 
-# Macro providing the length of the absolute source directory path so we can
-# create a relative (rather than absolute) __FILE__ macro
-string(LENGTH "${CMAKE_SOURCE_DIR}/" SOURCE_PATH_SIZE)
-target_compile_definitions(log_surgeon
-    PUBLIC
-    SOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}
-    )
-
 # Make off_t 64-bit
 target_compile_definitions(log_surgeon
     PRIVATE

--- a/src/log_surgeon/Token.hpp
+++ b/src/log_surgeon/Token.hpp
@@ -1,6 +1,7 @@
 #ifndef LOG_SURGEON_TOKEN_HPP
 #define LOG_SURGEON_TOKEN_HPP
 
+#include <cstdint>
 #include <set>
 #include <string>
 #include <string_view>


### PR DESCRIPTION
# Description
As title says. Previously, `SOURCE_PATH_SIZE` was used to print relative file paths, but this feature has since been removed.

# Validation performed
- Github CI passes.