### PR TITLE
ci: Add `macos-13` and `macos-14`; Fix `construct_at` compiler error for `macos-13` and `macos-14`.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,6 +31,8 @@ jobs:
     strategy:
       matrix:
         os:
+          - "macos-13"
+          - "macos-14"
           - "macos-15"
           - "ubuntu-22.04"
           - "ubuntu-24.04"

--- a/src/log_surgeon/Token.cpp
+++ b/src/log_surgeon/Token.cpp
@@ -51,10 +51,10 @@ void Token::append_context_to_logtype(
             if (reg_start_positions[j] < 0) {
                 continue;
             }
-            variable_positions.emplace_back(
-                    static_cast<uint32_t>(reg_start_positions[j]),
-                    static_cast<uint32_t>(reg_end_positions[j]),
-                    capture_id
+            variable_positions.push_back(
+                    {static_cast<uint32_t>(reg_start_positions[j]),
+                     static_cast<uint32_t>(reg_end_positions[j]),
+                     capture_id}
             );
         }
     }
@@ -64,7 +64,7 @@ void Token::append_context_to_logtype(
             variable_positions.end(),
             [](auto const& a, auto const& b) { return a.m_start_pos < b.m_start_pos; }
     );
-    variable_positions.emplace_back(m_end_pos, m_end_pos, 0);
+    variable_positions.push_back({m_end_pos, m_end_pos, 0});
 
     uint32_t prev{m_start_pos};
     for (auto const& variable_position : variable_positions) {


### PR DESCRIPTION
# Description
- Mac OS 13 and 14 have older requirements for `construct_at` than 15, so even though log-surgeon builds on 15, it doesn't on 13 and 14. 
- To fix this we add macos-13 and macos-14 to the CI.
- We then fix the `construct_at` bug:
  - It complains that struct `VariablePositions` is calling a non-existing constructor due to using `emplace_back`.
  - Instead of defining the constructor, we switch to `push_back({...})` to use aggregate initialization.

# Validation
- New CI passes successfully after changes.