### PR TITLE
refactor: Move methods using `fmtlib` to `.cpp` files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,19 +66,28 @@ set(SOURCE_FILES
     src/log_surgeon/FileReader.hpp
     src/log_surgeon/finite_automata/Capture.hpp
     src/log_surgeon/finite_automata/DeterminizationConfiguration.hpp
+    src/log_surgeon/finite_automata/Dfa.cpp
     src/log_surgeon/finite_automata/Dfa.hpp
+    src/log_surgeon/finite_automata/DfaState.cpp
     src/log_surgeon/finite_automata/DfaState.hpp
     src/log_surgeon/finite_automata/DfaStatePair.hpp
+    src/log_surgeon/finite_automata/DfaTransition.cpp
     src/log_surgeon/finite_automata/DfaTransition.hpp
+    src/log_surgeon/finite_automata/Nfa.cpp
     src/log_surgeon/finite_automata/Nfa.hpp
+    src/log_surgeon/finite_automata/NfaSpontaneousTransition.cpp
     src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
+    src/log_surgeon/finite_automata/NfaState.cpp
     src/log_surgeon/finite_automata/NfaState.hpp
     src/log_surgeon/finite_automata/PrefixTree.cpp
     src/log_surgeon/finite_automata/PrefixTree.hpp
+    src/log_surgeon/finite_automata/RegexAST.cpp
     src/log_surgeon/finite_automata/RegexAST.hpp
     src/log_surgeon/finite_automata/RegisterHandler.hpp
+    src/log_surgeon/finite_automata/RegisterOperation.cpp
     src/log_surgeon/finite_automata/RegisterOperation.hpp
     src/log_surgeon/finite_automata/StateType.hpp
+    src/log_surgeon/finite_automata/TagOperation.cpp
     src/log_surgeon/finite_automata/TagOperation.hpp
     src/log_surgeon/finite_automata/UnicodeIntervalTree.hpp
     src/log_surgeon/finite_automata/UnicodeIntervalTree.tpp

--- a/src/log_surgeon/finite_automata/Dfa.cpp
+++ b/src/log_surgeon/finite_automata/Dfa.cpp
@@ -1,0 +1,32 @@
+#include <log_surgeon/finite_automata/Dfa.hpp>
+#include <log_surgeon/finite_automata/DfaState.hpp>
+#include <log_surgeon/finite_automata/NfaState.hpp>
+
+#include <fmt/core.h>
+#include <fmt/format.h>
+
+namespace log_surgeon::finite_automata {
+template <typename TypedDfaState, typename TypedNfaState>
+auto Dfa<TypedDfaState, TypedNfaState>::serialize() const -> std::optional<std::string> {
+    auto const traversal_order = get_bfs_traversal_order();
+
+    std::unordered_map<TypedDfaState const*, uint32_t> state_ids;
+    state_ids.reserve(traversal_order.size());
+    for (auto const* state : traversal_order) {
+        state_ids.emplace(state, state_ids.size());
+    }
+
+    std::vector<std::string> serialized_states;
+    for (auto const* state : traversal_order) {
+        auto const optional_serialized_state{state->serialize(state_ids)};
+        if (false == optional_serialized_state.has_value()) {
+            return std::nullopt;
+        }
+        serialized_states.emplace_back(optional_serialized_state.value());
+    }
+    return fmt::format("{}\n", fmt::join(serialized_states, "\n"));
+}
+
+template auto Dfa<ByteDfaState, ByteNfaState>::serialize() const -> std::optional<std::string>;
+template auto Dfa<Utf8DfaState, Utf8NfaState>::serialize() const -> std::optional<std::string>;
+}  // namespace log_surgeon::finite_automata

--- a/src/log_surgeon/finite_automata/Dfa.cpp
+++ b/src/log_surgeon/finite_automata/Dfa.cpp
@@ -35,5 +35,4 @@ auto Dfa<TypedDfaState, TypedNfaState>::serialize() const -> std::optional<std::
 }
 
 template auto Dfa<ByteDfaState, ByteNfaState>::serialize() const -> std::optional<std::string>;
-template auto Dfa<Utf8DfaState, Utf8NfaState>::serialize() const -> std::optional<std::string>;
 }  // namespace log_surgeon::finite_automata

--- a/src/log_surgeon/finite_automata/Dfa.cpp
+++ b/src/log_surgeon/finite_automata/Dfa.cpp
@@ -1,4 +1,11 @@
-#include <log_surgeon/finite_automata/Dfa.hpp>
+#include "Dfa.hpp"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include <log_surgeon/finite_automata/DfaState.hpp>
 #include <log_surgeon/finite_automata/NfaState.hpp>
 

--- a/src/log_surgeon/finite_automata/Dfa.hpp
+++ b/src/log_surgeon/finite_automata/Dfa.hpp
@@ -23,7 +23,7 @@
 #include <log_surgeon/finite_automata/RegisterHandler.hpp>
 #include <log_surgeon/finite_automata/RegisterOperation.hpp>
 #include <log_surgeon/finite_automata/TagOperation.hpp>
-#include <log_surgeon/Token.hpp>
+#include <log_surgeon/types.hpp>
 
 namespace log_surgeon::finite_automata {
 /**

--- a/src/log_surgeon/finite_automata/Dfa.hpp
+++ b/src/log_surgeon/finite_automata/Dfa.hpp
@@ -25,9 +25,6 @@
 #include <log_surgeon/finite_automata/TagOperation.hpp>
 #include <log_surgeon/Token.hpp>
 
-#include <fmt/core.h>
-#include <fmt/format.h>
-
 namespace log_surgeon::finite_automata {
 /**
  * Represents a Deterministic Finite Automaton (DFA).
@@ -594,27 +591,6 @@ auto Dfa<TypedDfaState, TypedNfaState>::get_bfs_traversal_order() const
         }
     }
     return visited_order;
-}
-
-template <typename TypedDfaState, typename TypedNfaState>
-auto Dfa<TypedDfaState, TypedNfaState>::serialize() const -> std::optional<std::string> {
-    auto const traversal_order = get_bfs_traversal_order();
-
-    std::unordered_map<TypedDfaState const*, uint32_t> state_ids;
-    state_ids.reserve(traversal_order.size());
-    for (auto const* state : traversal_order) {
-        state_ids.emplace(state, state_ids.size());
-    }
-
-    std::vector<std::string> serialized_states;
-    for (auto const* state : traversal_order) {
-        auto const optional_serialized_state{state->serialize(state_ids)};
-        if (false == optional_serialized_state.has_value()) {
-            return std::nullopt;
-        }
-        serialized_states.emplace_back(optional_serialized_state.value());
-    }
-    return fmt::format("{}\n", fmt::join(serialized_states, "\n"));
 }
 }  // namespace log_surgeon::finite_automata
 #endif  // LOG_SURGEON_FINITE_AUTOMATA_DFA_HPP

--- a/src/log_surgeon/finite_automata/DfaState.cpp
+++ b/src/log_surgeon/finite_automata/DfaState.cpp
@@ -62,22 +62,22 @@ auto DfaState<state_type>::serialize(
     );
 }
 
-template auto ByteDfaState::serialize(
+template auto DfaState<StateType::Byte>::serialize(
         std::unordered_map<ByteDfaState const*, uint32_t> const& state_ids
 ) const -> std::optional<std::string>;
 
-template auto Utf8DfaState::serialize(
+template auto DfaState<StateType::Utf8>::serialize(
         std::unordered_map<Utf8DfaState const*, uint32_t> const& state_ids
 ) const -> std::optional<std::string>;
 
 template <>
-auto ByteDfaState::get_transition(uint8_t const character) const
+auto DfaState<StateType::Byte>::get_transition(uint8_t const character) const
         -> std::optional<DfaTransition<StateType::Byte>> const& {
     return m_bytes_transition[character];
 }
 
 template <>
-auto Utf8DfaState::get_transition(uint8_t const character) const
+auto DfaState<StateType::Utf8>::get_transition(uint8_t const character) const
         -> std::optional<DfaTransition<StateType::Utf8>> const& {
     // TODO: Handle UTF8
     return m_bytes_transition[character];

--- a/src/log_surgeon/finite_automata/DfaState.cpp
+++ b/src/log_surgeon/finite_automata/DfaState.cpp
@@ -1,4 +1,14 @@
-#include <log_surgeon/finite_automata/DfaState.hpp>
+#include "DfaState.hpp"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <log_surgeon/Constants.hpp>
+#include <log_surgeon/finite_automata/DfaTransition.hpp>
+#include <log_surgeon/finite_automata/StateType.hpp>
 
 #include <fmt/core.h>
 #include <fmt/format.h>

--- a/src/log_surgeon/finite_automata/DfaState.cpp
+++ b/src/log_surgeon/finite_automata/DfaState.cpp
@@ -65,8 +65,4 @@ auto DfaState<state_type>::serialize(
 template auto DfaState<StateType::Byte>::serialize(
         std::unordered_map<ByteDfaState const*, uint32_t> const& state_ids
 ) const -> std::optional<std::string>;
-
-template auto DfaState<StateType::Utf8>::serialize(
-        std::unordered_map<Utf8DfaState const*, uint32_t> const& state_ids
-) const -> std::optional<std::string>;
 }  // namespace log_surgeon::finite_automata

--- a/src/log_surgeon/finite_automata/DfaState.cpp
+++ b/src/log_surgeon/finite_automata/DfaState.cpp
@@ -69,17 +69,4 @@ template auto DfaState<StateType::Byte>::serialize(
 template auto DfaState<StateType::Utf8>::serialize(
         std::unordered_map<Utf8DfaState const*, uint32_t> const& state_ids
 ) const -> std::optional<std::string>;
-
-template <>
-auto DfaState<StateType::Byte>::get_transition(uint8_t const character) const
-        -> std::optional<DfaTransition<StateType::Byte>> const& {
-    return m_bytes_transition[character];
-}
-
-template <>
-auto DfaState<StateType::Utf8>::get_transition(uint8_t const character) const
-        -> std::optional<DfaTransition<StateType::Utf8>> const& {
-    // TODO: Handle UTF8
-    return m_bytes_transition[character];
-}
 }  // namespace log_surgeon::finite_automata

--- a/src/log_surgeon/finite_automata/DfaState.cpp
+++ b/src/log_surgeon/finite_automata/DfaState.cpp
@@ -1,0 +1,75 @@
+#include <log_surgeon/finite_automata/DfaState.hpp>
+
+#include <fmt/core.h>
+#include <fmt/format.h>
+
+namespace log_surgeon::finite_automata {
+template <StateType state_type>
+auto DfaState<state_type>::serialize(
+        std::unordered_map<DfaState const*, uint32_t> const& state_ids
+) const -> std::optional<std::string> {
+    auto const accepting_tags_string{
+            is_accepting()
+                    ? fmt::format("accepting_tags={{{}}},", fmt::join(m_matching_variable_ids, ","))
+                    : ""
+    };
+
+    std::vector<std::string> accepting_op_strings;
+    for (auto const& accepting_op : m_accepting_ops) {
+        auto const serialized_accepting_op{accepting_op.serialize()};
+        if (serialized_accepting_op.has_value()) {
+            accepting_op_strings.push_back(serialized_accepting_op.value());
+        }
+    }
+    auto const accepting_ops_string{
+            is_accepting() ? fmt::format(
+                                     "accepting_operations={{{}}},",
+                                     fmt::join(accepting_op_strings, ",")
+                             )
+                           : ""
+    };
+
+    std::vector<std::string> transition_strings;
+    for (uint32_t idx{0}; idx < cSizeOfByte; ++idx) {
+        if (false == m_bytes_transition[idx].has_value()) {
+            continue;
+        }
+        auto const optional_byte_transition_string{m_bytes_transition[idx]->serialize(state_ids)};
+        if (false == optional_byte_transition_string.has_value()) {
+            return std::nullopt;
+        }
+        transition_strings.emplace_back(
+                fmt::format("{}{}", static_cast<char>(idx), optional_byte_transition_string.value())
+        );
+    }
+
+    return fmt::format(
+            "{}:{}{}byte_transitions={{{}}}",
+            state_ids.at(this),
+            accepting_tags_string,
+            accepting_ops_string,
+            fmt::join(transition_strings, ",")
+    );
+}
+
+template auto ByteDfaState::serialize(
+        std::unordered_map<ByteDfaState const*, uint32_t> const& state_ids
+) const -> std::optional<std::string>;
+
+template auto Utf8DfaState::serialize(
+        std::unordered_map<Utf8DfaState const*, uint32_t> const& state_ids
+) const -> std::optional<std::string>;
+
+template <>
+auto ByteDfaState::get_transition(uint8_t const character) const
+        -> std::optional<DfaTransition<StateType::Byte>> const& {
+    return m_bytes_transition[character];
+}
+
+template <>
+auto Utf8DfaState::get_transition(uint8_t const character) const
+        -> std::optional<DfaTransition<StateType::Utf8>> const& {
+    // TODO: Handle UTF8
+    return m_bytes_transition[character];
+}
+}  // namespace log_surgeon::finite_automata

--- a/src/log_surgeon/finite_automata/DfaState.hpp
+++ b/src/log_surgeon/finite_automata/DfaState.hpp
@@ -18,9 +18,6 @@
 #include <log_surgeon/finite_automata/StateType.hpp>
 #include <log_surgeon/finite_automata/UnicodeIntervalTree.hpp>
 
-#include <fmt/core.h>
-#include <fmt/format.h>
-
 namespace log_surgeon::finite_automata {
 template <StateType state_type>
 class DfaState;
@@ -83,61 +80,6 @@ private:
     // use an empty class (`std::tuple<>`) in that case.
     std::conditional_t<state_type == StateType::Utf8, Tree, std::tuple<>> m_tree_transitions;
 };
-
-// TODO: Handle UTF-8.
-template <>
-[[nodiscard]] inline auto DfaState<StateType::Byte>::get_transition(uint8_t const character) const
-        -> std::optional<DfaTransition<StateType::Byte>> const& {
-    return m_bytes_transition[character];
-}
-
-template <StateType state_type>
-auto DfaState<state_type>::serialize(
-        std::unordered_map<DfaState const*, uint32_t> const& state_ids
-) const -> std::optional<std::string> {
-    auto const accepting_tags_string{
-            is_accepting()
-                    ? fmt::format("accepting_tags={{{}}},", fmt::join(m_matching_variable_ids, ","))
-                    : ""
-    };
-
-    std::vector<std::string> accepting_op_strings;
-    for (auto const& accepting_op : m_accepting_ops) {
-        auto const serialized_accepting_op{accepting_op.serialize()};
-        if (serialized_accepting_op.has_value()) {
-            accepting_op_strings.push_back(serialized_accepting_op.value());
-        }
-    }
-    auto const accepting_ops_string{
-            is_accepting() ? fmt::format(
-                                     "accepting_operations={{{}}},",
-                                     fmt::join(accepting_op_strings, ",")
-                             )
-                           : ""
-    };
-
-    std::vector<std::string> transition_strings;
-    for (uint32_t idx{0}; idx < cSizeOfByte; ++idx) {
-        if (false == m_bytes_transition[idx].has_value()) {
-            continue;
-        }
-        auto const optional_byte_transition_string{m_bytes_transition[idx]->serialize(state_ids)};
-        if (false == optional_byte_transition_string.has_value()) {
-            return std::nullopt;
-        }
-        transition_strings.emplace_back(
-                fmt::format("{}{}", static_cast<char>(idx), optional_byte_transition_string.value())
-        );
-    }
-
-    return fmt::format(
-            "{}:{}{}byte_transitions={{{}}}",
-            state_ids.at(this),
-            accepting_tags_string,
-            accepting_ops_string,
-            fmt::join(transition_strings, ",")
-    );
-}
 }  // namespace log_surgeon::finite_automata
 
 #endif  // LOG_SURGEON_FINITE_AUTOMATA_DFA_STATE

--- a/src/log_surgeon/finite_automata/DfaState.hpp
+++ b/src/log_surgeon/finite_automata/DfaState.hpp
@@ -4,7 +4,6 @@
 #include <array>
 #include <cassert>
 #include <cstdint>
-#include <memory>
 #include <optional>
 #include <string>
 #include <tuple>

--- a/src/log_surgeon/finite_automata/DfaState.hpp
+++ b/src/log_surgeon/finite_automata/DfaState.hpp
@@ -79,6 +79,12 @@ private:
     // use an empty class (`std::tuple<>`) in that case.
     std::conditional_t<state_type == StateType::Utf8, Tree, std::tuple<>> m_tree_transitions;
 };
+
+template <>
+[[nodiscard]] inline auto DfaState<StateType::Byte>::get_transition(uint8_t const character) const
+        -> std::optional<DfaTransition<StateType::Byte>> const& {
+    return m_bytes_transition[character];
+}
 }  // namespace log_surgeon::finite_automata
 
 #endif  // LOG_SURGEON_FINITE_AUTOMATA_DFA_STATE

--- a/src/log_surgeon/finite_automata/DfaTransition.cpp
+++ b/src/log_surgeon/finite_automata/DfaTransition.cpp
@@ -36,8 +36,4 @@ auto DfaTransition<state_type>::serialize(
 template auto DfaTransition<StateType::Byte>::serialize(
         std::unordered_map<ByteDfaState const*, uint32_t> const& state_ids
 ) const -> std::optional<std::string>;
-
-template auto DfaTransition<StateType::Utf8>::serialize(
-        std::unordered_map<Utf8DfaState const*, uint32_t> const& state_ids
-) const -> std::optional<std::string>;
 }  // namespace log_surgeon::finite_automata

--- a/src/log_surgeon/finite_automata/DfaTransition.cpp
+++ b/src/log_surgeon/finite_automata/DfaTransition.cpp
@@ -1,0 +1,36 @@
+#include <log_surgeon/finite_automata/DfaState.hpp>
+#include <log_surgeon/finite_automata/DfaTransition.hpp>
+#include <log_surgeon/finite_automata/StateType.hpp>
+
+#include <fmt/core.h>
+#include <fmt/format.h>
+
+namespace log_surgeon::finite_automata {
+template <StateType state_type>
+auto DfaTransition<state_type>::serialize(
+        std::unordered_map<DfaState<state_type> const*, uint32_t> const& state_ids
+) const -> std::optional<std::string> {
+    if (false == state_ids.contains(m_dest_state)) {
+        return std::nullopt;
+    }
+
+    std::vector<std::string> transformed_ops;
+    for (auto const& reg_op : m_reg_ops) {
+        auto const optional_serialized_op{reg_op.serialize()};
+        if (false == optional_serialized_op.has_value()) {
+            return std::nullopt;
+        }
+        transformed_ops.emplace_back(optional_serialized_op.value());
+    }
+
+    return fmt::format("-({})->{}", fmt::join(transformed_ops, ","), state_ids.at(m_dest_state));
+}
+
+template auto DfaTransition<StateType::Byte>::serialize(
+        std::unordered_map<ByteDfaState const*, uint32_t> const& state_ids
+) const -> std::optional<std::string>;
+
+template auto DfaTransition<StateType::Utf8>::serialize(
+        std::unordered_map<Utf8DfaState const*, uint32_t> const& state_ids
+) const -> std::optional<std::string>;
+}  // namespace log_surgeon::finite_automata

--- a/src/log_surgeon/finite_automata/DfaTransition.cpp
+++ b/src/log_surgeon/finite_automata/DfaTransition.cpp
@@ -1,3 +1,5 @@
+#include "DfaTransition.hpp"
+
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -5,7 +7,6 @@
 #include <vector>
 
 #include <log_surgeon/finite_automata/DfaState.hpp>
-#include <log_surgeon/finite_automata/DfaTransition.hpp>
 #include <log_surgeon/finite_automata/StateType.hpp>
 
 #include <fmt/core.h>

--- a/src/log_surgeon/finite_automata/DfaTransition.cpp
+++ b/src/log_surgeon/finite_automata/DfaTransition.cpp
@@ -1,3 +1,9 @@
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include <log_surgeon/finite_automata/DfaState.hpp>
 #include <log_surgeon/finite_automata/DfaTransition.hpp>
 #include <log_surgeon/finite_automata/StateType.hpp>

--- a/src/log_surgeon/finite_automata/DfaTransition.hpp
+++ b/src/log_surgeon/finite_automata/DfaTransition.hpp
@@ -11,9 +11,6 @@
 #include <log_surgeon/finite_automata/RegisterOperation.hpp>
 #include <log_surgeon/finite_automata/StateType.hpp>
 
-#include <fmt/core.h>
-#include <fmt/format.h>
-
 namespace log_surgeon::finite_automata {
 template <StateType state_type>
 class DfaState;
@@ -54,26 +51,6 @@ private:
     std::vector<RegisterOperation> m_reg_ops;
     DfaState<state_type> const* m_dest_state{nullptr};
 };
-
-template <StateType state_type>
-auto DfaTransition<state_type>::serialize(
-        std::unordered_map<DfaState<state_type> const*, uint32_t> const& state_ids
-) const -> std::optional<std::string> {
-    if (false == state_ids.contains(m_dest_state)) {
-        return std::nullopt;
-    }
-
-    std::vector<std::string> transformed_ops;
-    for (auto const& reg_op : m_reg_ops) {
-        auto const optional_serialized_op{reg_op.serialize()};
-        if (false == optional_serialized_op.has_value()) {
-            return std::nullopt;
-        }
-        transformed_ops.emplace_back(optional_serialized_op.value());
-    }
-
-    return fmt::format("-({})->{}", fmt::join(transformed_ops, ","), state_ids.at(m_dest_state));
-}
 }  // namespace log_surgeon::finite_automata
 
 #endif  // LOG_SURGEON_FINITE_AUTOMATA_DFATRANSITION_HPP

--- a/src/log_surgeon/finite_automata/Nfa.cpp
+++ b/src/log_surgeon/finite_automata/Nfa.cpp
@@ -33,5 +33,4 @@ auto Nfa<TypedNfaState>::serialize() const -> std::optional<std::string> {
 }
 
 template auto Nfa<ByteNfaState>::serialize() const -> std::optional<std::string>;
-template auto Nfa<Utf8NfaState>::serialize() const -> std::optional<std::string>;
 }  // namespace log_surgeon::finite_automata

--- a/src/log_surgeon/finite_automata/Nfa.cpp
+++ b/src/log_surgeon/finite_automata/Nfa.cpp
@@ -1,10 +1,11 @@
+#include "Nfa.hpp"
+
 #include <cstdint>
 #include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
-#include <log_surgeon/finite_automata/Nfa.hpp>
 #include <log_surgeon/finite_automata/NfaState.hpp>
 
 #include <fmt/core.h>

--- a/src/log_surgeon/finite_automata/Nfa.cpp
+++ b/src/log_surgeon/finite_automata/Nfa.cpp
@@ -1,0 +1,30 @@
+#include <log_surgeon/finite_automata/Nfa.hpp>
+#include <log_surgeon/finite_automata/NfaState.hpp>
+
+#include <fmt/core.h>
+#include <fmt/format.h>
+
+namespace log_surgeon::finite_automata {
+template <typename TypedNfaState>
+auto Nfa<TypedNfaState>::serialize() const -> std::optional<std::string> {
+    auto const traversal_order = get_bfs_traversal_order();
+
+    std::unordered_map<TypedNfaState const*, uint32_t> state_ids;
+    for (auto const* state : traversal_order) {
+        state_ids.emplace(state, state_ids.size());
+    }
+
+    std::vector<std::string> serialized_states;
+    for (auto const* state : traversal_order) {
+        auto const optional_serialized_state{state->serialize(state_ids)};
+        if (false == optional_serialized_state.has_value()) {
+            return std::nullopt;
+        }
+        serialized_states.emplace_back(optional_serialized_state.value());
+    }
+    return fmt::format("{}\n", fmt::join(serialized_states, "\n"));
+}
+
+template auto Nfa<ByteNfaState>::serialize() const -> std::optional<std::string>;
+template auto Nfa<Utf8NfaState>::serialize() const -> std::optional<std::string>;
+}  // namespace log_surgeon::finite_automata

--- a/src/log_surgeon/finite_automata/Nfa.cpp
+++ b/src/log_surgeon/finite_automata/Nfa.cpp
@@ -1,3 +1,9 @@
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include <log_surgeon/finite_automata/Nfa.hpp>
 #include <log_surgeon/finite_automata/NfaState.hpp>
 

--- a/src/log_surgeon/finite_automata/Nfa.hpp
+++ b/src/log_surgeon/finite_automata/Nfa.hpp
@@ -20,9 +20,6 @@
 #include <log_surgeon/types.hpp>
 #include <log_surgeon/UniqueIdGenerator.hpp>
 
-#include <fmt/core.h>
-#include <fmt/format.h>
-
 namespace log_surgeon::finite_automata {
 /**
  * Represents a Non-Deterministic Finite Automaton (NFA) designed to recognize a language based on
@@ -246,26 +243,6 @@ auto Nfa<TypedNfaState>::get_bfs_traversal_order() const -> std::vector<TypedNfa
         }
     }
     return visited_order;
-}
-
-template <typename TypedNfaState>
-auto Nfa<TypedNfaState>::serialize() const -> std::optional<std::string> {
-    auto const traversal_order = get_bfs_traversal_order();
-
-    std::unordered_map<TypedNfaState const*, uint32_t> state_ids;
-    for (auto const* state : traversal_order) {
-        state_ids.emplace(state, state_ids.size());
-    }
-
-    std::vector<std::string> serialized_states;
-    for (auto const* state : traversal_order) {
-        auto const optional_serialized_state{state->serialize(state_ids)};
-        if (false == optional_serialized_state.has_value()) {
-            return std::nullopt;
-        }
-        serialized_states.emplace_back(optional_serialized_state.value());
-    }
-    return fmt::format("{}\n", fmt::join(serialized_states, "\n"));
 }
 }  // namespace log_surgeon::finite_automata
 

--- a/src/log_surgeon/finite_automata/Nfa.hpp
+++ b/src/log_surgeon/finite_automata/Nfa.hpp
@@ -1,7 +1,6 @@
 #ifndef LOG_SURGEON_FINITE_AUTOMATA_NFA_HPP
 #define LOG_SURGEON_FINITE_AUTOMATA_NFA_HPP
 
-#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -125,6 +124,9 @@ private:
 
 template <typename TypedNfaState>
 Nfa<TypedNfaState>::Nfa(std::vector<LexicalRule<TypedNfaState>> const& rules) {
+    // Note: If `m_root` is in the initializer list it will use uninitialized
+    // `m_state_id_generator`. Instead of relying on member ordering we initialize below.
+    // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
     m_root = new_state();
     for (auto const& rule : rules) {
         rule.add_to_nfa(this);

--- a/src/log_surgeon/finite_automata/NfaSpontaneousTransition.cpp
+++ b/src/log_surgeon/finite_automata/NfaSpontaneousTransition.cpp
@@ -1,0 +1,31 @@
+#include <log_surgeon/finite_automata/NfaSpontaneousTransition.hpp>
+#include <log_surgeon/finite_automata/NfaState.hpp>
+
+#include <fmt/format.h>
+
+namespace log_surgeon::finite_automata {
+template <typename TypedNfaState>
+auto NfaSpontaneousTransition<TypedNfaState>::serialize(
+        std::unordered_map<TypedNfaState const*, uint32_t> const& state_ids
+) const -> std::optional<std::string> {
+    if (false == state_ids.contains(m_dest_state)) {
+        return std::nullopt;
+    }
+    auto transformed_operations
+            = m_tag_ops | std::ranges::views::transform(&TagOperation::serialize);
+
+    return fmt::format(
+            "{}[{}]",
+            state_ids.at(m_dest_state),
+            fmt::join(transformed_operations, ",")
+    );
+}
+
+template auto NfaSpontaneousTransition<NfaState<StateType::Byte>>::serialize(
+        std::unordered_map<ByteNfaState const*, uint32_t> const& state_ids
+) const -> std::optional<std::string>;
+
+template auto NfaSpontaneousTransition<NfaState<StateType::Utf8>>::serialize(
+        std::unordered_map<Utf8NfaState const*, uint32_t> const& state_ids
+) const -> std::optional<std::string>;
+}  // namespace log_surgeon::finite_automata

--- a/src/log_surgeon/finite_automata/NfaSpontaneousTransition.cpp
+++ b/src/log_surgeon/finite_automata/NfaSpontaneousTransition.cpp
@@ -1,5 +1,13 @@
-#include <log_surgeon/finite_automata/NfaSpontaneousTransition.hpp>
+#include "NfaSpontaneousTransition.hpp"
+
+#include <cstdint>
+#include <optional>
+#include <ranges>
+#include <string>
+#include <unordered_map>
+
 #include <log_surgeon/finite_automata/NfaState.hpp>
+#include <log_surgeon/finite_automata/TagOperation.hpp>
 
 #include <fmt/format.h>
 
@@ -21,11 +29,11 @@ auto NfaSpontaneousTransition<TypedNfaState>::serialize(
     );
 }
 
-template auto NfaSpontaneousTransition<NfaState<StateType::Byte>>::serialize(
+template auto NfaSpontaneousTransition<ByteNfaState>::serialize(
         std::unordered_map<ByteNfaState const*, uint32_t> const& state_ids
 ) const -> std::optional<std::string>;
 
-template auto NfaSpontaneousTransition<NfaState<StateType::Utf8>>::serialize(
+template auto NfaSpontaneousTransition<Utf8NfaState>::serialize(
         std::unordered_map<Utf8NfaState const*, uint32_t> const& state_ids
 ) const -> std::optional<std::string>;
 }  // namespace log_surgeon::finite_automata

--- a/src/log_surgeon/finite_automata/NfaSpontaneousTransition.cpp
+++ b/src/log_surgeon/finite_automata/NfaSpontaneousTransition.cpp
@@ -32,8 +32,4 @@ auto NfaSpontaneousTransition<TypedNfaState>::serialize(
 template auto NfaSpontaneousTransition<ByteNfaState>::serialize(
         std::unordered_map<ByteNfaState const*, uint32_t> const& state_ids
 ) const -> std::optional<std::string>;
-
-template auto NfaSpontaneousTransition<Utf8NfaState>::serialize(
-        std::unordered_map<Utf8NfaState const*, uint32_t> const& state_ids
-) const -> std::optional<std::string>;
 }  // namespace log_surgeon::finite_automata

--- a/src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
+++ b/src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
@@ -3,7 +3,6 @@
 
 #include <cstdint>
 #include <optional>
-#include <ranges>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
+++ b/src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
@@ -11,8 +11,6 @@
 
 #include <log_surgeon/finite_automata/TagOperation.hpp>
 
-#include <fmt/format.h>
-
 namespace log_surgeon::finite_automata {
 /**
  * Represents an NFA transition with a collection of tag operations to be performed during the
@@ -44,23 +42,6 @@ private:
     std::vector<TagOperation> m_tag_ops;
     TypedNfaState const* m_dest_state;
 };
-
-template <typename TypedNfaState>
-auto NfaSpontaneousTransition<TypedNfaState>::serialize(
-        std::unordered_map<TypedNfaState const*, uint32_t> const& state_ids
-) const -> std::optional<std::string> {
-    if (false == state_ids.contains(m_dest_state)) {
-        return std::nullopt;
-    }
-    auto transformed_operations
-            = m_tag_ops | std::ranges::views::transform(&TagOperation::serialize);
-
-    return fmt::format(
-            "{}[{}]",
-            state_ids.at(m_dest_state),
-            fmt::join(transformed_operations, ",")
-    );
-}
 }  // namespace log_surgeon::finite_automata
 
 #endif  // LOG_SURGEON_FINITE_AUTOMATA_NFASPONTANEOUSTRANSITION_HPP

--- a/src/log_surgeon/finite_automata/NfaState.cpp
+++ b/src/log_surgeon/finite_automata/NfaState.cpp
@@ -1,0 +1,49 @@
+#include <log_surgeon/finite_automata/NfaState.hpp>
+
+#include <fmt/core.h>
+#include <fmt/format.h>
+
+namespace log_surgeon::finite_automata {
+template <StateType state_type>
+auto NfaState<state_type>::serialize(
+        std::unordered_map<NfaState const*, uint32_t> const& state_ids
+) const -> std::optional<std::string> {
+    auto const accepting_tag_string{
+            m_accepting ? fmt::format("accepting_tag={},", m_matching_variable_id) : ""
+    };
+
+    std::vector<std::string> byte_transitions;
+    for (uint32_t idx{0}; idx < cSizeOfByte; ++idx) {
+        for (auto const* dest_state : m_bytes_transitions.at(idx)) {
+            byte_transitions.emplace_back(
+                    fmt::format("{}-->{}", static_cast<char>(idx), state_ids.at(dest_state))
+            );
+        }
+    }
+
+    std::vector<std::string> serialized_spontaneous_transitions;
+    for (auto const& spontaneous_transition : m_spontaneous_transitions) {
+        auto const optional_serialized_transition{spontaneous_transition.serialize(state_ids)};
+        if (false == optional_serialized_transition.has_value()) {
+            return std::nullopt;
+        }
+        serialized_spontaneous_transitions.emplace_back(optional_serialized_transition.value());
+    }
+
+    return fmt::format(
+            "{}:{}byte_transitions={{{}}},spontaneous_transition={{{}}}",
+            state_ids.at(this),
+            accepting_tag_string,
+            fmt::join(byte_transitions, ","),
+            fmt::join(serialized_spontaneous_transitions, ",")
+    );
+}
+
+template auto ByteNfaState::serialize(
+        std::unordered_map<ByteNfaState const*, uint32_t> const& state_ids
+) const -> std::optional<std::string>;
+
+template auto Utf8NfaState::serialize(
+        std::unordered_map<Utf8NfaState const*, uint32_t> const& state_ids
+) const -> std::optional<std::string>;
+}  // namespace log_surgeon::finite_automata

--- a/src/log_surgeon/finite_automata/NfaState.cpp
+++ b/src/log_surgeon/finite_automata/NfaState.cpp
@@ -1,3 +1,5 @@
+#include "NfaState.hpp"
+
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -5,7 +7,6 @@
 #include <vector>
 
 #include <log_surgeon/Constants.hpp>
-#include <log_surgeon/finite_automata/NfaState.hpp>
 #include <log_surgeon/finite_automata/StateType.hpp>
 
 #include <fmt/core.h>

--- a/src/log_surgeon/finite_automata/NfaState.cpp
+++ b/src/log_surgeon/finite_automata/NfaState.cpp
@@ -1,4 +1,12 @@
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <log_surgeon/Constants.hpp>
 #include <log_surgeon/finite_automata/NfaState.hpp>
+#include <log_surgeon/finite_automata/StateType.hpp>
 
 #include <fmt/core.h>
 #include <fmt/format.h>
@@ -39,11 +47,11 @@ auto NfaState<state_type>::serialize(
     );
 }
 
-template auto ByteNfaState::serialize(
+template auto NfaState<StateType::Byte>::serialize(
         std::unordered_map<ByteNfaState const*, uint32_t> const& state_ids
 ) const -> std::optional<std::string>;
 
-template auto Utf8NfaState::serialize(
-        std::unordered_map<Utf8NfaState const*, uint32_t> const& state_ids
+template auto NfaState<StateType::Utf8>::serialize(
+        std::unordered_map<NfaState const*, uint32_t> const& state_ids
 ) const -> std::optional<std::string>;
 }  // namespace log_surgeon::finite_automata

--- a/src/log_surgeon/finite_automata/NfaState.cpp
+++ b/src/log_surgeon/finite_automata/NfaState.cpp
@@ -51,8 +51,4 @@ auto NfaState<state_type>::serialize(
 template auto NfaState<StateType::Byte>::serialize(
         std::unordered_map<ByteNfaState const*, uint32_t> const& state_ids
 ) const -> std::optional<std::string>;
-
-template auto NfaState<StateType::Utf8>::serialize(
-        std::unordered_map<NfaState const*, uint32_t> const& state_ids
-) const -> std::optional<std::string>;
 }  // namespace log_surgeon::finite_automata

--- a/src/log_surgeon/finite_automata/NfaState.hpp
+++ b/src/log_surgeon/finite_automata/NfaState.hpp
@@ -20,9 +20,6 @@
 #include <log_surgeon/finite_automata/UnicodeIntervalTree.hpp>
 #include <log_surgeon/types.hpp>
 
-#include <fmt/core.h>
-#include <fmt/format.h>
-
 namespace log_surgeon::finite_automata {
 template <StateType state_type>
 class NfaState;
@@ -180,41 +177,6 @@ auto NfaState<state_type>::add_interval(Interval interval, NfaState* dest_state)
             m_tree_transitions.insert(interval, {dest_state});
         }
     }
-}
-
-template <StateType state_type>
-auto NfaState<state_type>::serialize(
-        std::unordered_map<NfaState const*, uint32_t> const& state_ids
-) const -> std::optional<std::string> {
-    auto const accepting_tag_string{
-            m_accepting ? fmt::format("accepting_tag={},", m_matching_variable_id) : ""
-    };
-
-    std::vector<std::string> byte_transitions;
-    for (uint32_t idx{0}; idx < cSizeOfByte; ++idx) {
-        for (auto const* dest_state : m_bytes_transitions.at(idx)) {
-            byte_transitions.emplace_back(
-                    fmt::format("{}-->{}", static_cast<char>(idx), state_ids.at(dest_state))
-            );
-        }
-    }
-
-    std::vector<std::string> serialized_spontaneous_transitions;
-    for (auto const& spontaneous_transition : m_spontaneous_transitions) {
-        auto const optional_serialized_transition{spontaneous_transition.serialize(state_ids)};
-        if (false == optional_serialized_transition.has_value()) {
-            return std::nullopt;
-        }
-        serialized_spontaneous_transitions.emplace_back(optional_serialized_transition.value());
-    }
-
-    return fmt::format(
-            "{}:{}byte_transitions={{{}}},spontaneous_transition={{{}}}",
-            state_ids.at(this),
-            accepting_tag_string,
-            fmt::join(byte_transitions, ","),
-            fmt::join(serialized_spontaneous_transitions, ",")
-    );
 }
 }  // namespace log_surgeon::finite_automata
 

--- a/src/log_surgeon/finite_automata/RegexAST.cpp
+++ b/src/log_surgeon/finite_automata/RegexAST.cpp
@@ -1,7 +1,15 @@
+#include "RegexAST.hpp"
+
+#include <cstdint>
+#include <ranges>
+#include <string>
+#include <utility>
+
+#include <log_surgeon/finite_automata/Capture.hpp>
 #include <log_surgeon/finite_automata/NfaState.hpp>
-#include <log_surgeon/finite_automata/RegexAST.hpp>
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <fmt/xchar.h>
 

--- a/src/log_surgeon/finite_automata/RegexAST.cpp
+++ b/src/log_surgeon/finite_automata/RegexAST.cpp
@@ -1,0 +1,158 @@
+#include <log_surgeon/finite_automata/NfaState.hpp>
+#include <log_surgeon/finite_automata/RegexAST.hpp>
+
+#include <fmt/core.h>
+#include <fmt/ranges.h>
+#include <fmt/xchar.h>
+
+namespace log_surgeon::finite_automata {
+template <typename TypedNfaState>
+auto RegexAST<TypedNfaState>::serialize_negative_captures() const -> std::u32string {
+    if (m_negative_captures.empty()) {
+        return U"";
+    }
+
+    auto const transformed_negative_captures{
+            m_negative_captures | std::ranges::views::transform([](Capture const* capture) {
+                return fmt::format("<~{}>", capture->get_name());
+            })
+    };
+    auto const negative_captures_string{
+            fmt::format("{}", fmt::join(transformed_negative_captures, ""))
+    };
+
+    return fmt::format(
+            U"{}",
+            std::u32string(negative_captures_string.begin(), negative_captures_string.end())
+    );
+}
+
+template <typename TypedNfaState>
+[[nodiscard]] auto RegexASTEmpty<TypedNfaState>::serialize() const -> std::u32string {
+    return fmt::format(U"{}", RegexAST<TypedNfaState>::serialize_negative_captures());
+}
+
+template <typename TypedNfaState>
+[[nodiscard]] auto RegexASTLiteral<TypedNfaState>::serialize() const -> std::u32string {
+    return fmt::format(
+            U"{}{}",
+            static_cast<char32_t>(m_character),
+            RegexAST<TypedNfaState>::serialize_negative_captures()
+    );
+}
+
+template <typename TypedNfaState>
+[[nodiscard]] auto RegexASTInteger<TypedNfaState>::serialize() const -> std::u32string {
+    auto const digits_string = fmt::format("{}", fmt::join(m_digits, ""));
+    return fmt::format(
+            U"{}{}",
+            std::u32string(digits_string.begin(), digits_string.end()),
+            RegexAST<TypedNfaState>::serialize_negative_captures()
+    );
+}
+
+template <typename TypedNfaState>
+[[nodiscard]] auto RegexASTOr<TypedNfaState>::serialize() const -> std::u32string {
+    return fmt::format(
+            U"({})|({}){}",
+            nullptr != m_left ? m_left->serialize() : U"null",
+            nullptr != m_right ? m_right->serialize() : U"null",
+            RegexAST<TypedNfaState>::serialize_negative_captures()
+    );
+}
+
+template <typename TypedNfaState>
+[[nodiscard]] auto RegexASTCat<TypedNfaState>::serialize() const -> std::u32string {
+    return fmt::format(
+            U"{}{}{}",
+            nullptr != m_left ? m_left->serialize() : U"null",
+            nullptr != m_right ? m_right->serialize() : U"null",
+            RegexAST<TypedNfaState>::serialize_negative_captures()
+    );
+}
+
+template <typename TypedNfaState>
+[[nodiscard]] auto RegexASTMultiplication<TypedNfaState>::serialize() const -> std::u32string {
+    auto const min_string = std::to_string(m_min);
+    auto const max_string = std::to_string(m_max);
+
+    return fmt::format(
+            U"({}){{{},{}}}{}",
+            nullptr != m_operand ? m_operand->serialize() : U"null",
+            std::u32string(min_string.begin(), min_string.end()),
+            is_infinite() ? U"inf" : std::u32string(max_string.begin(), max_string.end()),
+            RegexAST<TypedNfaState>::serialize_negative_captures()
+    );
+}
+
+template <typename TypedNfaState>
+[[nodiscard]] auto RegexASTCapture<TypedNfaState>::serialize() const -> std::u32string {
+    auto const capture_name_u32{
+            std::u32string(m_capture->get_name().cbegin(), m_capture->get_name().cend())
+    };
+    return fmt::format(
+            U"({})<{}>{}",
+            m_capture_regex_ast->serialize(),
+            capture_name_u32,
+            RegexAST<TypedNfaState>::serialize_negative_captures()
+    );
+}
+
+template <typename TypedNfaState>
+[[nodiscard]] auto RegexASTGroup<TypedNfaState>::serialize() const -> std::u32string {
+    std::u32string ranges_serialized;
+    if (m_is_wildcard) {
+        ranges_serialized += U"*";
+    } else {
+        auto const transformed_ranges
+                = m_ranges
+                  | std::ranges::views::transform([](std::pair<uint32_t, uint32_t> const& range) {
+                        auto const [begin, end] = range;
+                        return fmt::format(
+                                U"{}-{}",
+                                static_cast<char32_t>(begin),
+                                static_cast<char32_t>(end)
+                        );
+                    });
+        for (auto const& range_u32string : transformed_ranges) {
+            if (false == ranges_serialized.empty()) {
+                ranges_serialized += U", ";  // Add separator
+            }
+            ranges_serialized += range_u32string;
+        }
+    }
+    return fmt::format(
+            U"[{}{}]{}",
+            m_negate ? U"^" : U"",
+            ranges_serialized,
+            RegexAST<TypedNfaState>::serialize_negative_captures()
+    );
+}
+
+template auto RegexAST<ByteNfaState>::serialize_negative_captures() const -> std::u32string;
+template auto RegexAST<Utf8NfaState>::serialize_negative_captures() const -> std::u32string;
+
+template auto RegexASTEmpty<ByteNfaState>::serialize() const -> std::u32string;
+template auto RegexASTEmpty<Utf8NfaState>::serialize() const -> std::u32string;
+
+template auto RegexASTLiteral<ByteNfaState>::serialize() const -> std::u32string;
+template auto RegexASTLiteral<Utf8NfaState>::serialize() const -> std::u32string;
+
+template auto RegexASTInteger<ByteNfaState>::serialize() const -> std::u32string;
+template auto RegexASTInteger<Utf8NfaState>::serialize() const -> std::u32string;
+
+template auto RegexASTOr<ByteNfaState>::serialize() const -> std::u32string;
+template auto RegexASTOr<Utf8NfaState>::serialize() const -> std::u32string;
+
+template auto RegexASTCat<ByteNfaState>::serialize() const -> std::u32string;
+template auto RegexASTCat<Utf8NfaState>::serialize() const -> std::u32string;
+
+template auto RegexASTMultiplication<ByteNfaState>::serialize() const -> std::u32string;
+template auto RegexASTMultiplication<Utf8NfaState>::serialize() const -> std::u32string;
+
+template auto RegexASTCapture<ByteNfaState>::serialize() const -> std::u32string;
+template auto RegexASTCapture<Utf8NfaState>::serialize() const -> std::u32string;
+
+template auto RegexASTGroup<ByteNfaState>::serialize() const -> std::u32string;
+template auto RegexASTGroup<Utf8NfaState>::serialize() const -> std::u32string;
+}  // namespace log_surgeon::finite_automata

--- a/src/log_surgeon/finite_automata/RegexAST.cpp
+++ b/src/log_surgeon/finite_automata/RegexAST.cpp
@@ -16,15 +16,6 @@
 
 namespace log_surgeon::finite_automata {
 template <typename TypedNfaState>
-auto RegexASTEmpty<TypedNfaState>::add_to_nfa(
-        [[maybe_unused]] Nfa<TypedNfaState>* nfa,
-        [[maybe_unused]] TypedNfaState* end_state,
-        [[maybe_unused]] bool const descendent_of_repetition
-) const -> void {
-    nfa->get_root()->add_spontaneous_transition(end_state);
-}
-
-template <typename TypedNfaState>
 auto RegexAST<TypedNfaState>::serialize_negative_captures() const -> std::u32string {
     if (m_negative_captures.empty()) {
         return U"";
@@ -146,17 +137,6 @@ template <typename TypedNfaState>
             RegexAST<TypedNfaState>::serialize_negative_captures()
     );
 }
-
-template auto RegexASTEmpty<ByteNfaState>::add_to_nfa(
-        [[maybe_unused]] Nfa<ByteNfaState>* nfa,
-        [[maybe_unused]] ByteNfaState* end_state,
-        [[maybe_unused]] bool descendent_of_repetition
-) const -> void;
-template auto RegexASTEmpty<Utf8NfaState>::add_to_nfa(
-        [[maybe_unused]] Nfa<Utf8NfaState>* nfa,
-        [[maybe_unused]] Utf8NfaState* end_state,
-        [[maybe_unused]] bool descendent_of_repetition
-) const -> void;
 
 template auto RegexAST<ByteNfaState>::serialize_negative_captures() const -> std::u32string;
 template auto RegexAST<Utf8NfaState>::serialize_negative_captures() const -> std::u32string;

--- a/src/log_surgeon/finite_automata/RegexAST.cpp
+++ b/src/log_surgeon/finite_automata/RegexAST.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include <log_surgeon/finite_automata/Capture.hpp>
+#include <log_surgeon/finite_automata/Nfa.hpp>
 #include <log_surgeon/finite_automata/NfaState.hpp>
 
 #include <fmt/core.h>
@@ -14,6 +15,15 @@
 #include <fmt/xchar.h>
 
 namespace log_surgeon::finite_automata {
+template <typename TypedNfaState>
+auto RegexASTEmpty<TypedNfaState>::add_to_nfa(
+        [[maybe_unused]] Nfa<TypedNfaState>* nfa,
+        [[maybe_unused]] TypedNfaState* end_state,
+        [[maybe_unused]] bool const descendent_of_repetition
+) const -> void {
+    nfa->get_root()->add_spontaneous_transition(end_state);
+}
+
 template <typename TypedNfaState>
 auto RegexAST<TypedNfaState>::serialize_negative_captures() const -> std::u32string {
     if (m_negative_captures.empty()) {
@@ -136,6 +146,17 @@ template <typename TypedNfaState>
             RegexAST<TypedNfaState>::serialize_negative_captures()
     );
 }
+
+template auto RegexASTEmpty<ByteNfaState>::add_to_nfa(
+        [[maybe_unused]] Nfa<ByteNfaState>* nfa,
+        [[maybe_unused]] ByteNfaState* end_state,
+        [[maybe_unused]] bool descendent_of_repetition
+) const -> void;
+template auto RegexASTEmpty<Utf8NfaState>::add_to_nfa(
+        [[maybe_unused]] Nfa<Utf8NfaState>* nfa,
+        [[maybe_unused]] Utf8NfaState* end_state,
+        [[maybe_unused]] bool descendent_of_repetition
+) const -> void;
 
 template auto RegexAST<ByteNfaState>::serialize_negative_captures() const -> std::u32string;
 template auto RegexAST<Utf8NfaState>::serialize_negative_captures() const -> std::u32string;

--- a/src/log_surgeon/finite_automata/RegexAST.cpp
+++ b/src/log_surgeon/finite_automata/RegexAST.cpp
@@ -139,29 +139,20 @@ template <typename TypedNfaState>
 }
 
 template auto RegexAST<ByteNfaState>::serialize_negative_captures() const -> std::u32string;
-template auto RegexAST<Utf8NfaState>::serialize_negative_captures() const -> std::u32string;
 
 template auto RegexASTEmpty<ByteNfaState>::serialize() const -> std::u32string;
-template auto RegexASTEmpty<Utf8NfaState>::serialize() const -> std::u32string;
 
 template auto RegexASTLiteral<ByteNfaState>::serialize() const -> std::u32string;
-template auto RegexASTLiteral<Utf8NfaState>::serialize() const -> std::u32string;
 
 template auto RegexASTInteger<ByteNfaState>::serialize() const -> std::u32string;
-template auto RegexASTInteger<Utf8NfaState>::serialize() const -> std::u32string;
 
 template auto RegexASTOr<ByteNfaState>::serialize() const -> std::u32string;
-template auto RegexASTOr<Utf8NfaState>::serialize() const -> std::u32string;
 
 template auto RegexASTCat<ByteNfaState>::serialize() const -> std::u32string;
-template auto RegexASTCat<Utf8NfaState>::serialize() const -> std::u32string;
 
 template auto RegexASTMultiplication<ByteNfaState>::serialize() const -> std::u32string;
-template auto RegexASTMultiplication<Utf8NfaState>::serialize() const -> std::u32string;
 
 template auto RegexASTCapture<ByteNfaState>::serialize() const -> std::u32string;
-template auto RegexASTCapture<Utf8NfaState>::serialize() const -> std::u32string;
 
 template auto RegexASTGroup<ByteNfaState>::serialize() const -> std::u32string;
-template auto RegexASTGroup<Utf8NfaState>::serialize() const -> std::u32string;
 }  // namespace log_surgeon::finite_automata

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -15,6 +15,7 @@
 
 #include <log_surgeon/Constants.hpp>
 #include <log_surgeon/finite_automata/Capture.hpp>
+#include <log_surgeon/finite_automata/Nfa.hpp>
 #include <log_surgeon/finite_automata/UnicodeIntervalTree.hpp>
 
 #include <gsl/pointers>

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -15,7 +15,6 @@
 
 #include <log_surgeon/Constants.hpp>
 #include <log_surgeon/finite_automata/Capture.hpp>
-#include <log_surgeon/finite_automata/Nfa.hpp>
 #include <log_surgeon/finite_automata/UnicodeIntervalTree.hpp>
 
 #include <gsl/pointers>
@@ -190,10 +189,8 @@ public:
     auto add_to_nfa(
             [[maybe_unused]] Nfa<TypedNfaState>* nfa,
             [[maybe_unused]] TypedNfaState* end_state,
-            [[maybe_unused]] bool const descendent_of_repetition
-    ) const -> void override {
-        nfa->get_root()->add_spontaneous_transition(end_state);
-    }
+            [[maybe_unused]] bool descendent_of_repetition
+    ) const -> void override;
 
     [[nodiscard]] auto serialize() const -> std::u32string override;
 };

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <ranges>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -16,7 +15,6 @@
 
 #include <log_surgeon/Constants.hpp>
 #include <log_surgeon/finite_automata/Capture.hpp>
-#include <log_surgeon/finite_automata/TagOperation.hpp>
 #include <log_surgeon/finite_automata/UnicodeIntervalTree.hpp>
 
 #include <gsl/pointers>

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -190,7 +190,9 @@ public:
             [[maybe_unused]] Nfa<TypedNfaState>* nfa,
             [[maybe_unused]] TypedNfaState* end_state,
             [[maybe_unused]] bool descendent_of_repetition
-    ) const -> void override;
+    ) const -> void override {
+        nfa->get_root()->add_spontaneous_transition(end_state);
+    }
 
     [[nodiscard]] auto serialize() const -> std::u32string override;
 };

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -19,9 +19,6 @@
 #include <log_surgeon/finite_automata/TagOperation.hpp>
 #include <log_surgeon/finite_automata/UnicodeIntervalTree.hpp>
 
-#include <fmt/core.h>
-#include <fmt/ranges.h>
-#include <fmt/xchar.h>
 #include <gsl/pointers>
 
 namespace log_surgeon::finite_automata {
@@ -157,25 +154,7 @@ protected:
     RegexAST(RegexAST&& rhs) noexcept = delete;
     auto operator=(RegexAST&& rhs) noexcept -> RegexAST& = delete;
 
-    [[nodiscard]] auto serialize_negative_captures() const -> std::u32string {
-        if (m_negative_captures.empty()) {
-            return U"";
-        }
-
-        auto const transformed_negative_captures{
-                m_negative_captures | std::ranges::views::transform([](Capture const* capture) {
-                    return fmt::format("<~{}>", capture->get_name());
-                })
-        };
-        auto const negative_captures_string{
-                fmt::format("{}", fmt::join(transformed_negative_captures, ""))
-        };
-
-        return fmt::format(
-                U"{}",
-                std::u32string(negative_captures_string.begin(), negative_captures_string.end())
-        );
-    }
+    [[nodiscard]] auto serialize_negative_captures() const -> std::u32string;
 
 private:
     std::vector<Capture const*> m_subtree_positive_captures;
@@ -737,11 +716,6 @@ private:
 };
 
 template <typename TypedNfaState>
-[[nodiscard]] auto RegexASTEmpty<TypedNfaState>::serialize() const -> std::u32string {
-    return fmt::format(U"{}", RegexAST<TypedNfaState>::serialize_negative_captures());
-}
-
-template <typename TypedNfaState>
 RegexASTLiteral<TypedNfaState>::RegexASTLiteral(uint32_t character) : m_character(character) {}
 
 template <typename TypedNfaState>
@@ -751,15 +725,6 @@ void RegexASTLiteral<TypedNfaState>::add_to_nfa(
         [[maybe_unused]] bool const descendent_of_repetition
 ) const {
     nfa->add_root_interval(Interval(m_character, m_character), end_state);
-}
-
-template <typename TypedNfaState>
-[[nodiscard]] auto RegexASTLiteral<TypedNfaState>::serialize() const -> std::u32string {
-    return fmt::format(
-            U"{}{}",
-            static_cast<char32_t>(m_character),
-            RegexAST<TypedNfaState>::serialize_negative_captures()
-    );
 }
 
 template <typename TypedNfaState>
@@ -782,16 +747,6 @@ void RegexASTInteger<TypedNfaState>::add_to_nfa(
         [[maybe_unused]] bool const descendent_of_repetition
 ) const {
     throw std::runtime_error("Unsupported");
-}
-
-template <typename TypedNfaState>
-[[nodiscard]] auto RegexASTInteger<TypedNfaState>::serialize() const -> std::u32string {
-    auto const digits_string = fmt::format("{}", fmt::join(m_digits, ""));
-    return fmt::format(
-            U"{}{}",
-            std::u32string(digits_string.begin(), digits_string.end()),
-            RegexAST<TypedNfaState>::serialize_negative_captures()
-    );
 }
 
 template <typename TypedNfaState>
@@ -820,16 +775,6 @@ void RegexASTOr<TypedNfaState>::add_to_nfa(
 }
 
 template <typename TypedNfaState>
-[[nodiscard]] auto RegexASTOr<TypedNfaState>::serialize() const -> std::u32string {
-    return fmt::format(
-            U"({})|({}){}",
-            nullptr != m_left ? m_left->serialize() : U"null",
-            nullptr != m_right ? m_right->serialize() : U"null",
-            RegexAST<TypedNfaState>::serialize_negative_captures()
-    );
-}
-
-template <typename TypedNfaState>
 RegexASTCat<TypedNfaState>::RegexASTCat(
         std::unique_ptr<RegexAST<TypedNfaState>> left,
         std::unique_ptr<RegexAST<TypedNfaState>> right
@@ -854,16 +799,6 @@ void RegexASTCat<TypedNfaState>::add_to_nfa(
     nfa->set_root(intermediate_state);
     m_right->add_to_nfa_with_negative_captures(nfa, end_state, descendent_of_repetition);
     nfa->set_root(saved_root);
-}
-
-template <typename TypedNfaState>
-[[nodiscard]] auto RegexASTCat<TypedNfaState>::serialize() const -> std::u32string {
-    return fmt::format(
-            U"{}{}{}",
-            nullptr != m_left ? m_left->serialize() : U"null",
-            nullptr != m_right ? m_right->serialize() : U"null",
-            RegexAST<TypedNfaState>::serialize_negative_captures()
-    );
 }
 
 template <typename TypedNfaState>
@@ -918,20 +853,6 @@ void RegexASTMultiplication<TypedNfaState>::add_to_nfa(
 }
 
 template <typename TypedNfaState>
-[[nodiscard]] auto RegexASTMultiplication<TypedNfaState>::serialize() const -> std::u32string {
-    auto const min_string = std::to_string(m_min);
-    auto const max_string = std::to_string(m_max);
-
-    return fmt::format(
-            U"({}){{{},{}}}{}",
-            nullptr != m_operand ? m_operand->serialize() : U"null",
-            std::u32string(min_string.begin(), min_string.end()),
-            is_infinite() ? U"inf" : std::u32string(max_string.begin(), max_string.end()),
-            RegexAST<TypedNfaState>::serialize_negative_captures()
-    );
-}
-
-template <typename TypedNfaState>
 auto RegexASTCapture<TypedNfaState>::add_to_nfa(
         Nfa<TypedNfaState>* nfa,
         TypedNfaState* dest_state,
@@ -980,19 +901,6 @@ auto RegexASTCapture<TypedNfaState>::add_to_nfa(
     m_capture_regex_ast
             ->add_to_nfa_with_negative_captures(nfa, capture_end_state, descendent_of_repetition);
     nfa->set_root(initial_root);
-}
-
-template <typename TypedNfaState>
-[[nodiscard]] auto RegexASTCapture<TypedNfaState>::serialize() const -> std::u32string {
-    auto const capture_name_u32{
-            std::u32string(m_capture->get_name().cbegin(), m_capture->get_name().cend())
-    };
-    return fmt::format(
-            U"({})<{}>{}",
-            m_capture_regex_ast->serialize(),
-            capture_name_u32,
-            RegexAST<TypedNfaState>::serialize_negative_captures()
-    );
 }
 
 template <typename TypedNfaState>
@@ -1125,37 +1033,6 @@ void RegexASTGroup<TypedNfaState>::add_to_nfa(
     for (auto const& [begin, end] : merged_ranges) {
         nfa->get_root()->add_interval(Interval(begin, end), end_state);
     }
-}
-
-template <typename TypedNfaState>
-[[nodiscard]] auto RegexASTGroup<TypedNfaState>::serialize() const -> std::u32string {
-    std::u32string ranges_serialized;
-    if (m_is_wildcard) {
-        ranges_serialized += U"*";
-    } else {
-        auto const transformed_ranges
-                = m_ranges
-                  | std::ranges::views::transform([](std::pair<uint32_t, uint32_t> const& range) {
-                        auto const [begin, end] = range;
-                        return fmt::format(
-                                U"{}-{}",
-                                static_cast<char32_t>(begin),
-                                static_cast<char32_t>(end)
-                        );
-                    });
-        for (auto const& range_u32string : transformed_ranges) {
-            if (false == ranges_serialized.empty()) {
-                ranges_serialized += U", ";  // Add separator
-            }
-            ranges_serialized += range_u32string;
-        }
-    }
-    return fmt::format(
-            U"[{}{}]{}",
-            m_negate ? U"^" : U"",
-            ranges_serialized,
-            RegexAST<TypedNfaState>::serialize_negative_captures()
-    );
 }
 }  // namespace log_surgeon::finite_automata
 

--- a/src/log_surgeon/finite_automata/RegisterOperation.cpp
+++ b/src/log_surgeon/finite_automata/RegisterOperation.cpp
@@ -1,0 +1,21 @@
+#include <log_surgeon/finite_automata/RegisterOperation.hpp>
+
+#include <fmt/core.h>
+
+namespace log_surgeon::finite_automata {
+auto RegisterOperation::serialize() const -> std::optional<std::string> {
+    switch (m_type) {
+        case Type::Copy:
+            if (false == m_copy_reg_id.has_value()) {
+                return std::nullopt;
+            }
+            return fmt::format("{}{}{}", m_reg_id, "c", m_copy_reg_id.value());
+        case Type::Set:
+            return fmt::format("{}{}", m_reg_id, "p");
+        case Type::Negate:
+            return fmt::format("{}{}", m_reg_id, "n");
+        default:
+            return std::nullopt;
+    }
+}
+}  // namespace log_surgeon::finite_automata

--- a/src/log_surgeon/finite_automata/RegisterOperation.cpp
+++ b/src/log_surgeon/finite_automata/RegisterOperation.cpp
@@ -1,4 +1,7 @@
-#include <log_surgeon/finite_automata/RegisterOperation.hpp>
+#include "RegisterOperation.hpp"
+
+#include <optional>
+#include <string>
 
 #include <fmt/core.h>
 

--- a/src/log_surgeon/finite_automata/RegisterOperation.hpp
+++ b/src/log_surgeon/finite_automata/RegisterOperation.hpp
@@ -7,8 +7,6 @@
 
 #include <log_surgeon/types.hpp>
 
-#include <fmt/core.h>
-
 namespace log_surgeon::finite_automata {
 /**
  * Represents a register operation:
@@ -58,21 +56,7 @@ public:
      * - the operation type is invalid.
      * - no source register is specified for a copy operation.
      */
-    [[nodiscard]] auto serialize() const -> std::optional<std::string> {
-        switch (m_type) {
-            case Type::Copy:
-                if (false == m_copy_reg_id.has_value()) {
-                    return std::nullopt;
-                }
-                return fmt::format("{}{}{}", m_reg_id, "c", m_copy_reg_id.value());
-            case Type::Set:
-                return fmt::format("{}{}", m_reg_id, "p");
-            case Type::Negate:
-                return fmt::format("{}{}", m_reg_id, "n");
-            default:
-                return std::nullopt;
-        }
-    }
+    [[nodiscard]] auto serialize() const -> std::optional<std::string>;
 
 private:
     RegisterOperation(reg_id_t const reg_id, Type const type) : m_reg_id{reg_id}, m_type{type} {}

--- a/src/log_surgeon/finite_automata/TagOperation.cpp
+++ b/src/log_surgeon/finite_automata/TagOperation.cpp
@@ -1,0 +1,18 @@
+#include <log_surgeon/finite_automata/TagOperation.hpp>
+
+#include <fmt/core.h>
+
+namespace log_surgeon::finite_automata {
+[[nodiscard]] auto TagOperation::serialize() const -> std::string {
+    char type_char = '?';
+    switch (m_type) {
+        case TagOperationType::Set:
+            type_char = 'p';
+            break;
+        case TagOperationType::Negate:
+            type_char = 'n';
+            break;
+    }
+    return fmt::format("{}{}{}", m_tag_id, type_char, m_multi_valued ? "+" : "");
+}
+}  // namespace log_surgeon::finite_automata

--- a/src/log_surgeon/finite_automata/TagOperation.cpp
+++ b/src/log_surgeon/finite_automata/TagOperation.cpp
@@ -1,4 +1,6 @@
-#include <log_surgeon/finite_automata/TagOperation.hpp>
+#include "TagOperation.hpp"
+
+#include <string>
 
 #include <fmt/core.h>
 

--- a/src/log_surgeon/finite_automata/TagOperation.hpp
+++ b/src/log_surgeon/finite_automata/TagOperation.hpp
@@ -7,8 +7,6 @@
 
 #include <log_surgeon/types.hpp>
 
-#include <fmt/core.h>
-
 namespace log_surgeon::finite_automata {
 enum class TagOperationType : uint8_t {
     Set,
@@ -39,18 +37,7 @@ public:
     /**
      * @return A string representation of the tag operation.
      */
-    [[nodiscard]] auto serialize() const -> std::string {
-        char type_char = '?';
-        switch (m_type) {
-            case TagOperationType::Set:
-                type_char = 'p';
-                break;
-            case TagOperationType::Negate:
-                type_char = 'n';
-                break;
-        }
-        return fmt::format("{}{}{}", m_tag_id, type_char, m_multi_valued ? "+" : "");
-    }
+    [[nodiscard]] auto serialize() const -> std::string;
 
 private:
     tag_id_t m_tag_id;

--- a/tools/init.sh
+++ b/tools/init.sh
@@ -7,7 +7,7 @@ set -e
 set -u
 
 repo_dir="$(git rev-parse --show-toplevel)"
-clang_tidy_config_src_relative_to_repo="tools/yscope-dev-utils/lint-configs/.clang-tidy"
+clang_tidy_config_src_relative_to_repo="tools/yscope-dev-utils/exports/lint-configs/.clang-tidy"
 
 clang_tidy_config_src="${repo_dir}/${clang_tidy_config_src_relative_to_repo}"
 clang_tidy_config_dst="${repo_dir}/.clang-tidy"


### PR DESCRIPTION
# Reference
- Fixes issue #75.

# Description
- Moved all `serialize` methods from `.hpp` files to `.cpp` files.
- For some of these files this requires using explicit instantiation as they are templated methods. This is probably the ideal approach anyway that we should move to for all templated methods in `LogSurgeon` as we have a known finite set of types (byte/utf8) and it lets us follow the standard of defining methods in `.cpp` files.
- Currently we don't have full utf8 support, so only the byte templates were instantiated. Trying to instantiate all will cause MacOS compiler errors, as it goes down code paths that aren't up to date.
- Made sure no new clang-tidy issues were introduced. Didn't fully fix all clang-tidy issues as some require potential logic changes and performance changes that are unrelated to the issue being fixed.

# Todo (Move into description when done)
- Remove the requirement for fmtlib from `LogSurgeon` when included in another cmake (e.g., CLP). What is the best way to do this?

# Validation Performed
- All existing unit-tests run succesfully.
- When above TODO is fixed, we need to test if it works. 