### PR TITLE
build: Clean-up CMake build:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ else()
 endif()
 
 if(log_surgeon_ENABLE_TESTS)
-    find_package(Catch2 3.8.0 REQUIRED)
+    find_package(Catch2 3 REQUIRED)
     if(Catch2_FOUND)
         message(STATUS "Found Catch2 ${Catch2_VERSION}.")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.22.1)
 
 project(log_surgeon
     VERSION 0.0.1
@@ -11,18 +11,51 @@ if (POLICY CMP0077)
     cmake_policy(SET CMP0077 NEW)
 endif()
 
-if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
-    find_package(Catch2 3 REQUIRED)
-    include(Catch)
-    include(CTest)
-endif()
-
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 include(FetchContent)
 
-find_package(Microsoft.GSL QUIET CONFIG)
-if (NOT Microsoft.GSL_FOUND)
+option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
+option(log_surgeon_BUILD_TESTING "Build the testing tree." ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS
+    ON
+    CACHE BOOL
+    "Enable/Disable output of compile commands during generation."
+)
+
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(default_build_type "Release")
+    message(STATUS "No build type specified. Setting to '${default_build_type}'.")
+    set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Choose the type of build.")
+endif()
+
+if(log_surgeon_IS_TOP_LEVEL)
+    # If previously undefined, `BUILD_TESTING` will be set to ON.
+    include(CTest)
+endif()
+
+if(BUILD_TESTING AND log_surgeon_BUILD_TESTING)
+    set(log_surgeon_ENABLE_TESTS ON)
+endif()
+
+# Use <fmt/*.h> as <format> is unsupported in gcc-10.
+find_package(fmt 8.0.1 QUIET)
+if(fmt_FOUND)
+    message(STATUS "Found fmt ${fmt_VERSION}.")
+else()
+    FetchContent_Declare(fmt
+                         GIT_REPOSITORY https://github.com/fmtlib/fmt
+                         GIT_TAG "8.0.1"
+                         GIT_SHALLOW ON
+    )
+    # Force fmt to generate install rules
+    set(FMT_INSTALL ON CACHE BOOL "Enable installation for fmt." FORCE)
+endif()
+
+find_package(Microsoft.GSL QUIET)
+if(Microsoft.GSL_FOUND)
+    message(STATUS "Found Microsoft.GSL ${Microsoft.GSL_VERSION}.")
+else()
     FetchContent_Declare(GSL
                          GIT_REPOSITORY "https://github.com/microsoft/GSL"
                          GIT_TAG "v4.0.0"
@@ -30,36 +63,16 @@ if (NOT Microsoft.GSL_FOUND)
     )
 endif()
 
-# Use <fmt/*.h> as <format> is unsupported in gcc-10.
-find_package(fmt 8.0.1 QUIET)
-if (NOT fmt_FOUND)
-    FetchContent_Declare(fmt
-                         GIT_REPOSITORY https://github.com/fmtlib/fmt
-                         GIT_TAG "8.0.1"
-                         GIT_SHALLOW ON
-    )
+if(log_surgeon_ENABLE_TESTS)
+    find_package(Catch2 3.8.0 REQUIRED)
+    if(Catch2_FOUND)
+        message(STATUS "Found Catch2 ${Catch2_VERSION}.")
+    endif()
+    include(Catch)
 endif()
 
 # Declare the details of all fetched content before making them available.
-if (NOT Microsoft.GSL_FOUND)
-    FetchContent_MakeAvailable(GSL)
-endif()
-
-if (NOT fmt_FOUND)
-    # Force fmt to generate install rules
-    set(FMT_INSTALL ON CACHE BOOL "Enable installation for fmt." FORCE)
-    FetchContent_MakeAvailable(fmt)
-endif()
-
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-    set(default_build_type "Release")
-    message(STATUS "No build type specified. Setting to '${default_build_type}'.")
-    set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Choose the type of build." FORCE)
-endif()
-
-option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
+FetchContent_MakeAvailable()
 
 set(SOURCE_FILES
     src/log_surgeon/Buffer.hpp
@@ -117,10 +130,10 @@ set(SOURCE_FILES
     src/log_surgeon/UniqueIdGenerator.hpp
     )
 
-set(LCHIP_INSTALL_CONFIG_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/log_surgeon)
-set(LCHIP_INSTALL_INCLUDE_DIR ${CMAKE_INSTALL_INCLUDEDIR})
+set(LOG_SURGEON_INSTALL_CONFIG_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/log_surgeon)
+set(LOG_SURGEON_INSTALL_INCLUDE_DIR ${CMAKE_INSTALL_INCLUDEDIR})
 # Directory for installing third-party includes that the user doesn't have installed.
-set(LCHIP_THIRD_PARTY_INCLUDE_DIR "${LCHIP_INSTALL_INCLUDE_DIR}/log_surgeon/third_party_include")
+set(LOG_SURGEON_THIRD_PARTY_INCLUDE_DIR "${LOG_SURGEON_INSTALL_INCLUDE_DIR}/log_surgeon/third_party_include")
 
 add_library(log_surgeon ${SOURCE_FILES})
 add_library(log_surgeon::log_surgeon ALIAS log_surgeon)
@@ -139,7 +152,7 @@ else()
     target_include_directories(log_surgeon
             PUBLIC
             $<BUILD_INTERFACE:${GSL_SOURCE_DIR}/include>
-            $<INSTALL_INTERFACE:${LCHIP_THIRD_PARTY_INCLUDE_DIR}>
+            $<INSTALL_INTERFACE:${LOG_SURGEON_THIRD_PARTY_INCLUDE_DIR}>
             )
 endif()
 
@@ -181,14 +194,14 @@ install(
     NAMESPACE
     log_surgeon::
     DESTINATION
-    ${LCHIP_INSTALL_CONFIG_DIR}
+    ${LOG_SURGEON_INSTALL_CONFIG_DIR}
     )
 
 install(
     DIRECTORY
     "${PROJECT_SOURCE_DIR}/src/log_surgeon"
     DESTINATION
-    "${LCHIP_INSTALL_INCLUDE_DIR}"
+    "${LOG_SURGEON_INSTALL_INCLUDE_DIR}"
     FILES_MATCHING
     PATTERN "*.h"
     PATTERN "*.hpp"
@@ -201,7 +214,7 @@ if (NOT Microsoft.GSL_FOUND)
         # its contents.
         "${GSL_SOURCE_DIR}/include/gsl"
         DESTINATION
-        "${LCHIP_THIRD_PARTY_INCLUDE_DIR}"
+        "${LOG_SURGEON_THIRD_PARTY_INCLUDE_DIR}"
         )
 endif ()
 
@@ -209,9 +222,9 @@ configure_package_config_file(
     ${CMAKE_CURRENT_LIST_DIR}/cmake/log_surgeon-config.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/log_surgeon-config.cmake
     INSTALL_DESTINATION
-    ${LCHIP_INSTALL_CONFIG_DIR}
+    ${LOG_SURGEON_INSTALL_CONFIG_DIR}
     PATH_VARS
-    LCHIP_INSTALL_INCLUDE_DIR
+    LOG_SURGEON_INSTALL_INCLUDE_DIR
     )
 
 write_basic_package_version_file(
@@ -225,9 +238,9 @@ install(
     ${CMAKE_CURRENT_BINARY_DIR}/log_surgeon-config.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/log_surgeon-config-version.cmake
     DESTINATION
-    ${LCHIP_INSTALL_CONFIG_DIR}
+    ${LOG_SURGEON_INSTALL_CONFIG_DIR}
     )
 
-if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
+if (log_surgeon_ENABLE_TESTS)
     add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,12 +21,13 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS
     ON
     CACHE BOOL
     "Enable/Disable output of compile commands during generation."
+    FORCE
 )
 
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(default_build_type "Release")
     message(STATUS "No build type specified. Setting to '${default_build_type}'.")
-    set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Choose the type of build.")
+    set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Choose the type of build." FORCE)
 endif()
 
 if(log_surgeon_IS_TOP_LEVEL)
@@ -37,6 +38,8 @@ endif()
 if(BUILD_TESTING AND log_surgeon_BUILD_TESTING)
     set(log_surgeon_ENABLE_TESTS ON)
 endif()
+
+list(APPEND DEPS_TO_FETCH "")
 
 # Use <fmt/*.h> as <format> is unsupported in gcc-10.
 find_package(fmt 8.0.1 QUIET)
@@ -50,6 +53,7 @@ else()
     )
     # Force fmt to generate install rules
     set(FMT_INSTALL ON CACHE BOOL "Enable installation for fmt." FORCE)
+    list(APPEND DEPS_TO_FETCH fmt)
 endif()
 
 find_package(Microsoft.GSL QUIET)
@@ -61,6 +65,7 @@ else()
                          GIT_TAG "v4.0.0"
                          GIT_SHALLOW ON
     )
+    list(APPEND DEPS_TO_FETCH GSL)
 endif()
 
 if(log_surgeon_ENABLE_TESTS)
@@ -72,7 +77,7 @@ if(log_surgeon_ENABLE_TESTS)
 endif()
 
 # Declare the details of all fetched content before making them available.
-FetchContent_MakeAvailable()
+FetchContent_MakeAvailable("${DEPS_TO_FETCH}")
 
 set(SOURCE_FILES
     src/log_surgeon/Buffer.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,14 +162,6 @@ target_compile_options(log_surgeon PRIVATE
     $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
     )
 
-# Macro providing the length of the absolute source directory path so we can
-# create a relative (rather than absolute) __FILE__ macro
-string(LENGTH "${CMAKE_SOURCE_DIR}/" SOURCE_PATH_SIZE)
-target_compile_definitions(log_surgeon
-    PUBLIC
-    SOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}
-    )
-
 # Make off_t 64-bit
 target_compile_definitions(log_surgeon
     PRIVATE

--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ To run unit tests, run:
 cmake --build ./build --target test
 ```
 
+When generating targets, the CMake variable `BUILD_TESTING` is followed (unless overruled by setting
+`log-surgeon_BUILD_TESTING` to false). By default, if built as a top-level project, `BUILD_TESTING`
+is set to true and unit tests are built.
+
 ## Linting
 
 Before submitting a PR, ensure you've run our linting tools and either fixed any violations or

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ cmake --build ./build --target test
 ```
 
 When generating targets, the CMake variable `BUILD_TESTING` is followed (unless overruled by setting
-`log-surgeon_BUILD_TESTING` to false). By default, if built as a top-level project, `BUILD_TESTING`
+`log_surgeon_BUILD_TESTING` to false). By default, if built as a top-level project, `BUILD_TESTING`
 is set to true and unit tests are built.
 
 ## Linting

--- a/cmake/log_surgeon-config.cmake.in
+++ b/cmake/log_surgeon-config.cmake.in
@@ -6,7 +6,7 @@ if (@Microsoft.GSL_FOUND@)
     find_dependency(Microsoft.GSL)
 endif()
 
-set_and_check(log_surgeon_INCLUDE_DIR "@PACKAGE_LCHIP_INSTALL_INCLUDE_DIR@")
+set_and_check(log_surgeon_INCLUDE_DIR "@PACKAGE_LOG_SURGEON_INSTALL_INCLUDE_DIR@")
 
 check_required_components(log_surgeon)
 

--- a/cmake/log_surgeon-config.cmake.in
+++ b/cmake/log_surgeon-config.cmake.in
@@ -2,7 +2,11 @@ include(CMakeFindDependencyMacro)
 
 @PACKAGE_INIT@
 
-if (@Microsoft.GSL_FOUND@)
+if(@fmt_FOUND@)
+    find_dependency(fmt)
+endif()
+
+if(@Microsoft.GSL_FOUND@)
     find_dependency(Microsoft.GSL)
 endif()
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,7 +7,12 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Choose the type of build." FORCE)
 endif()
 
-add_subdirectory(.. log-surgeon-build EXCLUDE_FROM_ALL)
+find_package(log_surgeon QUIET)
+if(log_surgeon_FOUND)
+    message(STATUS "Found log_surgeon ${log_surgeon_VERSION}.")
+else()
+    add_subdirectory(.. log-surgeon-build EXCLUDE_FROM_ALL)
+endif()
 
 function(add_to_target target libraries)
     target_link_libraries(${target} ${libraries})


### PR DESCRIPTION
# Description
- Call `find_dependency(fmt)` in `cmake/log_surgeon-config.cmake.in` to fix linking issues when using an installed version.
- Respect `BUILD_TESTING` unless `log_surgeon_BUILD_TESTING` is set.
- Try `find_package` before `add_subdirectory` in `examples/` to more easily test an installed version.
- Reorganize `FetchContent` related code.
- Bump `cmake_minimum_required` to 3.22.1.
- Move `set` and `option` statements to the top of `CMakeLists.txt`.
- Replace `LCHIP` with `LOG_SURGEON`.

Note: `FetchContent` is expected to be dropped in favour of installing deps through `task` in the next build PR.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Tested building+installing locally and CI still passing.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new build options for enabling/disabling testing and shared library builds.
  - Default build type is now set to "Release" if unspecified.

- **Improvements**
  - Enhanced build configuration clarity and consistency, including renaming install directory variables.
  - Unified and streamlined dependency fetching for required libraries.
  - Updated documentation to clarify testing options and build behaviour.
  - Improved logic for resolving dependencies in example builds, preferring installed packages when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->