### PR TITLE
test: Add unit tests for multi-capture schema rules necessary in Android and Kubernetes logs.

### DIFF
--- a/tests/test-buffer-parser.cpp
+++ b/tests/test-buffer-parser.cpp
@@ -896,7 +896,7 @@ TEST_CASE("multi_capture_one", "[BufferParser]") {
     constexpr string_view cInput{"1999-12-12T01:02:03.456 1234 5678 I MyService A=TEXT B=1.1"};
 
     string const header_rule{fmt::format("header:{} {} {} {}", cTime, cPid, cTid, cLogLevel)};
-    ExpectedEvent const expected_event1{
+    ExpectedEvent const expected_event{
             .m_logtype{"<timestamp> <PID> <TID> <LogLevel> MyService A=TEXT B=1.1"},
             .m_timestamp_raw{""},
             .m_tokens{
@@ -917,7 +917,7 @@ TEST_CASE("multi_capture_one", "[BufferParser]") {
     schema.add_variable(header_rule, -1);
     BufferParser buffer_parser{std::move(schema.release_schema_ast_ptr())};
 
-    parse_and_validate(buffer_parser, cInput, {expected_event1});
+    parse_and_validate(buffer_parser, cInput, {expected_event});
 }
 
 /**
@@ -975,7 +975,7 @@ TEST_CASE("multi_capture_two", "[BufferParser]") {
             cLTime,
             cTid
     )};
-    ExpectedEvent const expected_event1{
+    ExpectedEvent const expected_event{
             .m_logtype{"<timestamp> ip-<IP> ku[<PID>]: <LogLevel><LID> <LTime>    <TID> Y failed"},
             .m_timestamp_raw{""},
             .m_tokens{
@@ -998,5 +998,5 @@ TEST_CASE("multi_capture_two", "[BufferParser]") {
     schema.add_variable(header_rule, -1);
     BufferParser buffer_parser{std::move(schema.release_schema_ast_ptr())};
 
-    parse_and_validate(buffer_parser, cInput, {expected_event1});
+    parse_and_validate(buffer_parser, cInput, {expected_event});
 }


### PR DESCRIPTION
# Description
Add two `BufferParser` unit-tests with the following:

- Test 1 (Android log):
  - Schema rule:
    `header:(?<timestamp>\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}) (?<PID>\d{4}) (?<TID>\d{4}) (?<LogLevel>I|D|E|W)`

  - Input:
     `1999-12-12T01:02:03.456 1234 5678 I MyService A=TEXT B=1.1`
   
  - Logtype:
     `<timestamp> <PID> <TID> <LogLevel> MyService A=TEXT B=1.1`
     
- Test 2 (Kubernetes log):
  - Schema rule:
    `header:(?<timestamp>[A-Za-z]{3} \d{2} \d{2}:\d{2}:\d{2}) ip-(?<IP>\d{3}\-\d{2}\-\d{2}\-\d{2}) ku[(?<PID>\d{4})]: (?<LogLevel>I|D|E|W)(?<LID>\d{4}) (?<LTime>\d{2}:\d{2}:\d{2}\.\d{4})    (?<TID>\d{4})`

  - Input:
     `Jan 01 02:03:04 ip-999-99-99-99 ku[1234]: E5678 02:03:04.5678    1111 Y Failed`
   
  - Logtype:
     `<timestamp> ip-<IP> ku[<PID>]: <LogLevel><LID> <LTime>    <TID> Y failed`

Both tests ensure it's output has the correct flattened logtype and full token structure.

# Validation performed
New unit-tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added two unit tests validating multi-capture parsing of complex log headers with named captures (timestamp, IP, PID, TID, levels).
  * Verifies header is flattened into a single log type while preserving the full capture tree and tokenizing remaining fields.
  * No changes to runtime behaviour or public interfaces; improves parser reliability and test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->