### PR TITLE
fix: Add NFA node for 0 repetition case.

### DIFF
--- a/src/log_surgeon/finite_automata/Dfa.hpp
+++ b/src/log_surgeon/finite_automata/Dfa.hpp
@@ -315,7 +315,9 @@ auto Dfa<TypedDfaState, TypedNfaState>::try_get_mapping(
                 {
                     reg_map_lhs_to_rhs.insert({lhs_reg_id, rhs_reg_id});
                     reg_map_rhs_to_lhs.insert({rhs_reg_id, lhs_reg_id});
-                } else if (reg_map_lhs_to_rhs.at(lhs_reg_id) != rhs_reg_id
+                } else if (false == reg_map_lhs_to_rhs.contains(lhs_reg_id)
+                           || false == reg_map_rhs_to_lhs.contains(rhs_reg_id)
+                           || reg_map_lhs_to_rhs.at(lhs_reg_id) != rhs_reg_id
                            || reg_map_rhs_to_lhs.at(rhs_reg_id) != lhs_reg_id)
                 {
                     return std::nullopt;

--- a/src/log_surgeon/finite_automata/Dfa.hpp
+++ b/src/log_surgeon/finite_automata/Dfa.hpp
@@ -315,9 +315,7 @@ auto Dfa<TypedDfaState, TypedNfaState>::try_get_mapping(
                 {
                     reg_map_lhs_to_rhs.insert({lhs_reg_id, rhs_reg_id});
                     reg_map_rhs_to_lhs.insert({rhs_reg_id, lhs_reg_id});
-                } else if (false == reg_map_lhs_to_rhs.contains(lhs_reg_id)
-                           || false == reg_map_rhs_to_lhs.contains(rhs_reg_id)
-                           || reg_map_lhs_to_rhs.at(lhs_reg_id) != rhs_reg_id
+                } else if (reg_map_lhs_to_rhs.at(lhs_reg_id) != rhs_reg_id
                            || reg_map_rhs_to_lhs.at(rhs_reg_id) != lhs_reg_id)
                 {
                     return std::nullopt;

--- a/tests/test-dfa.cpp
+++ b/tests/test-dfa.cpp
@@ -156,16 +156,3 @@ TEST_CASE("Test Repetition Tagged DFA", "[DFA]") {
     };
     test_dfa({var_schema}, expected_serialized_dfa);
 }
-
-TEST_CASE("Test integer DFA", "[DFA]") {
-    string const var_schema{"int:\\-{0,1}\\d+"};
-    string const expected_serialized_dfa{
-            "0:byte_transitions={--()->1,0-()->2,1-()->2,2-()->2,3-()->2,4-()->2,5-()->2,6-()->2,7-"
-            "()->2,8-()->2,9-()->2}\n"
-            "1:byte_transitions={0-()->2,1-()->2,2-()->2,3-()->2,4-()->2,5-()->2,6-()->2,7-()->2,8-"
-            "()->2,9-()->2}\n"
-            "2:accepting_tags={0},accepting_operations={},byte_transitions={0-()->2,1-()->2,2-()->"
-            "2,3-()->2,4-()->2,5-()->2,6-()->2,7-()->2,8-()->2,9-()->2}\n"
-    };
-    test_dfa({var_schema}, expected_serialized_dfa);
-}

--- a/tests/test-dfa.cpp
+++ b/tests/test-dfa.cpp
@@ -156,3 +156,16 @@ TEST_CASE("Test Repetition Tagged DFA", "[DFA]") {
     };
     test_dfa({var_schema}, expected_serialized_dfa);
 }
+
+TEST_CASE("Test integer DFA", "[DFA]") {
+    string const var_schema{"int:\\-{0,1}\\d+"};
+    string const expected_serialized_dfa{
+            "0:byte_transitions={--()->1,0-()->2,1-()->2,2-()->2,3-()->2,4-()->2,5-()->2,6-()->2,7-"
+            "()->2,8-()->2,9-()->2}\n"
+            "1:byte_transitions={0-()->2,1-()->2,2-()->2,3-()->2,4-()->2,5-()->2,6-()->2,7-()->2,8-"
+            "()->2,9-()->2}\n"
+            "2:accepting_tags={0},accepting_operations={},byte_transitions={0-()->2,1-()->2,2-()->"
+            "2,3-()->2,4-()->2,5-()->2,6-()->2,7-()->2,8-()->2,9-()->2}\n"
+    };
+    test_dfa({var_schema}, expected_serialized_dfa);
+}


### PR DESCRIPTION
# Description
- Previously for the 0 repetition case we were not modifying the NFA. This means if this case is reached the NFA will incorrectly terminate. This bug became apparent with the introduction of tags as we now treat R{0,N) as R{0}R{1,|N}.
- To fix this we add a node with an epsilon transition for the 0 repetition case.

# Validation performed
Added an integer test to the DFA which uses the regex "\-{0,1}\d+". This test now passes successfully.