### PR TITLE
test: Add new tests for NFA.

### DIFF
--- a/tests/test-nfa.cpp
+++ b/tests/test-nfa.cpp
@@ -63,31 +63,28 @@ auto test_nfa(string const& var_schema, string const& expected_serialized_nfa) -
 
 TEST_CASE("Test simple NFA", "[NFA]") {
     string const var_schema{"capture:userID=(?<uid>123)"};
-
-    // Compare against expected output
-    string expected_serialized_nfa{"0:byte_transitions={u-->1},spontaneous_transition={}\n"};
-    expected_serialized_nfa += "1:byte_transitions={s-->2},spontaneous_transition={}\n";
-    expected_serialized_nfa += "2:byte_transitions={e-->3},spontaneous_transition={}\n";
-    expected_serialized_nfa += "3:byte_transitions={r-->4},spontaneous_transition={}\n";
-    expected_serialized_nfa += "4:byte_transitions={I-->5},spontaneous_transition={}\n";
-    expected_serialized_nfa += "5:byte_transitions={D-->6},spontaneous_transition={}\n";
-    expected_serialized_nfa += "6:byte_transitions={=-->7},spontaneous_transition={}\n";
-    expected_serialized_nfa += "7:byte_transitions={},spontaneous_transition={8[0p]}\n";
-    expected_serialized_nfa += "8:byte_transitions={1-->9},spontaneous_transition={}\n";
-    expected_serialized_nfa += "9:byte_transitions={2-->10},spontaneous_transition={}\n";
-    expected_serialized_nfa += "10:byte_transitions={3-->11},spontaneous_transition={}\n";
-    expected_serialized_nfa += "11:byte_transitions={},spontaneous_transition={12[1p]}\n";
-    expected_serialized_nfa += "12:accepting_tag=0,byte_transitions={},spontaneous_transition={}\n";
-
+    string const expected_serialized_nfa{
+            "0:byte_transitions={u-->1},spontaneous_transition={}\n"
+            "1:byte_transitions={s-->2},spontaneous_transition={}\n"
+            "2:byte_transitions={e-->3},spontaneous_transition={}\n"
+            "3:byte_transitions={r-->4},spontaneous_transition={}\n"
+            "4:byte_transitions={I-->5},spontaneous_transition={}\n"
+            "5:byte_transitions={D-->6},spontaneous_transition={}\n"
+            "6:byte_transitions={=-->7},spontaneous_transition={}\n"
+            "7:byte_transitions={},spontaneous_transition={8[0p]}\n"
+            "8:byte_transitions={1-->9},spontaneous_transition={}\n"
+            "9:byte_transitions={2-->10},spontaneous_transition={}\n"
+            "10:byte_transitions={3-->11},spontaneous_transition={}\n"
+            "11:byte_transitions={},spontaneous_transition={12[1p]}\n"
+            "12:accepting_tag=0,byte_transitions={},spontaneous_transition={}\n"
+    };
     test_nfa(var_schema, expected_serialized_nfa);
 }
 
 TEST_CASE("Test Complex NFA", "[NFA]") {
     string const var_schema{"capture:Z|(A(?<letter>((?<letter1>(a)|(b))|(?<letter2>(c)|(d))))B(?"
                             "<containerID>\\d+)C)"};
-
-    // Compare against expected output
-    // capture order(tags in brackets): letter1(0,1), letter2(2,3), letter(4,5), containerID(6,7)
+    // tags: letter1(0,1), letter2(2,3), letter(4,5), containerID(6,7)
     string const expected_serialized_nfa{
             "0:byte_transitions={A-->1,Z-->2},spontaneous_transition={}\n"
             "1:byte_transitions={},spontaneous_transition={3[4p]}\n"
@@ -109,14 +106,11 @@ TEST_CASE("Test Complex NFA", "[NFA]") {
             "->15},spontaneous_transition={16[7p]}\n"
             "16:byte_transitions={C-->4},spontaneous_transition={}\n"
     };
-
     test_nfa(var_schema, expected_serialized_nfa);
 }
 
 TEST_CASE("Test simple repetition NFA", "[NFA]") {
     string const var_schema{"capture:a*(?<one>1)+"};
-
-    // Compare against expected output
     string const expected_serialized_nfa{
             "0:byte_transitions={a-->1},spontaneous_transition={1[]}\n"
             "1:byte_transitions={a-->1},spontaneous_transition={2[0p+]}\n"
@@ -126,14 +120,11 @@ TEST_CASE("Test simple repetition NFA", "[NFA]") {
             "5:byte_transitions={1-->6},spontaneous_transition={}\n"
             "6:byte_transitions={},spontaneous_transition={4[1p+]}\n"
     };
-
     test_nfa(var_schema, expected_serialized_nfa);
 }
 
 TEST_CASE("Test complex repetition NFA", "[NFA]") {
     string const var_schema{"capture:(a*(?<one>1))+"};
-
-    // Compare against expected output
     string const expected_serialized_nfa{
             "0:byte_transitions={a-->1},spontaneous_transition={1[]}\n"
             "1:byte_transitions={a-->1},spontaneous_transition={2[0p+]}\n"
@@ -144,6 +135,51 @@ TEST_CASE("Test complex repetition NFA", "[NFA]") {
             "6:byte_transitions={1-->7},spontaneous_transition={}\n"
             "7:byte_transitions={},spontaneous_transition={4[1p+]}\n"
     };
+    test_nfa(var_schema, expected_serialized_nfa);
+}
 
+TEST_CASE("Test more complex repetition NFA", "[NFA]") {
+    string const var_schema{"capture:(a+=(?<val>1+),)+"};
+    string const expected_serialized_nfa{
+            "0:byte_transitions={a-->1},spontaneous_transition={}\n"
+            "1:byte_transitions={=-->2,a-->1},spontaneous_transition={}\n"
+            "2:byte_transitions={},spontaneous_transition={3[0p+]}\n"
+            "3:byte_transitions={1-->4},spontaneous_transition={}\n"
+            "4:byte_transitions={1-->4},spontaneous_transition={5[1p+]}\n"
+            "5:byte_transitions={,-->6},spontaneous_transition={}\n"
+            "6:accepting_tag=0,byte_transitions={a-->7},spontaneous_transition={}\n"
+            "7:byte_transitions={=-->8,a-->7},spontaneous_transition={}\n"
+            "8:byte_transitions={},spontaneous_transition={9[0p+]}\n"
+            "9:byte_transitions={1-->10},spontaneous_transition={}\n"
+            "10:byte_transitions={1-->10},spontaneous_transition={11[1p+]}\n"
+            "11:byte_transitions={,-->6},spontaneous_transition={}\n"
+    };
+    test_nfa(var_schema, expected_serialized_nfa);
+}
+
+TEST_CASE("Test integer NFA", "[NFA]") {
+    string const var_schema{"int:\\-{0,1}\\d+"};
+    string const expected_serialized_nfa{
+            "0:byte_transitions={--->1},spontaneous_transition={1[]}\n"
+            "1:byte_transitions={0-->2,1-->2,2-->2,3-->2,4-->2,5-->2,6-->2,7-->2,8-->2,9-->2},"
+            "spontaneous_transition={}\n"
+            "2:accepting_tag=0,byte_transitions={0-->2,1-->2,2-->2,3-->2,4-->2,5-->2,6-->2,7-->2,8-"
+            "->2,9-->2},spontaneous_transition={}\n"
+    };
+    test_nfa(var_schema, expected_serialized_nfa);
+}
+
+TEST_CASE("Test equal NFA", "[NFA]") {
+    string const var_schema{R"(equals:[A]+=(?<val>[=AB]*A[=AB]*))"};
+    string const expected_serialized_nfa{
+            "0:byte_transitions={A-->1},spontaneous_transition={}\n"
+            "1:byte_transitions={=-->2,A-->1},spontaneous_transition={}\n"
+            "2:byte_transitions={},spontaneous_transition={3[0p]}\n"
+            "3:byte_transitions={=-->4,A-->4,B-->4},spontaneous_transition={4[]}\n"
+            "4:byte_transitions={=-->4,A-->4,A-->5,B-->4},spontaneous_transition={}\n"
+            "5:byte_transitions={=-->6,A-->6,B-->6},spontaneous_transition={6[]}\n"
+            "6:byte_transitions={=-->6,A-->6,B-->6},spontaneous_transition={7[1p]}\n"
+            "7:accepting_tag=0,byte_transitions={},spontaneous_transition={}\n"
+    };
     test_nfa(var_schema, expected_serialized_nfa);
 }


### PR DESCRIPTION
# Description
Add NFA tests for:
- Complex repetition case: "(a+=(?<val>1+),)+",
- Integer: "int:\\-{0,1}\\d+",
- Equals: "(equals:[A]+=(?<val>[=AB]*A[=AB]*))".
Clean up existing tests to be more concise.

# Validation performed
- New tests run succesfully.