### PR TITLE
fix(cmake): Add `-Wno-stringop-overflow`on certain GCC versions to avoid false positives; Enable Ubuntu 24.04 in CI.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,7 @@ jobs:
         os:
           - "macos-15"
           - "ubuntu-22.04"
+          - "ubuntu-24.04"
         build_type:
           - "debug"
           - "release"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,9 @@ jobs:
   lint:
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os:
+          - "macos-15"
+          - "ubuntu-24.04"
     runs-on: "${{matrix.os}}"
     steps:
       - uses: "actions/checkout@v4"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,18 @@ target_compile_options(log_surgeon PRIVATE
     $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
     )
 
+# Disable -Wstringop-overflow to avoid a false positive in all versions prior to a fix.
+# See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117983
+if("GNU" STREQUAL "${CMAKE_CXX_COMPILER_ID}"
+    AND ((CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12
+         AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 12.4)
+         OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13
+             AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 13.3)
+         OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14
+             AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 14.2)))
+    target_compile_options(log_surgeon PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-stringop-overflow>)
+endif()
+
 # Make off_t 64-bit
 target_compile_definitions(log_surgeon
     PRIVATE


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

Certain GCC versions have a regression where the `stringop-overflow` warning will create false positives. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117983 for more details.

This issue was blocking builds on Ubuntu 24.04 as the default version GCC installed by the package manger has this regression.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Enabled Ubuntu 24.04 in CI and it is passing.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
