### PR TITLE
ci: Drop support for macOS 13 & 14 mirroring y-scope/clp#1130.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,8 +31,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - "macos-13"
-          - "macos-14"
           - "macos-15"
           - "ubuntu-22.04"
           - "ubuntu-24.04"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,9 +33,5 @@ jobs:
       - name: "Install task"
         run: "npm install -g @go-task/cli"
 
-      - if: "matrix.os == 'macos-15'"
-        name: "Install coreutils (for md5sum)"
-        run: "brew install coreutils"
-
       - name: "Run lint task"
         run: "task lint:check"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR drops macos-13 and macos-14 from CI as they are no longer required by CLP since [y-scope/clp#1130](https://github.com/y-scope/clp/pull/1130). Similar to that PR, this also prepares log-surgeon for the eventual addition of ystdlib-cpp.

We also drop `brew install coreutils` as it is unnecessary in macos-15.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
CI passing.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow to only run on macOS 15 and Ubuntu 22.04/24.04, removing older macOS versions.
  * Removed the step that installed coreutils on macOS 15 runners in the lint workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->