### PR TITLE
build(deps): Bump fmtlib version to 11.2.0.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,7 @@ if(BUILD_TESTING AND log_surgeon_BUILD_TESTING)
     set(log_surgeon_ENABLE_TESTS ON)
 endif()
 
-# Use <fmt/*.h> as <format> is unsupported in gcc-10.
-find_package(fmt 8.0.1 REQUIRED)
+find_package(fmt 11.2.0 REQUIRED)
 message(STATUS "Found fmt ${fmt_VERSION}.")
 
 find_package(Microsoft.GSL 4.0.0 REQUIRED)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Requirements:
 * CMake >= 3.22.1
 * GCC >= 10 or Clang >= 7
 * [Catch2] >= 3.8.1
-* [fmt] >= 8.0.1
+* [fmt] >= 11.2.0
 * [GSL] >= 4.0.0
 * [Task] >= 3.38
 * [uv] >= 0.7.10

--- a/src/log_surgeon/finite_automata/Dfa.hpp
+++ b/src/log_surgeon/finite_automata/Dfa.hpp
@@ -25,8 +25,8 @@
 #include <log_surgeon/finite_automata/TagOperation.hpp>
 #include <log_surgeon/Token.hpp>
 
-#include <fmt/core.h>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 namespace log_surgeon::finite_automata {
 /**

--- a/src/log_surgeon/finite_automata/DfaState.hpp
+++ b/src/log_surgeon/finite_automata/DfaState.hpp
@@ -18,8 +18,7 @@
 #include <log_surgeon/finite_automata/StateType.hpp>
 #include <log_surgeon/finite_automata/UnicodeIntervalTree.hpp>
 
-#include <fmt/core.h>
-#include <fmt/format.h>
+#include <fmt/ranges.h>
 
 namespace log_surgeon::finite_automata {
 template <StateType state_type>

--- a/src/log_surgeon/finite_automata/DfaState.hpp
+++ b/src/log_surgeon/finite_automata/DfaState.hpp
@@ -18,6 +18,7 @@
 #include <log_surgeon/finite_automata/StateType.hpp>
 #include <log_surgeon/finite_automata/UnicodeIntervalTree.hpp>
 
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 
 namespace log_surgeon::finite_automata {

--- a/src/log_surgeon/finite_automata/DfaTransition.hpp
+++ b/src/log_surgeon/finite_automata/DfaTransition.hpp
@@ -11,8 +11,8 @@
 #include <log_surgeon/finite_automata/RegisterOperation.hpp>
 #include <log_surgeon/finite_automata/StateType.hpp>
 
-#include <fmt/core.h>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 namespace log_surgeon::finite_automata {
 template <StateType state_type>

--- a/src/log_surgeon/finite_automata/Nfa.hpp
+++ b/src/log_surgeon/finite_automata/Nfa.hpp
@@ -20,8 +20,8 @@
 #include <log_surgeon/types.hpp>
 #include <log_surgeon/UniqueIdGenerator.hpp>
 
-#include <fmt/core.h>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 namespace log_surgeon::finite_automata {
 /**

--- a/src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
+++ b/src/log_surgeon/finite_automata/NfaSpontaneousTransition.hpp
@@ -12,6 +12,7 @@
 #include <log_surgeon/finite_automata/TagOperation.hpp>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 namespace log_surgeon::finite_automata {
 /**

--- a/src/log_surgeon/finite_automata/NfaState.hpp
+++ b/src/log_surgeon/finite_automata/NfaState.hpp
@@ -20,8 +20,8 @@
 #include <log_surgeon/finite_automata/UnicodeIntervalTree.hpp>
 #include <log_surgeon/types.hpp>
 
-#include <fmt/core.h>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 namespace log_surgeon::finite_automata {
 template <StateType state_type>

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -19,7 +19,7 @@
 #include <log_surgeon/finite_automata/TagOperation.hpp>
 #include <log_surgeon/finite_automata/UnicodeIntervalTree.hpp>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <fmt/xchar.h>
 #include <gsl/pointers>

--- a/src/log_surgeon/finite_automata/RegisterOperation.hpp
+++ b/src/log_surgeon/finite_automata/RegisterOperation.hpp
@@ -7,7 +7,7 @@
 
 #include <log_surgeon/types.hpp>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace log_surgeon::finite_automata {
 /**

--- a/src/log_surgeon/finite_automata/TagOperation.hpp
+++ b/src/log_surgeon/finite_automata/TagOperation.hpp
@@ -7,7 +7,7 @@
 
 #include <log_surgeon/types.hpp>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace log_surgeon::finite_automata {
 enum class TagOperationType : uint8_t {

--- a/src/log_surgeon/wildcard_query_parser/QueryInterpretation.cpp
+++ b/src/log_surgeon/wildcard_query_parser/QueryInterpretation.cpp
@@ -9,8 +9,8 @@
 #include <log_surgeon/wildcard_query_parser/StaticQueryToken.hpp>
 #include <log_surgeon/wildcard_query_parser/VariableQueryToken.hpp>
 
-#include <fmt/core.h>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 using std::string;
 using std::strong_ordering;

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -57,8 +57,8 @@ tasks:
             - "-DFMT_TEST=OFF"
           CMAKE_PACKAGE_NAME: "fmt"
           CMAKE_SETTINGS_DIR: "{{.G_DEPS_CMAKE_SETTINGS_DIR}}"
-          TAR_SHA256: "b06ca3130158c625848f3fb7418f235155a4d389b2abc3a6245fb01cb0eb1e01"
-          TAR_URL: "https://github.com/fmtlib/fmt/archive/refs/tags/8.0.1.tar.gz"
+          TAR_SHA256: "bc23066d87ab3168f27cef3e97d545fa63314f5c79df5ea444d41d56f962c6af"
+          TAR_URL: "https://github.com/fmtlib/fmt/archive/refs/tags/11.2.0.tar.gz"
           WORK_DIR: "{{.G_DEPS_DIR}}"
 
   install-microsoft.gsl:

--- a/tests/test-buffer-parser.cpp
+++ b/tests/test-buffer-parser.cpp
@@ -14,7 +14,7 @@
 #include <log_surgeon/types.hpp>
 
 #include <catch2/catch_test_macros.hpp>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 using log_surgeon::BufferParser;
 using log_surgeon::capture_id_t;

--- a/tests/test-schema.cpp
+++ b/tests/test-schema.cpp
@@ -6,7 +6,6 @@
 #include <log_surgeon/SchemaParser.hpp>
 
 #include <catch2/catch_test_macros.hpp>
-#include <fmt/core.h>
 
 /**
  * @defgroup unit_tests_schema Schema unit tests.


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

`CLP` is [bumping](https://github.com/y-scope/clp/pull/1263) fmtlib version to 11.2.0, so we need to do the same for log-surgeon to stay consistent across projects.

Bumps `fmtlib` version and cleans up fmt headers. In `11.2.0`:
- `fmt::format` should be brought in by `<fmt/format.h>`
- `fmt::join` should be brought in by `<fmt/ranges.h>`.
- `<fmt/core.h>` is obsolete.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [X] Unit tests pass and clang-tidy has no complaints.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded the formatting library to a newer version, improving build compatibility and stability.
  - Updated build configuration to require the newer dependency.
- Documentation
  - Revised Requirements to reflect the new minimum version of the formatting library.
- Tests
  - Adjusted test includes to align with the updated dependency.

No user-facing behaviour changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->