### PR TITLE
fix: Correctly collapse wildcards in `Query` constructor. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,8 @@ set(SOURCE_FILES
     src/log_surgeon/wildcard_query_parser/ExpressionCharacter.hpp
     src/log_surgeon/wildcard_query_parser/ExpressionView.cpp
     src/log_surgeon/wildcard_query_parser/ExpressionView.hpp
+    src/log_surgeon/wildcard_query_parser/Query.cpp
+    src/log_surgeon/wildcard_query_parser/Query.hpp
     src/log_surgeon/wildcard_query_parser/QueryInterpretation.cpp
     src/log_surgeon/wildcard_query_parser/QueryInterpretation.hpp
     src/log_surgeon/wildcard_query_parser/StaticQueryToken.hpp

--- a/docs/doxygen/mainpage.dox
+++ b/docs/doxygen/mainpage.dox
@@ -17,6 +17,7 @@
  * - @ref unit_tests_expression_view "Expression View"
  * - @ref unit_tests_nfa "NFA"
  * - @ref unit_tests_prefix_tree "Prefix tree"
+ * - @ref unit_tests_query "Query"
  * - @ref unit_tests_query_interpretation "Query Interpretation"
  * - @ref unit_tests_regex_ast "Regex AST"
  * - @ref unit_tests_register_handler "Register handler"

--- a/src/log_surgeon/Lexer.hpp
+++ b/src/log_surgeon/Lexer.hpp
@@ -152,6 +152,10 @@ public:
 
     [[nodiscard]] auto get_has_delimiters() const -> bool const& { return m_has_delimiters; }
 
+    [[nodiscard]] auto get_delim_table() const -> std::array<bool, cSizeOfByte> const& {
+        return m_is_delimiter;
+    }
+
     [[nodiscard]] auto is_delimiter(uint8_t byte) const -> bool const& {
         return m_is_delimiter[byte];
     }

--- a/src/log_surgeon/Lexer.hpp
+++ b/src/log_surgeon/Lexer.hpp
@@ -256,8 +256,10 @@ private:
     std::array<bool, cSizeOfByte> m_is_first_char_of_a_variable{false};
     std::vector<LexicalRule<TypedNfaState>> m_rules;
     uint32_t m_line{0};
-    // `m_has_delimiters` is cached for performance
+
+    // For performance, `m_has_delimiters` caches whether any element in `m_is_delimiter` is true.
     bool m_has_delimiters{false};
+
     std::unique_ptr<finite_automata::Dfa<TypedDfaState, TypedNfaState>> m_dfa;
     std::optional<uint32_t> m_first_delimiter_pos{std::nullopt};
     bool m_asked_for_more_data{false};

--- a/src/log_surgeon/Lexer.hpp
+++ b/src/log_surgeon/Lexer.hpp
@@ -256,6 +256,7 @@ private:
     std::array<bool, cSizeOfByte> m_is_first_char_of_a_variable{false};
     std::vector<LexicalRule<TypedNfaState>> m_rules;
     uint32_t m_line{0};
+    // `m_has_delimiters` is cached for performance
     bool m_has_delimiters{false};
     std::unique_ptr<finite_automata::Dfa<TypedDfaState, TypedNfaState>> m_dfa;
     std::optional<uint32_t> m_first_delimiter_pos{std::nullopt};

--- a/src/log_surgeon/wildcard_query_parser/Expression.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Expression.hpp
@@ -1,6 +1,7 @@
 #ifndef LOG_SURGEON_WILDCARD_QUERY_PARSER_EXPRESSION_HPP
 #define LOG_SURGEON_WILDCARD_QUERY_PARSER_EXPRESSION_HPP
 
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -23,6 +24,8 @@ public:
     }
 
     [[nodiscard]] auto get_search_string() const -> std::string const& { return m_search_string; }
+
+    [[nodiscard]] auto length() const -> size_t { return m_search_string.size(); }
 
 private:
     std::vector<ExpressionCharacter> m_chars;

--- a/src/log_surgeon/wildcard_query_parser/ExpressionCharacter.hpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionCharacter.hpp
@@ -16,9 +16,11 @@ public:
         Escape
     };
 
-    ExpressionCharacter(char const value, Type const type) : m_value{value}, m_type{type} {}
+    ExpressionCharacter(unsigned char const value, Type const type)
+            : m_value{value},
+              m_type{type} {}
 
-    [[nodiscard]] auto value() const -> char { return m_value; }
+    [[nodiscard]] auto value() const -> unsigned char { return m_value; }
 
     [[nodiscard]] auto is_greedy_wildcard() const -> bool { return Type::GreedyWildcard == m_type; }
 
@@ -42,7 +44,7 @@ public:
     [[nodiscard]] auto is_escape() const -> bool { return Type::Escape == m_type; }
 
 private:
-    char m_value;
+    unsigned char m_value;
     Type m_type;
 };
 }  // namespace log_surgeon::wildcard_query_parser

--- a/src/log_surgeon/wildcard_query_parser/ExpressionCharacter.hpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionCharacter.hpp
@@ -26,13 +26,17 @@ public:
         return Type::NonGreedyWildcard == m_type;
     }
 
+    [[nodiscard]] auto is_wildcard() const -> bool {
+        return Type::GreedyWildcard == m_type || Type::NonGreedyWildcard == m_type;
+    }
+
     [[nodiscard]] auto is_delim(std::array<bool, cSizeOfByte> const& delim_table) const -> bool {
         return delim_table.at(m_value);
     }
 
     [[nodiscard]] auto is_delim_or_wildcard(std::array<bool, cSizeOfByte> const& delim_table) const
             -> bool {
-        return is_greedy_wildcard() || is_non_greedy_wildcard() || is_delim(delim_table);
+        return is_delim(delim_table) || is_wildcard();
     }
 
     [[nodiscard]] auto is_escape() const -> bool { return Type::Escape == m_type; }

--- a/src/log_surgeon/wildcard_query_parser/ExpressionCharacter.hpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionCharacter.hpp
@@ -16,11 +16,9 @@ public:
         Escape
     };
 
-    ExpressionCharacter(unsigned char const value, Type const type)
-            : m_value{value},
-              m_type{type} {}
+    ExpressionCharacter(char const value, Type const type) : m_value{value}, m_type{type} {}
 
-    [[nodiscard]] auto value() const -> unsigned char { return m_value; }
+    [[nodiscard]] auto value() const -> char { return m_value; }
 
     [[nodiscard]] auto is_greedy_wildcard() const -> bool { return Type::GreedyWildcard == m_type; }
 
@@ -33,7 +31,7 @@ public:
     }
 
     [[nodiscard]] auto is_delim(std::array<bool, cSizeOfByte> const& delim_table) const -> bool {
-        return delim_table.at(m_value);
+        return delim_table.at(static_cast<uint8_t>(m_value));
     }
 
     [[nodiscard]] auto is_delim_or_wildcard(std::array<bool, cSizeOfByte> const& delim_table) const
@@ -44,7 +42,7 @@ public:
     [[nodiscard]] auto is_escape() const -> bool { return Type::Escape == m_type; }
 
 private:
-    unsigned char m_value;
+    char m_value;
     Type m_type;
 };
 }  // namespace log_surgeon::wildcard_query_parser

--- a/src/log_surgeon/wildcard_query_parser/ExpressionCharacter.hpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionCharacter.hpp
@@ -1,7 +1,10 @@
 #ifndef LOG_SURGEON_WILDCARD_QUERY_PARSER_EXPRESSION_CHARACTER_HPP
 #define LOG_SURGEON_WILDCARD_QUERY_PARSER_EXPRESSION_CHARACTER_HPP
 
+#include <array>
 #include <cstdint>
+
+#include <log_surgeon/Constants.hpp>
 
 namespace log_surgeon::wildcard_query_parser {
 class ExpressionCharacter {
@@ -21,6 +24,14 @@ public:
 
     [[nodiscard]] auto is_non_greedy_wildcard() const -> bool {
         return Type::NonGreedyWildcard == m_type;
+    }
+
+    [[nodiscard]] auto is_delim(std::array<bool, cSizeOfByte> const& delim_table) const -> bool {
+        return delim_table[m_value];
+    }
+
+    [[nodiscard]] auto is_delim_or_wildcard(std::array<bool, cSizeOfByte> const& delim_table) const -> bool {
+        return is_greedy_wildcard() || is_non_greedy_wildcard() || is_delim(delim_table);
     }
 
     [[nodiscard]] auto is_escape() const -> bool { return Type::Escape == m_type; }

--- a/src/log_surgeon/wildcard_query_parser/ExpressionCharacter.hpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionCharacter.hpp
@@ -27,7 +27,7 @@ public:
     }
 
     [[nodiscard]] auto is_delim(std::array<bool, cSizeOfByte> const& delim_table) const -> bool {
-        return delim_table[m_value];
+        return delim_table.at(m_value);
     }
 
     [[nodiscard]] auto is_delim_or_wildcard(std::array<bool, cSizeOfByte> const& delim_table) const

--- a/src/log_surgeon/wildcard_query_parser/ExpressionCharacter.hpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionCharacter.hpp
@@ -30,7 +30,8 @@ public:
         return delim_table[m_value];
     }
 
-    [[nodiscard]] auto is_delim_or_wildcard(std::array<bool, cSizeOfByte> const& delim_table) const -> bool {
+    [[nodiscard]] auto is_delim_or_wildcard(std::array<bool, cSizeOfByte> const& delim_table) const
+            -> bool {
         return is_greedy_wildcard() || is_non_greedy_wildcard() || is_delim(delim_table);
     }
 

--- a/src/log_surgeon/wildcard_query_parser/ExpressionView.cpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionView.cpp
@@ -56,7 +56,7 @@ auto ExpressionView::extend_to_adjacent_greedy_wildcards() const
         auto const& preceding_char{m_expression->get_chars()[begin_idx - 1]};
         auto const& first_char{m_chars[0]};
         has_left_boundary = preceding_char.is_delim_or_wildcard(delim_table)
-                || first_char.is_greedy_wildcard();
+                            || first_char.is_greedy_wildcard();
     }
 
     bool has_right_boundary{false};

--- a/src/log_surgeon/wildcard_query_parser/ExpressionView.cpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionView.cpp
@@ -44,7 +44,7 @@ auto ExpressionView::extend_to_adjacent_greedy_wildcards() const
     return {is_extended, wildcard_expression_view};
 }
 
-[[nodiscard]] auto ExpressionView::is_surrounded_by_delims_or_wildcards(
+auto ExpressionView::is_surrounded_by_delims_or_wildcards(
         std::array<bool, cSizeOfByte> const& delim_table
 ) const -> bool {
     auto const [begin_idx, end_idx]{get_indices()};
@@ -54,9 +54,8 @@ auto ExpressionView::extend_to_adjacent_greedy_wildcards() const
         has_left_boundary = true;
     } else {
         auto const& preceding_char{m_expression->get_chars()[begin_idx - 1]};
-        auto const& first_char{m_chars[0]};
         has_left_boundary = preceding_char.is_delim_or_wildcard(delim_table)
-                            || first_char.is_greedy_wildcard();
+                            || false == m_chars.empty() && m_chars[0].is_greedy_wildcard();
     }
 
     bool has_right_boundary{false};
@@ -70,8 +69,8 @@ auto ExpressionView::extend_to_adjacent_greedy_wildcards() const
         } else {
             has_right_boundary = succeeding_char.is_delim_or_wildcard(delim_table);
         }
-        auto const& last_char{m_chars.back()};
-        has_right_boundary = has_right_boundary || last_char.is_greedy_wildcard();
+        has_right_boundary = has_right_boundary
+                             || false == m_chars.empty() && m_chars.back().is_greedy_wildcard();
     }
 
     return has_left_boundary && has_right_boundary;

--- a/src/log_surgeon/wildcard_query_parser/ExpressionView.cpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionView.cpp
@@ -55,7 +55,7 @@ auto ExpressionView::is_surrounded_by_delims_or_wildcards(
     } else {
         auto const& preceding_char{m_expression->get_chars()[begin_idx - 1]};
         has_left_boundary = preceding_char.is_delim_or_wildcard(delim_table)
-                            || false == m_chars.empty() && m_chars[0].is_greedy_wildcard();
+                            || (false == m_chars.empty() && m_chars.front().is_greedy_wildcard());
     }
 
     bool has_right_boundary{false};
@@ -70,7 +70,7 @@ auto ExpressionView::is_surrounded_by_delims_or_wildcards(
             has_right_boundary = succeeding_char.is_delim_or_wildcard(delim_table);
         }
         has_right_boundary = has_right_boundary
-                             || false == m_chars.empty() && m_chars.back().is_greedy_wildcard();
+                             || (false == m_chars.empty() && m_chars.back().is_greedy_wildcard());
     }
 
     return has_left_boundary && has_right_boundary;

--- a/src/log_surgeon/wildcard_query_parser/ExpressionView.cpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionView.cpp
@@ -49,28 +49,32 @@ auto ExpressionView::extend_to_adjacent_greedy_wildcards() const
 ) const -> bool {
     auto const [begin_idx, end_idx]{get_indices()};
 
-    bool has_preceding{false};
+    bool has_left_boundary{false};
     if (0 == begin_idx) {
-        has_preceding = true;
+        has_left_boundary = true;
     } else {
         auto const& preceding_char{m_expression->get_chars()[begin_idx - 1]};
-        has_preceding = preceding_char.is_delim_or_wildcard(delim_table);
+        auto const& first_char{m_chars[0]};
+        has_left_boundary = preceding_char.is_delim_or_wildcard(delim_table)
+                || first_char.is_greedy_wildcard();
     }
 
-    bool has_succeeding{false};
+    bool has_right_boundary{false};
     if (m_expression->length() == end_idx) {
-        has_succeeding = true;
+        has_right_boundary = true;
     } else {
         auto const& succeeding_char{m_expression->get_chars()[end_idx]};
         if (succeeding_char.is_escape()) {
             auto const& logical_succeeding_char{m_expression->get_chars()[end_idx + 1]};
-            has_succeeding = logical_succeeding_char.is_delim_or_wildcard(delim_table);
+            has_right_boundary = logical_succeeding_char.is_delim_or_wildcard(delim_table);
         } else {
-            has_succeeding = succeeding_char.is_delim_or_wildcard(delim_table);
+            has_right_boundary = succeeding_char.is_delim_or_wildcard(delim_table);
         }
+        auto const& last_char{m_chars.back()};
+        has_right_boundary = has_right_boundary || last_char.is_greedy_wildcard();
     }
 
-    return has_preceding && has_succeeding;
+    return has_left_boundary && has_right_boundary;
 }
 
 auto ExpressionView::is_well_formed() const -> bool {

--- a/src/log_surgeon/wildcard_query_parser/ExpressionView.cpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionView.cpp
@@ -64,7 +64,7 @@ auto ExpressionView::is_surrounded_by_delims(std::array<bool, cSizeOfByte> const
         auto const& succeeding_char{m_expression->get_chars()[end_idx]};
         if (succeeding_char.is_escape()) {
             auto const& logical_succeeding_char{m_expression->get_chars()[end_idx + 1]};
-            has_right_boundary = logical_succeeding_char.is_delim_or_wildcard(delim_table);
+            has_right_boundary = logical_succeeding_char.is_delim(delim_table);
         } else {
             has_right_boundary = succeeding_char.is_delim_or_wildcard(delim_table);
         }

--- a/src/log_surgeon/wildcard_query_parser/ExpressionView.cpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionView.cpp
@@ -44,7 +44,7 @@ auto ExpressionView::extend_to_adjacent_greedy_wildcards() const
     return {is_extended, wildcard_expression_view};
 }
 
-auto ExpressionView::is_surrounded_by_delims_or_wildcards(
+auto ExpressionView::is_surrounded_by_delims(
         std::array<bool, cSizeOfByte> const& delim_table
 ) const -> bool {
     auto const [begin_idx, end_idx]{get_indices()};

--- a/src/log_surgeon/wildcard_query_parser/ExpressionView.cpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionView.cpp
@@ -44,7 +44,9 @@ auto ExpressionView::extend_to_adjacent_greedy_wildcards() const
     return {is_extended, wildcard_expression_view};
 }
 
-[[nodiscard]] auto ExpressionView::is_surrounded_by_delims_or_wildcards(std::array<bool, cSizeOfByte> const& delim_table) const -> bool {
+[[nodiscard]] auto ExpressionView::is_surrounded_by_delims_or_wildcards(
+        std::array<bool, cSizeOfByte> const& delim_table
+) const -> bool {
     auto const [begin_idx, end_idx]{get_indices()};
 
     bool has_preceding{false};
@@ -60,7 +62,7 @@ auto ExpressionView::extend_to_adjacent_greedy_wildcards() const
         has_succeeding = true;
     } else {
         auto const& succeeding_char{m_expression->get_chars()[end_idx]};
-        if(succeeding_char.is_escape()) {
+        if (succeeding_char.is_escape()) {
             auto const& logical_succeeding_char{m_expression->get_chars()[end_idx + 1]};
             has_succeeding = logical_succeeding_char.is_delim_or_wildcard(delim_table);
         } else {

--- a/src/log_surgeon/wildcard_query_parser/ExpressionView.cpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionView.cpp
@@ -44,9 +44,8 @@ auto ExpressionView::extend_to_adjacent_greedy_wildcards() const
     return {is_extended, wildcard_expression_view};
 }
 
-auto ExpressionView::is_surrounded_by_delims(
-        std::array<bool, cSizeOfByte> const& delim_table
-) const -> bool {
+auto ExpressionView::is_surrounded_by_delims(std::array<bool, cSizeOfByte> const& delim_table) const
+        -> bool {
     auto const [begin_idx, end_idx]{get_indices()};
 
     bool has_left_boundary{false};

--- a/src/log_surgeon/wildcard_query_parser/ExpressionView.cpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionView.cpp
@@ -63,8 +63,10 @@ auto ExpressionView::is_surrounded_by_delims(std::array<bool, cSizeOfByte> const
     } else {
         auto const& succeeding_char{m_expression->get_chars()[end_idx]};
         if (succeeding_char.is_escape()) {
-            auto const& logical_succeeding_char{m_expression->get_chars()[end_idx + 1]};
-            has_right_boundary = logical_succeeding_char.is_delim(delim_table);
+            if (m_expression->length() > end_idx + 1) {
+                auto const& logical_succeeding_char{m_expression->get_chars()[end_idx + 1]};
+                has_right_boundary = logical_succeeding_char.is_delim(delim_table);
+            }
         } else {
             has_right_boundary = succeeding_char.is_delim_or_wildcard(delim_table);
         }

--- a/src/log_surgeon/wildcard_query_parser/ExpressionView.hpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionView.hpp
@@ -53,12 +53,12 @@ public:
      *
      * Left boundary:
      * - The view is at the start of the expression, or
-     * - The first character is a greedy wildcard, or
+     * - The first character is a greedy wildcard (if non-empty), or
      * - Immediately left of the view is a delimiter or wildcard.
      *
      * Right boundary:
      * - The view is at the end of the expression, or
-     * - The last character is a greedy wildcard, or
+     * - The last character is a greedy wildcard (if non-empty), or
      * - Immediately right of the view is a delimiter or wildcard, or
      * - Immediately right of the view is an escape character and the character to its
      *   immediate right is a delimiter.

--- a/src/log_surgeon/wildcard_query_parser/ExpressionView.hpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionView.hpp
@@ -61,7 +61,7 @@ public:
      * @return true when both preceding and succeeding boundaries qualify; false otherwise.
      */
     [[nodiscard]] auto is_surrounded_by_delims_or_wildcards(
-        std::array<bool, cSizeOfByte> const& delim_table
+            std::array<bool, cSizeOfByte> const& delim_table
     ) const -> bool;
 
     /**

--- a/src/log_surgeon/wildcard_query_parser/ExpressionView.hpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionView.hpp
@@ -1,12 +1,14 @@
 #ifndef LOG_SURGEON_WILDCARD_QUERY_PARSER_EXPRESSION_VIEW_HPP
 #define LOG_SURGEON_WILDCARD_QUERY_PARSER_EXPRESSION_VIEW_HPP
 
+#include <array>
 #include <cstddef>
 #include <span>
 #include <string>
 #include <string_view>
 #include <utility>
 
+#include <log_surgeon/Constants.hpp>
 #include <log_surgeon/wildcard_query_parser/Expression.hpp>
 #include <log_surgeon/wildcard_query_parser/ExpressionCharacter.hpp>
 

--- a/src/log_surgeon/wildcard_query_parser/ExpressionView.hpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionView.hpp
@@ -61,7 +61,7 @@ public:
      * - The last character is a greedy wildcard, or
      * - Immediately right of the view is a delimiter or wildcard, or
      * - Immediately right of the view is an escape character and the character to its
-     * immediate right is a delimiter or wildcard.
+     *   immediate right is a delimiter.
      *
      * @param delim_table Table indicating for each character whether or not it is a delimiter.
      * @return true when both left and right boundaries qualify; false otherwise.

--- a/src/log_surgeon/wildcard_query_parser/ExpressionView.hpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionView.hpp
@@ -44,27 +44,29 @@ public:
     }
 
     /**
-     * Checks whether the view is surrounded by delimiters or wildcards.
+     * Checks whether the view is surrounded by delimiters. The start and end of an expression are
+     * always considered a delimiter. A greedy wildcard may represent a string that includes a
+     * flanking delimiter.
      *
-     * An expression is considered surrounded if both its left and right boundary satisfy certain
+     * A view is considered bounded if both its left and right boundary satisfy certain
      * requirements.
      *
      * Left boundary:
      * - The view is at the start of the expression, or
      * - The first character is a greedy wildcard, or
-     * - The character immediately left of the view is a delimiter or wildcard.
+     * - Immediately left of the view is a delimiter or wildcard.
      *
      * Right boundary:
      * - The view is at the end of the expression, or
      * - The last character is a greedy wildcard, or
-     * - The character immediately right of the view is a delimiter or wildcard, or
-     * - The character immediately right of the view is an escape character and the character to its
+     * - Immediately right of the view is a delimiter or wildcard, or
+     * - Immediately right of the view is an escape character and the character to its
      * immediate right is a delimiter or wildcard.
      *
      * @param delim_table Table indicating for each character whether or not it is a delimiter.
-     * @return true when both preceding and succeeding boundaries qualify; false otherwise.
+     * @return true when both left and right boundaries qualify; false otherwise.
      */
-    [[nodiscard]] auto is_surrounded_by_delims_or_wildcards(
+    [[nodiscard]] auto is_surrounded_by_delims(
             std::array<bool, cSizeOfByte> const& delim_table
     ) const -> bool;
 

--- a/src/log_surgeon/wildcard_query_parser/ExpressionView.hpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionView.hpp
@@ -51,10 +51,12 @@ public:
      *
      * Left boundary:
      * - The view is at the start of the expression, or
+     * - The first character is a greedy wildcard, or
      * - The character immediately left of the view is a delimiter or wildcard.
      *
      * Right boundary:
      * - The view is at the end of the expression, or
+     * - The last character is a greedy wildcard, or
      * - The character immediately right of the view is a delimiter or wildcard, or
      * - The character immediately right of the view is an escape character and the character to its
      * immediate right is a delimiter or wildcard.

--- a/src/log_surgeon/wildcard_query_parser/ExpressionView.hpp
+++ b/src/log_surgeon/wildcard_query_parser/ExpressionView.hpp
@@ -42,6 +42,29 @@ public:
     }
 
     /**
+     * Checks whether the view is surrounded by delimiters or wildcards.
+     *
+     * An expression is considered surrounded if both its left and right boundary satisfy certain
+     * requirements.
+     *
+     * Left boundary:
+     * - The view is at the start of the expression, or
+     * - The character immediately left of the view is a delimiter or wildcard.
+     *
+     * Right boundary:
+     * - The view is at the end of the expression, or
+     * - The character immediately right of the view is a delimiter or wildcard, or
+     * - The character immediately right of the view is an escape character and the character to its
+     * immediate right is a delimiter or wildcard.
+     *
+     * @param delim_table Table indicating for each character whether or not it is a delimiter.
+     * @return true when both preceding and succeeding boundaries qualify; false otherwise.
+     */
+    [[nodiscard]] auto is_surrounded_by_delims_or_wildcards(
+        std::array<bool, cSizeOfByte> const& delim_table
+    ) const -> bool;
+
+    /**
      * Checks whether this `ExpressionView` represents a well-formed subrange.
      *
      * A subrange is well-formed if:

--- a/src/log_surgeon/wildcard_query_parser/Query.cpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.cpp
@@ -168,12 +168,9 @@ auto Query::get_matching_variable_types(string const& regex_string, ByteLexer co
     auto& rule_ast = dynamic_cast<SchemaVarAST&>(*schema_ast->m_schema_vars[0]);
     vector<ByteLexicalRule> rules;
     rules.emplace_back(0, std::move(rule_ast.m_regex_ptr));
-    // TODO: Optimize NFA creation.
     ByteNfa const nfa{rules};
-    // TODO: Optimize DFA creation.
     ByteDfa const dfa{nfa};
 
-    // TODO: Could optimize to use a forward/reverse lexer in a lot of cases.
     auto var_types = lexer.get_dfa()->get_intersect(&dfa);
     return var_types;
 }

--- a/src/log_surgeon/wildcard_query_parser/Query.cpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.cpp
@@ -77,13 +77,12 @@ Query::Query(string const& query_string) {
 
 auto Query::get_all_multi_token_interpretations(ByteLexer const& lexer) const
         -> std::set<QueryInterpretation> {
-    Expression const expression{m_processed_query_string};
-    vector<set<QueryInterpretation>> query_interpretations(expression.length());
-
     if (m_processed_query_string.empty()) {
         return {};
     }
 
+    Expression const expression{m_processed_query_string};
+    vector<set<QueryInterpretation>> query_interpretations(expression.length());
     for (size_t end_idx = 1; end_idx <= expression.length(); ++end_idx) {
         for (size_t begin_idx = 0; begin_idx < end_idx; ++begin_idx) {
             ExpressionView const expression_view{expression, begin_idx, end_idx};

--- a/src/log_surgeon/wildcard_query_parser/Query.cpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.cpp
@@ -34,7 +34,9 @@ using ByteNfa = log_surgeon::finite_automata::Nfa<ByteNfaState>;
 
 namespace log_surgeon::wildcard_query_parser {
 Query::Query(string const& query_string) {
+    m_query_string.reserve(query_string.size());
     Expression const expression(query_string);
+
     bool prev_is_escape{false};
     string unhandled_wildcard_sequence;
     bool unhandled_wildcard_sequence_contains_greedy_wildcard{false};

--- a/src/log_surgeon/wildcard_query_parser/Query.cpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.cpp
@@ -35,7 +35,8 @@ Query::Query(string const& query_string) {
     bool unhandled_wildcard_sequence_contains_greedy_wildcard{false};
     for (auto c : expression.get_chars()) {
         if (false == unhandled_wildcard_sequence.empty() && false == c.is_greedy_wildcard()
-            && false == c.is_non_greedy_wildcard()) {
+            && false == c.is_non_greedy_wildcard())
+        {
             if (unhandled_wildcard_sequence_contains_greedy_wildcard) {
                 m_query_string.push_back('*');
             } else {

--- a/src/log_surgeon/wildcard_query_parser/Query.cpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.cpp
@@ -86,7 +86,8 @@ auto Query::get_all_multi_token_interpretations(ByteLexer const& lexer) const
         for (size_t begin_idx = 0; begin_idx < end_idx; ++begin_idx) {
             ExpressionView const expression_view{expression, begin_idx, end_idx};
             if ("*" != expression_view.get_search_string()
-                && expression_view.starts_or_ends_with_greedy_wildcard()) {
+                && expression_view.starts_or_ends_with_greedy_wildcard())
+            {
                 continue;
             }
 

--- a/src/log_surgeon/wildcard_query_parser/Query.cpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.cpp
@@ -1,8 +1,11 @@
 #include "Query.hpp"
 
+#include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <log_surgeon/finite_automata/Dfa.hpp>
@@ -11,7 +14,9 @@
 #include <log_surgeon/finite_automata/NfaState.hpp>
 #include <log_surgeon/Lexer.hpp>
 #include <log_surgeon/LexicalRule.hpp>
+#include <log_surgeon/parser_types.hpp>
 #include <log_surgeon/Schema.hpp>
+#include <log_surgeon/SchemaParser.hpp>
 #include <log_surgeon/wildcard_query_parser/Expression.hpp>
 #include <log_surgeon/wildcard_query_parser/ExpressionView.hpp>
 #include <log_surgeon/wildcard_query_parser/QueryInterpretation.hpp>
@@ -77,7 +82,7 @@ auto Query::get_all_multi_token_interpretations(ByteLexer const& lexer) const
 
     for (size_t end_idx = 1; end_idx <= expression.length(); ++end_idx) {
         for (size_t begin_idx = 0; begin_idx < end_idx; ++begin_idx) {
-            ExpressionView expression_view{expression, begin_idx, end_idx};
+            ExpressionView const expression_view{expression, begin_idx, end_idx};
             if (expression_view.starts_or_ends_with_greedy_wildcard()) {
                 continue;
             }
@@ -97,7 +102,7 @@ auto Query::get_all_multi_token_interpretations(ByteLexer const& lexer) const
                 );
             } else {
                 for (auto const& prefix : query_interpretations[begin_idx - 1]) {
-                    for (auto& suffix : single_token_interpretations) {
+                    for (auto const& suffix : single_token_interpretations) {
                         QueryInterpretation combined{prefix};
                         combined.append_query_interpretation(suffix);
                         query_interpretations[end_idx - 1].insert(std::move(combined));

--- a/src/log_surgeon/wildcard_query_parser/Query.cpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.cpp
@@ -1,0 +1,166 @@
+#include "Query.hpp"
+
+#include <cstdint>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <log_surgeon/finite_automata/Dfa.hpp>
+#include <log_surgeon/finite_automata/DfaState.hpp>
+#include <log_surgeon/finite_automata/Nfa.hpp>
+#include <log_surgeon/finite_automata/NfaState.hpp>
+#include <log_surgeon/Lexer.hpp>
+#include <log_surgeon/LexicalRule.hpp>
+#include <log_surgeon/Schema.hpp>
+#include <log_surgeon/wildcard_query_parser/Expression.hpp>
+#include <log_surgeon/wildcard_query_parser/ExpressionView.hpp>
+#include <log_surgeon/wildcard_query_parser/QueryInterpretation.hpp>
+
+using log_surgeon::finite_automata::ByteDfaState;
+using log_surgeon::finite_automata::ByteNfaState;
+using log_surgeon::lexers::ByteLexer;
+using std::set;
+using std::string;
+using std::vector;
+
+using ByteDfa = log_surgeon::finite_automata::Dfa<ByteDfaState, ByteNfaState>;
+using ByteLexicalRule = log_surgeon::LexicalRule<ByteNfaState>;
+using ByteNfa = log_surgeon::finite_automata::Nfa<ByteNfaState>;
+
+namespace log_surgeon::wildcard_query_parser {
+
+Query::Query(string const& query_string) {
+    Expression const expression(query_string);
+    bool prev_is_escape{false};
+    string unhandled_wildcard_sequence;
+    bool unhandled_wildcard_sequence_contains_greedy_wildcard{false};
+    for(auto c : expression.get_chars()) {
+        if(false == unhandled_wildcard_sequence.empty() && false == c.is_greedy_wildcard() &&
+          false == c.is_non_greedy_wildcard()) {
+            if (unhandled_wildcard_sequence_contains_greedy_wildcard) {
+               m_query_string.push_back('*');
+            } else {
+                m_query_string += unhandled_wildcard_sequence;
+            }
+            unhandled_wildcard_sequence.clear();
+            unhandled_wildcard_sequence_contains_greedy_wildcard = false;
+        }
+
+        if(prev_is_escape) {
+            m_query_string.push_back(c.value());
+            prev_is_escape = false;
+        } else if(c.is_escape()) {
+            prev_is_escape = true;
+            m_query_string.push_back(c.value());
+        } else if(c.is_greedy_wildcard()) {
+            unhandled_wildcard_sequence.push_back(c.value());
+            unhandled_wildcard_sequence_contains_greedy_wildcard = true;
+        } else if (c.is_non_greedy_wildcard()) {
+            unhandled_wildcard_sequence.push_back(c.value());
+        } else {
+            m_query_string.push_back(c.value());
+        }
+    }
+    if (false == unhandled_wildcard_sequence.empty()) {
+        if (unhandled_wildcard_sequence_contains_greedy_wildcard) {
+            m_query_string.push_back('*');
+        } else {
+            m_query_string += unhandled_wildcard_sequence;
+        }
+    }
+}
+
+auto Query::get_all_multi_token_interpretations(ByteLexer const& lexer) const -> std::set<QueryInterpretation> {
+    Expression const expression{m_query_string};
+    vector<set<QueryInterpretation>> query_interpretations(expression.length());
+
+    for (size_t end_idx = 1; end_idx <= expression.length(); ++end_idx) {
+        for (size_t begin_idx = 0; begin_idx < end_idx; ++begin_idx) {
+            ExpressionView expression_view{expression, begin_idx, end_idx};
+            if (expression_view.starts_or_ends_with_greedy_wildcard()) {
+                continue;
+            }
+
+            auto const extended_view{
+                expression_view.extend_to_adjacent_greedy_wildcards().second
+            };
+            auto const single_token_interpretations{
+                get_all_single_token_interpretations(extended_view, lexer)
+            };
+            if(single_token_interpretations.empty()) {
+                continue;
+            }
+
+            if (begin_idx == 0) {
+                query_interpretations[end_idx - 1].insert(
+                    std::make_move_iterator(single_token_interpretations.begin()),
+                    std::make_move_iterator(single_token_interpretations.end())
+                );
+            } else {
+                for (auto const& prefix : query_interpretations[begin_idx - 1]) {
+                    for (auto& suffix : single_token_interpretations) {
+                        QueryInterpretation combined{prefix};
+                        combined.append_query_interpretation(suffix);
+                        query_interpretations[end_idx - 1].insert(std::move(combined));
+                    }
+                }
+            }
+        }
+    }
+    return query_interpretations.back();
+}
+
+auto Query::get_all_single_token_interpretations(ExpressionView const& expression_view, ByteLexer const& lexer) -> std::vector<QueryInterpretation> {
+    vector<QueryInterpretation> interpretations;
+
+    if (false == expression_view.is_well_formed()) {
+        return interpretations;
+    }
+    if ("*" == expression_view.get_search_string()) {
+        interpretations.emplace_back("*");
+        return interpretations;
+    }
+    if (false == expression_view.is_surrounded_by_delims_or_wildcards(lexer.get_delim_table())) {
+        interpretations.emplace_back(string{expression_view.get_search_string()});
+        return interpretations;
+    }
+
+    auto const [regex_string, contains_wildcard]{expression_view.generate_regex_string()};
+
+    auto const matching_var_type_ids{get_matching_variable_types(regex_string, lexer)};
+    if (matching_var_type_ids.empty() || contains_wildcard) {
+        interpretations.emplace_back(string{expression_view.get_search_string()});
+    }
+
+    for (auto const variable_type_id : matching_var_type_ids) {
+        interpretations.emplace_back(
+                variable_type_id,
+                string{expression_view.get_search_string()},
+                contains_wildcard
+        );
+        if (false == contains_wildcard) {
+            break;
+        }
+    }
+    return interpretations;
+}
+
+auto Query::get_matching_variable_types(string const& regex_string, ByteLexer const& lexer) -> set<uint32_t> {
+    NonTerminal::m_next_children_start = 0;
+
+    Schema schema;
+    schema.add_variable("search:" + regex_string, -1);
+    auto const schema_ast = schema.release_schema_ast_ptr();
+    auto& rule_ast = dynamic_cast<SchemaVarAST&>(*schema_ast->m_schema_vars[0]);
+    vector<ByteLexicalRule> rules;
+    rules.emplace_back(0, std::move(rule_ast.m_regex_ptr));
+    // TODO: Optimize NFA creation.
+    ByteNfa const nfa{rules};
+    // TODO: Optimize DFA creation.
+    ByteDfa const dfa{nfa};
+
+    // TODO: Could optimize to use a forward/reverse lexer in a lot of cases.
+    auto var_types = lexer.get_dfa()->get_intersect(&dfa);
+    return var_types;
+}
+}  // namespace log_surgeon::wildcard_query_parser

--- a/src/log_surgeon/wildcard_query_parser/Query.cpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.cpp
@@ -34,7 +34,7 @@ using ByteNfa = log_surgeon::finite_automata::Nfa<ByteNfaState>;
 
 namespace log_surgeon::wildcard_query_parser {
 Query::Query(string const& query_string) {
-    m_query_string.reserve(query_string.size());
+    m_processed_query_string.reserve(query_string.size());
     Expression const expression(query_string);
 
     bool prev_is_escape{false};
@@ -43,44 +43,44 @@ Query::Query(string const& query_string) {
     for (auto c : expression.get_chars()) {
         if (false == unhandled_wildcard_sequence.empty() && false == c.is_wildcard()) {
             if (unhandled_wildcard_sequence_contains_greedy_wildcard) {
-                m_query_string.push_back('*');
+                m_processed_query_string.push_back('*');
             } else {
-                m_query_string += unhandled_wildcard_sequence;
+                m_processed_query_string += unhandled_wildcard_sequence;
             }
             unhandled_wildcard_sequence.clear();
             unhandled_wildcard_sequence_contains_greedy_wildcard = false;
         }
 
         if (prev_is_escape) {
-            m_query_string.push_back(c.value());
+            m_processed_query_string.push_back(c.value());
             prev_is_escape = false;
         } else if (c.is_escape()) {
             prev_is_escape = true;
-            m_query_string.push_back(c.value());
+            m_processed_query_string.push_back(c.value());
         } else if (c.is_greedy_wildcard()) {
             unhandled_wildcard_sequence.push_back(c.value());
             unhandled_wildcard_sequence_contains_greedy_wildcard = true;
         } else if (c.is_non_greedy_wildcard()) {
             unhandled_wildcard_sequence.push_back(c.value());
         } else {
-            m_query_string.push_back(c.value());
+            m_processed_query_string.push_back(c.value());
         }
     }
     if (false == unhandled_wildcard_sequence.empty()) {
         if (unhandled_wildcard_sequence_contains_greedy_wildcard) {
-            m_query_string.push_back('*');
+            m_processed_query_string.push_back('*');
         } else {
-            m_query_string += unhandled_wildcard_sequence;
+            m_processed_query_string += unhandled_wildcard_sequence;
         }
     }
 }
 
 auto Query::get_all_multi_token_interpretations(ByteLexer const& lexer) const
         -> std::set<QueryInterpretation> {
-    Expression const expression{m_query_string};
+    Expression const expression{m_processed_query_string};
     vector<set<QueryInterpretation>> query_interpretations(expression.length());
 
-    if (m_query_string.empty()) {
+    if (m_processed_query_string.empty()) {
         return {};
     }
 

--- a/src/log_surgeon/wildcard_query_parser/Query.cpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.cpp
@@ -28,17 +28,16 @@ using ByteLexicalRule = log_surgeon::LexicalRule<ByteNfaState>;
 using ByteNfa = log_surgeon::finite_automata::Nfa<ByteNfaState>;
 
 namespace log_surgeon::wildcard_query_parser {
-
 Query::Query(string const& query_string) {
     Expression const expression(query_string);
     bool prev_is_escape{false};
     string unhandled_wildcard_sequence;
     bool unhandled_wildcard_sequence_contains_greedy_wildcard{false};
-    for(auto c : expression.get_chars()) {
-        if(false == unhandled_wildcard_sequence.empty() && false == c.is_greedy_wildcard() &&
+    for (auto c : expression.get_chars()) {
+        if (false == unhandled_wildcard_sequence.empty() && false == c.is_greedy_wildcard() &&
           false == c.is_non_greedy_wildcard()) {
             if (unhandled_wildcard_sequence_contains_greedy_wildcard) {
-               m_query_string.push_back('*');
+                m_query_string.push_back('*');
             } else {
                 m_query_string += unhandled_wildcard_sequence;
             }
@@ -46,13 +45,13 @@ Query::Query(string const& query_string) {
             unhandled_wildcard_sequence_contains_greedy_wildcard = false;
         }
 
-        if(prev_is_escape) {
+        if (prev_is_escape) {
             m_query_string.push_back(c.value());
             prev_is_escape = false;
-        } else if(c.is_escape()) {
+        } else if (c.is_escape()) {
             prev_is_escape = true;
             m_query_string.push_back(c.value());
-        } else if(c.is_greedy_wildcard()) {
+        } else if (c.is_greedy_wildcard()) {
             unhandled_wildcard_sequence.push_back(c.value());
             unhandled_wildcard_sequence_contains_greedy_wildcard = true;
         } else if (c.is_non_greedy_wildcard()) {
@@ -70,7 +69,8 @@ Query::Query(string const& query_string) {
     }
 }
 
-auto Query::get_all_multi_token_interpretations(ByteLexer const& lexer) const -> std::set<QueryInterpretation> {
+auto Query::get_all_multi_token_interpretations(ByteLexer const& lexer) const
+        -> std::set<QueryInterpretation> {
     Expression const expression{m_query_string};
     vector<set<QueryInterpretation>> query_interpretations(expression.length());
 
@@ -81,20 +81,18 @@ auto Query::get_all_multi_token_interpretations(ByteLexer const& lexer) const ->
                 continue;
             }
 
-            auto const extended_view{
-                expression_view.extend_to_adjacent_greedy_wildcards().second
-            };
+            auto const extended_view{expression_view.extend_to_adjacent_greedy_wildcards().second};
             auto const single_token_interpretations{
-                get_all_single_token_interpretations(extended_view, lexer)
+                    get_all_single_token_interpretations(extended_view, lexer)
             };
-            if(single_token_interpretations.empty()) {
+            if (single_token_interpretations.empty()) {
                 continue;
             }
 
             if (begin_idx == 0) {
                 query_interpretations[end_idx - 1].insert(
-                    std::make_move_iterator(single_token_interpretations.begin()),
-                    std::make_move_iterator(single_token_interpretations.end())
+                        std::make_move_iterator(single_token_interpretations.begin()),
+                        std::make_move_iterator(single_token_interpretations.end())
                 );
             } else {
                 for (auto const& prefix : query_interpretations[begin_idx - 1]) {
@@ -110,7 +108,10 @@ auto Query::get_all_multi_token_interpretations(ByteLexer const& lexer) const ->
     return query_interpretations.back();
 }
 
-auto Query::get_all_single_token_interpretations(ExpressionView const& expression_view, ByteLexer const& lexer) -> std::vector<QueryInterpretation> {
+auto Query::get_all_single_token_interpretations(
+        ExpressionView const& expression_view,
+        ByteLexer const& lexer
+) -> std::vector<QueryInterpretation> {
     vector<QueryInterpretation> interpretations;
 
     if (false == expression_view.is_well_formed()) {
@@ -145,7 +146,8 @@ auto Query::get_all_single_token_interpretations(ExpressionView const& expressio
     return interpretations;
 }
 
-auto Query::get_matching_variable_types(string const& regex_string, ByteLexer const& lexer) -> set<uint32_t> {
+auto Query::get_matching_variable_types(string const& regex_string, ByteLexer const& lexer)
+        -> set<uint32_t> {
     NonTerminal::m_next_children_start = 0;
 
     Schema schema;

--- a/src/log_surgeon/wildcard_query_parser/Query.cpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.cpp
@@ -133,7 +133,7 @@ auto Query::get_all_single_token_interpretations(
         interpretations.emplace_back("*");
         return interpretations;
     }
-    if (false == expression_view.is_surrounded_by_delims_or_wildcards(lexer.get_delim_table())) {
+    if (false == expression_view.is_surrounded_by_delims(lexer.get_delim_table())) {
         interpretations.emplace_back(string{expression_view.get_search_string()});
         return interpretations;
     }

--- a/src/log_surgeon/wildcard_query_parser/Query.cpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.cpp
@@ -34,8 +34,8 @@ Query::Query(string const& query_string) {
     string unhandled_wildcard_sequence;
     bool unhandled_wildcard_sequence_contains_greedy_wildcard{false};
     for (auto c : expression.get_chars()) {
-        if (false == unhandled_wildcard_sequence.empty() && false == c.is_greedy_wildcard() &&
-          false == c.is_non_greedy_wildcard()) {
+        if (false == unhandled_wildcard_sequence.empty() && false == c.is_greedy_wildcard()
+            && false == c.is_non_greedy_wildcard()) {
             if (unhandled_wildcard_sequence_contains_greedy_wildcard) {
                 m_query_string.push_back('*');
             } else {

--- a/src/log_surgeon/wildcard_query_parser/Query.cpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.cpp
@@ -39,9 +39,7 @@ Query::Query(string const& query_string) {
     string unhandled_wildcard_sequence;
     bool unhandled_wildcard_sequence_contains_greedy_wildcard{false};
     for (auto c : expression.get_chars()) {
-        if (false == unhandled_wildcard_sequence.empty() && false == c.is_greedy_wildcard()
-            && false == c.is_non_greedy_wildcard())
-        {
+        if (false == unhandled_wildcard_sequence.empty() && false == c.is_wildcard()) {
             if (unhandled_wildcard_sequence_contains_greedy_wildcard) {
                 m_query_string.push_back('*');
             } else {
@@ -80,10 +78,15 @@ auto Query::get_all_multi_token_interpretations(ByteLexer const& lexer) const
     Expression const expression{m_query_string};
     vector<set<QueryInterpretation>> query_interpretations(expression.length());
 
+    if (m_query_string.empty()) {
+        return {};
+    }
+
     for (size_t end_idx = 1; end_idx <= expression.length(); ++end_idx) {
         for (size_t begin_idx = 0; begin_idx < end_idx; ++begin_idx) {
             ExpressionView const expression_view{expression, begin_idx, end_idx};
-            if (expression_view.starts_or_ends_with_greedy_wildcard()) {
+            if ("*" != expression_view.get_search_string()
+                && expression_view.starts_or_ends_with_greedy_wildcard()) {
                 continue;
             }
 

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -25,7 +25,7 @@ public:
      *
      *    - Substrings adjacent to greedy wildcards must be interpreted as if they include them.
      *      - Example: query "a*b" is equivalent to "a***b". For a lexer with a `hasNum` variable
-     *        type ("\w*\d*\w*"), without extensions, the only interpretations would be:
+     *        type ("\w*\d+\w*"), without extensions, the only interpretations would be:
      *          {<static>(a*b)},
      *          {<hasNum>(a*) <static>(b)},
      *          {<static>(a) <hasNum>(*b)}.
@@ -40,7 +40,8 @@ public:
      *    - Substrings that begin or end with a wildcard are skipped as they are redundant.
      *      - Example: in "a*b", substring (0,1] extends to "a*", therefore substring (0,2] "a*" is
      *        redundant. In other words, a decomposition like "a*" + "b"  is a subset of the more
-     *        general "a*" + "*" + "*b".
+     *        general "a*" + "*" + "*b".  However, an isolated "*" must not be skipped as it is not
+     *        captured by any other substring extension.
      *
      * 2. Let I(a) be the set of all multi-length interpretations of substring [0,a).
      *    - We can compute I(a) recursively using previously computed sets:
@@ -71,6 +72,10 @@ public:
      */
     [[nodiscard]] auto get_all_multi_token_interpretations(lexers::ByteLexer const& lexer) const
             -> std::set<QueryInterpretation>;
+
+    [[nodiscard]] auto get_processed_query_string() const -> std::string {
+        return m_query_string;
+    }
 
 private:
     /**

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -29,11 +29,11 @@ public:
      *          {<static>(a*b)},
      *          {<hasNum>(a*) <static>(b)},
      *          {<static>(a) <hasNum>(*b)}.
-     *        However, a string like "a1 abc 1b" is also matched by "a*b", and  requires the
+     *        However, a string like "a1 abc 1b" is also matched by "a*b", and requires the
      *        interpretation {<hasNum>(a*) <static>(*) <hasNum>(*b)}. Extension ensures such cases
      *        are captured.
-     *      - Note: isolated greedy wildcard (`*`) are never extended as the `Query` collapses
-     *        repeated greedy wildcards.
+     *      - Note: isolated greedy wildcards (`*`) are never extended as the `Query` collapses
+     *        repeated greedy wildcards during preprocessing.
      *      - Note: non-greedy wildcards (`?`) are not extended as "a?b" is not equivalent to
      *        "a??b".
      *

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -72,7 +72,9 @@ public:
     [[nodiscard]] auto get_all_multi_token_interpretations(lexers::ByteLexer const& lexer) const
             -> std::set<QueryInterpretation>;
 
-    [[nodiscard]] auto get_processed_query_string() const -> std::string { return m_query_string; }
+    [[nodiscard]] auto get_processed_query_string() const -> std::string const& {
+        return m_query_string;
+    }
 
 private:
     /**

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -93,9 +93,9 @@ private:
      *   - Is an isolated greedy wildcard, "*", or
      *   - Is not surrounded by delimiters or wildcards (lexer won't consider it a variable), or
      *   - Does not match any variable.
-     * - Then:
-     *   - The only interpretation is a static token.
-     * - Else, if the substring contains a wildcard:
+     *   - Then:
+     *     - The only interpretation is a static token.
+     * - Else if the substring contains a wildcard:
      *   - The interpretations include a static token, plus a variable token for each matching type.
      * - Else:
      *   - The only interpretation is the variable token corresponding to the highest priority

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -57,7 +57,7 @@ public:
      *
      * 3. Use dynamic programming to compute I(n) efficiently:
      *    - Instead of generating all possible combinations naively, we store only unique
-     *      interpretations by recurisvely building up the combinations as shown below.
+     *      interpretations by recursively building up the combinations as shown below.
      *    - Compute I(n) iteratively in increasing order of substring length:
      *      - Compute T(0,1), then I(1)
      *      - Compute T(0,2), T(1,2), then I(2)

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -20,9 +20,6 @@ public:
      * interpretations of the query string belong to this set):
      *
      * 1. Interpret each substring [a,b) as a single token (1-length interpretation).
-     *    - Denote T(a,b) to be the set of all valid single-token interpretations of substring
-     *      [a,b).
-     *
      *    - Substrings adjacent to greedy wildcards must be interpreted as if they include them.
      *      - Example: query "a*b" is equivalent to "a***b". For a lexer with a `hasNum` variable
      *        type ("\w*\d+\w*"), without extensions, the only interpretations would be:
@@ -44,13 +41,14 @@ public:
      *        captured by any other substring extension.
      *
      * 2. Let I(a) be the set of all multi-length interpretations of substring [0,a).
-     *    - We can compute I(a) recursively using previously computed sets:
+     *    - Let T(a,b) to be the set of all valid single-token interpretations of substring [a,b).
+     *    - We can then compute I(a) recursively:
      *
-     *      I(a) = T(0,a)
-     *             U (I(1) x T(1,a))
-     *             U (I(2) x T(2,a))
-     *             ...
-     *             U (I(a-1) x T(a-1,a))
+     *        I(a) = T(0,a)
+     *               U (I(1) x T(1,a))
+     *               U (I(2) x T(2,a))
+     *               ...
+     *               U (I(a-1) x T(a-1,a))
      *
      *      where x denotes the cross product: all combinations of prefix interpretations from I(i)
      *      and suffix interpretations from T(i,a).

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -73,9 +73,7 @@ public:
     [[nodiscard]] auto get_all_multi_token_interpretations(lexers::ByteLexer const& lexer) const
             -> std::set<QueryInterpretation>;
 
-    [[nodiscard]] auto get_processed_query_string() const -> std::string {
-        return m_query_string;
-    }
+    [[nodiscard]] auto get_processed_query_string() const -> std::string { return m_query_string; }
 
 private:
     /**

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -73,7 +73,7 @@ public:
             -> std::set<QueryInterpretation>;
 
     [[nodiscard]] auto get_processed_query_string() const -> std::string const& {
-        return m_query_string;
+        return m_processed_query_string;
     }
 
 private:
@@ -125,7 +125,7 @@ private:
     get_matching_variable_types(std::string const& regex_string, lexers::ByteLexer const& lexer)
             -> std::set<uint32_t>;
 
-    std::string m_query_string;
+    std::string m_processed_query_string;
 };
 }  // namespace log_surgeon::wildcard_query_parser
 

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -21,7 +21,8 @@ public:
      * interpretations of the query string belong to this set):
      *
      * 1. Interpret each substring [a,b) as a single token (1-length interpretation).
-     *    - Denote T(a,b) to be the set of all valid single-token interpretations of substring [a,b).
+     *    - Denote T(a,b) to be the set of all valid single-token interpretations of substring
+     *      [a,b).
      *
      *    - Substrings adjacent to greedy wildcards must be interpreted as if they include them.
      *      - Example: query "a*b" is equivalent to "a***b". For a lexer with a `hasNum` variable
@@ -34,7 +35,8 @@ public:
      *        are captured.
      *      - Note: isolated greedy wildcard (`*`) are never extended as the `Query` collapses
      *        repeated greedy wildcards.
-     *      - Note: non-greedy wildcards (`?`) are not extended as "a?b" is not equivalent to "a??b".
+     *      - Note: non-greedy wildcards (`?`) are not extended as "a?b" is not equivalent to
+     *        "a??b".
      *
      *    - Substrings that begin or end with a wildcard are skipped as they are redundant.
      *      - Example: in "a*b", substring (0,1] extends to "a*", therefore substring (0,2] "a*" is
@@ -73,7 +75,8 @@ public:
 
 private:
     /**
-     * Generates all single-token interpretations for a given expression view matching a given lexer.
+     * Generates all single-token interpretations for a given expression view matching a given
+     * lexer.
      *
      * A single-token interpretation can be one of:
      * - A static token (literal text).
@@ -92,7 +95,8 @@ private:
      * - Else, if the substring contains a wildcard:
      *   - The interpretations include a static token, plus a variable token for each matching type.
      * - Else:
-     *   - The only interpretation is the variable token corresponding to the highest priority match.
+     *   - The only interpretation is the variable token corresponding to the highest priority
+     *     match.
      *
      * @param expression_view The view of the substring to interpret.
      * @param lexer The lexer used to determine variable types and delimiters.

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -1,0 +1,119 @@
+#ifndef LOG_SURGEON_WILDCARD_QUERY_PARSER_QUERY_HPP
+#define LOG_SURGEON_WILDCARD_QUERY_PARSER_QUERY_HPP
+
+#include <cstdint>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <log_surgeon/Lexer.hpp>
+#include <log_surgeon/Schema.hpp>
+#include <log_surgeon/wildcard_query_parser/ExpressionView.hpp>
+#include <log_surgeon/wildcard_query_parser/QueryInterpretation.hpp>
+
+namespace log_surgeon::wildcard_query_parser {
+class Query {
+public:
+    explicit Query(std::string const& query_string);
+
+   /**
+    * Generates all multi-token interpretations of the n-length query string (single-token
+    * interpretations of the query string belong to this set):
+    *
+    * 1. Interpret each substring [a,b) as a single token (1-length interpretation).
+    *    - Denote T(a,b) to be the set of all valid single-token interpretations of substring [a,b).
+    *
+    *    - Substrings adjacent to greedy wildcards must be interpreted as if they include them.
+    *      - Example: query "a*b" is equivalent to "a***b". For a lexer with a `hasNum` variable
+    *        type ("\w*\d*\w*"), without extensions, the only interpretations would be:
+    *          {<static>(a*b)},
+    *          {<hasNum>(a*) <static>(b)},
+    *          {<static>(a) <hasNum>(*b)}.
+    *        However, a string like "a1 abc 1b" is also matched by "a*b", and  requires the
+    *        interpretation {<hasNum>(a*) <static>(*) <hasNum>(*b)}. Extension ensures such cases
+    *        are captured.
+    *      - Note: isolated greedy wildcard (`*`) are never extended as the `Query` collapses
+    *        repeated greedy wildcards.
+    *      - Note: non-greedy wildcards (`?`) are not extended as "a?b" is not equivalent to "a??b".
+    *
+    *    - Substrings that begin or end with a wildcard are skipped as they are redundant.
+    *      - Example: in "a*b", substring (0,1] extends to "a*", therefore substring (0,2] "a*" is
+    *        redundant. In other words, a decomposition like "a*" + "b"  is a subset of the more
+    *        general "a*" + "*" + "*b".
+    *
+    * 2. Let I(a) be the set of all multi-length interpretations of substring [0,a).
+    *    - We can compute I(a) recursively using previously computed sets:
+    *
+    *      I(a) = T(0,a)
+    *             U (I(1) x T(1,a))
+    *             U (I(2) x T(2,a))
+    *             ...
+    *             U (I(a-1) x T(a-1,a))
+    *
+    *      where x denotes the cross product: all combinations of prefix interpretations from I(i)
+    *      and suffix interpretations from T(i,a).
+    *
+    * 3. Use dynamic programming to compute I(n) efficiently:
+    *    - Instead of generating all possible combinations naively (O(2^n * k^n)), we store only
+    *      unique interpretations, reducing complexity to roughly O(k^n), where k is the number of
+    *      unique token types.
+    *    - Compute I(n) iteratively in increasing order of substring length:
+    *      - Compute T(0,1), then I(1)
+    *      - Compute T(0,2), T(1,2), then I(2)
+    *      - Compute T(0,3), T(1,3), T(2,3), then I(3)
+    *      - ...
+    *      - Compute T(0,n), ..., T(n-1,n), then I(n)
+    *
+    * @param lexer The lexer used to determine variable types and delimiters.
+    * @return A set of `QueryInterpretation` representing all valid multi-token interpretations of
+    * the full query string.
+    */
+    [[nodiscard]] auto get_all_multi_token_interpretations(lexers::ByteLexer const& lexer) const -> std::set<QueryInterpretation>;
+
+private:
+   /**
+    * Generates all single-token interpretations for a given expression view matching a given lexer.
+    *
+    * A single-token interpretation can be one of:
+    * - A static token (literal text).
+    * - A variable token (e.g., int, float, hasNumber) as defined by the lexer's schema. Each
+    * unique variable types is considered a distinct interpretation.
+    *
+    * Rules:
+    * - If the substring is malformed (has hanging escape characters):
+    *   - There are no valid interpretations.
+    * - Else if the substring:
+    *   - Is an isolated greedy wildcard, `*, or
+    *   - Is not surrounded by delimiters or wildcards (lexer won't consider it a variable), or
+    *   - Does not match any variable.
+    * - Then:
+    *   - The only interpretation is a static token.
+    * - Else, if the substring contains a wildcard:
+    *   - The interpretations include a static token, plus a variable token for each matching type.
+    * - Else:
+    *   - The only interpretation is the variable token corresponding to the highest priority match.
+    *
+    * @param expression_view The view of the substring to interpret.
+    * @param lexer The lexer used to determine variable types and delimiters.
+    * @return A vector of `Queryinterpretation` objects representing all valid single-token
+    * interpretations for the given substring.
+    */
+    [[nodiscard]] static auto get_all_single_token_interpretations(ExpressionView const& expression_view, lexers::ByteLexer const& lexer) -> std::vector<QueryInterpretation>;
+
+    /**
+     * Determines the set of variable types matched by the lexer for all strings generated from the
+     * input regex.
+     *
+     * Generates a DFA from the input regex and computes its intersection with the lexer's DFA.
+     *
+     * @param regex_string The input regex string for which to find matching variable types.
+     * @param lexer The lexer whose DFA is used for matching.
+     * @return The set of all matching variable type IDs.
+     */
+    [[nodiscard]] static auto get_matching_variable_types(std::string const& regex_string, lexers::ByteLexer const& lexer) -> std::set<uint32_t>;
+
+    std::string m_query_string;
+};
+}  // namespace log_surgeon::wildcard_query_parser
+
+#endif  // LOG_SURGEON_WILDCARD_QUERY_PARSER_QUERY_HPP

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -45,8 +45,8 @@ public:
      *      - Example: in "a*b", substring [0,1) extends to "a*", therefore substring [0,2) "a*" is
      *        redundant. This avoids producing interpretation {<hasNum>(a*)b}, which is a subset of
      *        {<hasNum>(a*)*b}.
-     *      - Note: The length >= 2 requirement avoids skipping 1-length greedy substrings ("*")
-     *        as they are never redundant (i.e., no 0-length substring exists to extend).
+     *      - Note: The length >= 2 requirement avoids skipping 1-length greedy substrings ("*") as
+     *        they are never redundant (i.e., no 0-length substring exists to extend).
      *
      * 2. Let I(a) be the set of all multi-length interpretations of substring [0,a).
      *    - Let T(a,b) to be the set of all valid single-token interpretations of substring [a,b).

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -56,9 +56,8 @@ public:
      *      and suffix interpretations from T(i,a).
      *
      * 3. Use dynamic programming to compute I(n) efficiently:
-     *    - Instead of generating all possible combinations naively (O(2^n * k^n)), we store only
-     *      unique interpretations, reducing complexity to roughly O(k^n), where k is the number of
-     *      unique token types.
+     *    - Instead of generating all possible combinations naively, we store only unique
+     *      interpretations by recurisvely building up the combinations as shown below.
      *    - Compute I(n) iteratively in increasing order of substring length:
      *      - Compute T(0,1), then I(1)
      *      - Compute T(0,2), T(1,2), then I(2)

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -37,7 +37,7 @@ public:
      *      - Note: non-greedy wildcards (`?`) are not extended as "a?b" is not equivalent to
      *        "a??b".
      *
-     *    - Substrings that begin or end with a wildcard are skipped as they are redundant.
+     *    - Substrings that begin or end with a greedy wildcard are skipped as they are redundant.
      *      - Example: in "a*b", substring (0,1] extends to "a*", therefore substring (0,2] "a*" is
      *        redundant. In other words, a decomposition like "a*" + "b"  is a subset of the more
      *        general "a*" + "*" + "*b".  However, an isolated "*" must not be skipped as it is not

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -35,7 +35,7 @@ public:
      *        "a??b".
      *
      *    - Substrings that begin or end with a greedy wildcard are skipped as they are redundant.
-     *      - Example: in "a*b", substring (0,1] extends to "a*", therefore substring [0,2) "a*" is
+     *      - Example: in "a*b", substring [0,1) extends to "a*", therefore substring [0,2) "a*" is
      *        redundant. In other words, a decomposition like "a*" + "b"  is a subset of the more
      *        general "a*" + "*" + "*b".  However, an isolated "*" must not be skipped as it is not
      *        captured by any other substring extension.

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -16,8 +16,7 @@ public:
     explicit Query(std::string const& query_string);
 
     /**
-     * Generates all k-length interpretations of the n-length query string, where k is the number of
-     * tokens in the intepretation, n is the number of characters in the query, and 1 <= k < n.
+     * Generates all k-token interpretations of the n-character query string, where 1 <= k < n.
      *
      * 1. Interpret each substring [a,b) as a single token (k=1).
      *    - Substrings adjacent to greedy wildcards must be interpreted as if they include them. To

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -7,7 +7,6 @@
 #include <vector>
 
 #include <log_surgeon/Lexer.hpp>
-#include <log_surgeon/Schema.hpp>
 #include <log_surgeon/wildcard_query_parser/ExpressionView.hpp>
 #include <log_surgeon/wildcard_query_parser/QueryInterpretation.hpp>
 

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -47,8 +47,8 @@ public:
      *      - Note: The length >= 2 requirement avoids skipping 1-length greedy substrings ("*") as
      *        they are never redundant (i.e., no 0-length substring exists to extend).
      *
-     * 2. Let I(a) be the set of all k-length interpretations of substring [0,a), where 1 <= k < a.
-     *    - Let T(a,b) to be the set of all valid single-token interpretations of substring [a,b).
+     * 2. Let I(a) be the set of all k-token interpretations of substring [0,a), where 1 <= k < a.
+     *    - Let T(a,b) be the set of all valid single-token interpretations of substring [a,b).
      *    - We can then compute I(a) recursively:
      *
      *        I(a) = T(0,a)

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -16,10 +16,10 @@ public:
     explicit Query(std::string const& query_string);
 
     /**
-     * Generates all multi-token interpretations of the n-length query string (single-token
-     * interpretations of the query string belong to this set):
+     * Generates all k-length interpretations of the n-length query string, where k is the number of
+     * tokens in the intepretation, n is the number of characters in the query, and 1 <= k < n.
      *
-     * 1. Interpret each substring [a,b) as a single token (1-length interpretation).
+     * 1. Interpret each substring [a,b) as a single token (k=1).
      *    - Substrings adjacent to greedy wildcards must be interpreted as if they include them. To
      *      implement this, we extend all substrings to include adjacent wildcards.
      *      - Example: consider query "a*b" and variable type `hasNum` ("\w*\d+\w*"):
@@ -48,7 +48,7 @@ public:
      *      - Note: The length >= 2 requirement avoids skipping 1-length greedy substrings ("*") as
      *        they are never redundant (i.e., no 0-length substring exists to extend).
      *
-     * 2. Let I(a) be the set of all multi-length interpretations of substring [0,a).
+     * 2. Let I(a) be the set of all k-length interpretations of substring [0,a), where 1 <= k < a.
      *    - Let T(a,b) to be the set of all valid single-token interpretations of substring [a,b).
      *    - We can then compute I(a) recursively:
      *

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -83,13 +83,13 @@ private:
      * A single-token interpretation can be one of:
      * - A static token (literal text).
      * - A variable token (e.g., int, float, hasNumber) as defined by the lexer's schema. Each
-     * unique variable types is considered a distinct interpretation.
+     * unique variable type is considered a distinct interpretation.
      *
      * Rules:
      * - If the substring is malformed (has hanging escape characters):
      *   - There are no valid interpretations.
      * - Else if the substring:
-     *   - Is an isolated greedy wildcard, `*, or
+     *   - Is an isolated greedy wildcard, "*", or
      *   - Is not surrounded by delimiters or wildcards (lexer won't consider it a variable), or
      *   - Does not match any variable.
      * - Then:
@@ -102,7 +102,7 @@ private:
      *
      * @param expression_view The view of the substring to interpret.
      * @param lexer The lexer used to determine variable types and delimiters.
-     * @return A vector of `Queryinterpretation` objects representing all valid single-token
+     * @return A vector of `QueryInterpretation` objects representing all valid single-token
      * interpretations for the given substring.
      */
     [[nodiscard]] static auto get_all_single_token_interpretations(

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -20,7 +20,7 @@ public:
      *
      * 1. Interpret each substring [a,b) as a single token (k=1).
      *    - Substrings adjacent to greedy wildcards must be interpreted as if they include them. To
-     *      implement this, we extend all substrings to include adjacent wildcards.
+     *      implement this, we extend all substrings to include adjacent greedy wildcards.
      *      - Example: consider query "a*b" and variable type `hasNum` ("\w*\d+\w*"):
      *        - Without extension:
      *          - "a" -> static-text

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -38,7 +38,7 @@ public:
      *        "a??b".
      *
      *    - Substrings that begin or end with a greedy wildcard are skipped as they are redundant.
-     *      - Example: in "a*b", substring (0,1] extends to "a*", therefore substring (0,2] "a*" is
+     *      - Example: in "a*b", substring (0,1] extends to "a*", therefore substring [0,2) "a*" is
      *        redundant. In other words, a decomposition like "a*" + "b"  is a subset of the more
      *        general "a*" + "*" + "*b".  However, an isolated "*" must not be skipped as it is not
      *        captured by any other substring extension.

--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -16,89 +16,93 @@ class Query {
 public:
     explicit Query(std::string const& query_string);
 
-   /**
-    * Generates all multi-token interpretations of the n-length query string (single-token
-    * interpretations of the query string belong to this set):
-    *
-    * 1. Interpret each substring [a,b) as a single token (1-length interpretation).
-    *    - Denote T(a,b) to be the set of all valid single-token interpretations of substring [a,b).
-    *
-    *    - Substrings adjacent to greedy wildcards must be interpreted as if they include them.
-    *      - Example: query "a*b" is equivalent to "a***b". For a lexer with a `hasNum` variable
-    *        type ("\w*\d*\w*"), without extensions, the only interpretations would be:
-    *          {<static>(a*b)},
-    *          {<hasNum>(a*) <static>(b)},
-    *          {<static>(a) <hasNum>(*b)}.
-    *        However, a string like "a1 abc 1b" is also matched by "a*b", and  requires the
-    *        interpretation {<hasNum>(a*) <static>(*) <hasNum>(*b)}. Extension ensures such cases
-    *        are captured.
-    *      - Note: isolated greedy wildcard (`*`) are never extended as the `Query` collapses
-    *        repeated greedy wildcards.
-    *      - Note: non-greedy wildcards (`?`) are not extended as "a?b" is not equivalent to "a??b".
-    *
-    *    - Substrings that begin or end with a wildcard are skipped as they are redundant.
-    *      - Example: in "a*b", substring (0,1] extends to "a*", therefore substring (0,2] "a*" is
-    *        redundant. In other words, a decomposition like "a*" + "b"  is a subset of the more
-    *        general "a*" + "*" + "*b".
-    *
-    * 2. Let I(a) be the set of all multi-length interpretations of substring [0,a).
-    *    - We can compute I(a) recursively using previously computed sets:
-    *
-    *      I(a) = T(0,a)
-    *             U (I(1) x T(1,a))
-    *             U (I(2) x T(2,a))
-    *             ...
-    *             U (I(a-1) x T(a-1,a))
-    *
-    *      where x denotes the cross product: all combinations of prefix interpretations from I(i)
-    *      and suffix interpretations from T(i,a).
-    *
-    * 3. Use dynamic programming to compute I(n) efficiently:
-    *    - Instead of generating all possible combinations naively (O(2^n * k^n)), we store only
-    *      unique interpretations, reducing complexity to roughly O(k^n), where k is the number of
-    *      unique token types.
-    *    - Compute I(n) iteratively in increasing order of substring length:
-    *      - Compute T(0,1), then I(1)
-    *      - Compute T(0,2), T(1,2), then I(2)
-    *      - Compute T(0,3), T(1,3), T(2,3), then I(3)
-    *      - ...
-    *      - Compute T(0,n), ..., T(n-1,n), then I(n)
-    *
-    * @param lexer The lexer used to determine variable types and delimiters.
-    * @return A set of `QueryInterpretation` representing all valid multi-token interpretations of
-    * the full query string.
-    */
-    [[nodiscard]] auto get_all_multi_token_interpretations(lexers::ByteLexer const& lexer) const -> std::set<QueryInterpretation>;
+    /**
+     * Generates all multi-token interpretations of the n-length query string (single-token
+     * interpretations of the query string belong to this set):
+     *
+     * 1. Interpret each substring [a,b) as a single token (1-length interpretation).
+     *    - Denote T(a,b) to be the set of all valid single-token interpretations of substring [a,b).
+     *
+     *    - Substrings adjacent to greedy wildcards must be interpreted as if they include them.
+     *      - Example: query "a*b" is equivalent to "a***b". For a lexer with a `hasNum` variable
+     *        type ("\w*\d*\w*"), without extensions, the only interpretations would be:
+     *          {<static>(a*b)},
+     *          {<hasNum>(a*) <static>(b)},
+     *          {<static>(a) <hasNum>(*b)}.
+     *        However, a string like "a1 abc 1b" is also matched by "a*b", and  requires the
+     *        interpretation {<hasNum>(a*) <static>(*) <hasNum>(*b)}. Extension ensures such cases
+     *        are captured.
+     *      - Note: isolated greedy wildcard (`*`) are never extended as the `Query` collapses
+     *        repeated greedy wildcards.
+     *      - Note: non-greedy wildcards (`?`) are not extended as "a?b" is not equivalent to "a??b".
+     *
+     *    - Substrings that begin or end with a wildcard are skipped as they are redundant.
+     *      - Example: in "a*b", substring (0,1] extends to "a*", therefore substring (0,2] "a*" is
+     *        redundant. In other words, a decomposition like "a*" + "b"  is a subset of the more
+     *        general "a*" + "*" + "*b".
+     *
+     * 2. Let I(a) be the set of all multi-length interpretations of substring [0,a).
+     *    - We can compute I(a) recursively using previously computed sets:
+     *
+     *      I(a) = T(0,a)
+     *             U (I(1) x T(1,a))
+     *             U (I(2) x T(2,a))
+     *             ...
+     *             U (I(a-1) x T(a-1,a))
+     *
+     *      where x denotes the cross product: all combinations of prefix interpretations from I(i)
+     *      and suffix interpretations from T(i,a).
+     *
+     * 3. Use dynamic programming to compute I(n) efficiently:
+     *    - Instead of generating all possible combinations naively (O(2^n * k^n)), we store only
+     *      unique interpretations, reducing complexity to roughly O(k^n), where k is the number of
+     *      unique token types.
+     *    - Compute I(n) iteratively in increasing order of substring length:
+     *      - Compute T(0,1), then I(1)
+     *      - Compute T(0,2), T(1,2), then I(2)
+     *      - Compute T(0,3), T(1,3), T(2,3), then I(3)
+     *      - ...
+     *      - Compute T(0,n), ..., T(n-1,n), then I(n)
+     *
+     * @param lexer The lexer used to determine variable types and delimiters.
+     * @return A set of `QueryInterpretation` representing all valid multi-token interpretations of
+     * the full query string.
+     */
+    [[nodiscard]] auto get_all_multi_token_interpretations(lexers::ByteLexer const& lexer) const
+            -> std::set<QueryInterpretation>;
 
 private:
-   /**
-    * Generates all single-token interpretations for a given expression view matching a given lexer.
-    *
-    * A single-token interpretation can be one of:
-    * - A static token (literal text).
-    * - A variable token (e.g., int, float, hasNumber) as defined by the lexer's schema. Each
-    * unique variable types is considered a distinct interpretation.
-    *
-    * Rules:
-    * - If the substring is malformed (has hanging escape characters):
-    *   - There are no valid interpretations.
-    * - Else if the substring:
-    *   - Is an isolated greedy wildcard, `*, or
-    *   - Is not surrounded by delimiters or wildcards (lexer won't consider it a variable), or
-    *   - Does not match any variable.
-    * - Then:
-    *   - The only interpretation is a static token.
-    * - Else, if the substring contains a wildcard:
-    *   - The interpretations include a static token, plus a variable token for each matching type.
-    * - Else:
-    *   - The only interpretation is the variable token corresponding to the highest priority match.
-    *
-    * @param expression_view The view of the substring to interpret.
-    * @param lexer The lexer used to determine variable types and delimiters.
-    * @return A vector of `Queryinterpretation` objects representing all valid single-token
-    * interpretations for the given substring.
-    */
-    [[nodiscard]] static auto get_all_single_token_interpretations(ExpressionView const& expression_view, lexers::ByteLexer const& lexer) -> std::vector<QueryInterpretation>;
+    /**
+     * Generates all single-token interpretations for a given expression view matching a given lexer.
+     *
+     * A single-token interpretation can be one of:
+     * - A static token (literal text).
+     * - A variable token (e.g., int, float, hasNumber) as defined by the lexer's schema. Each
+     * unique variable types is considered a distinct interpretation.
+     *
+     * Rules:
+     * - If the substring is malformed (has hanging escape characters):
+     *   - There are no valid interpretations.
+     * - Else if the substring:
+     *   - Is an isolated greedy wildcard, `*, or
+     *   - Is not surrounded by delimiters or wildcards (lexer won't consider it a variable), or
+     *   - Does not match any variable.
+     * - Then:
+     *   - The only interpretation is a static token.
+     * - Else, if the substring contains a wildcard:
+     *   - The interpretations include a static token, plus a variable token for each matching type.
+     * - Else:
+     *   - The only interpretation is the variable token corresponding to the highest priority match.
+     *
+     * @param expression_view The view of the substring to interpret.
+     * @param lexer The lexer used to determine variable types and delimiters.
+     * @return A vector of `Queryinterpretation` objects representing all valid single-token
+     * interpretations for the given substring.
+     */
+    [[nodiscard]] static auto get_all_single_token_interpretations(
+            ExpressionView const& expression_view,
+            lexers::ByteLexer const& lexer
+    ) -> std::vector<QueryInterpretation>;
 
     /**
      * Determines the set of variable types matched by the lexer for all strings generated from the
@@ -110,7 +114,9 @@ private:
      * @param lexer The lexer whose DFA is used for matching.
      * @return The set of all matching variable type IDs.
      */
-    [[nodiscard]] static auto get_matching_variable_types(std::string const& regex_string, lexers::ByteLexer const& lexer) -> std::set<uint32_t>;
+    [[nodiscard]] static auto
+    get_matching_variable_types(std::string const& regex_string, lexers::ByteLexer const& lexer)
+            -> std::set<uint32_t>;
 
     std::string m_query_string;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(
         test-expression-view.cpp
         test-nfa.cpp
         test-prefix-tree.cpp
+        test-query.cpp
         test-query-interpretation.cpp
         test-regex-ast.cpp
         test-register-handler.cpp

--- a/tests/test-buffer-parser.cpp
+++ b/tests/test-buffer-parser.cpp
@@ -887,7 +887,7 @@ TEST_CASE("multi_line_with_delimited_vars", "[BufferParser]") {
  * " B=1.1" -> uncaught string
  * @endcode
  */
-TEST_CASE("multi_capture", "[BufferParser]") {
+TEST_CASE("multi_capture_one", "[BufferParser]") {
     constexpr string_view cDelimitersSchema{R"(delimiters: \n\r\[:,)"};
     constexpr string_view cTime{R"((?<timestamp>\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}))"};
     constexpr string_view cPid{R"((?<PID>\d{4}))"};
@@ -909,6 +909,78 @@ TEST_CASE("multi_capture", "[BufferParser]") {
                      {" MyService", "", {}},
                      {" A=TEXT", "", {}},
                      {" B=1.1", "", {}}}
+            }
+    };
+
+    Schema schema;
+    schema.add_delimiters(cDelimitersSchema);
+    schema.add_variable(header_rule, -1);
+    BufferParser buffer_parser{std::move(schema.release_schema_ast_ptr())};
+
+    parse_and_validate(buffer_parser, cInput, {expected_event1});
+}
+
+/**
+ * @ingroup test_buffer_parser_capture
+ * @brief Tests a multi-capture rule.
+ *
+ * This test also verifies that a multi-capture rule correctly identifies the location of each
+ * capture group. It tests that `BufferParser` correctly flattens the logtype, as well as stores the
+ * full tree correctly.
+ *
+ * ### Schema Definition
+ * @code
+ * delimiters: \n\r\[:,
+ * header:(?<timestamp>[A-Za-z]{3} \d{2} \d{2}:\d{2}:\d{2}) ip-(?<IP>\d{3}\-\d{2}\-\d{2}\-\d{2}) \
+ *        ku[(?<PID>\d{4})]: (?<LogLevel>I|D|E|W)(?<LID>\d{4}) \
+ *        (?<LTime>\d{2}:\d{2}:\d{2}\.\d{4})    (?<TID>\d{4})
+ * @endcode
+ *
+ * ### Input Example
+ * @code
+ * "Jan 01 02:03:04 ip-999-99-99-99 ku[1234]: E5678 02:03:04.5678    1111 Y Failed"
+ * @endcode
+ *
+ * ### Expected Logtype
+ * @code
+ * "<timestamp> ip-<IP> ku[<PID>]: <LogLevel><LID> <LTime>    <TID> Y failed"
+ * @endcode
+ *
+ * ### Expected Tokenization
+ * @code
+ * "Jan 01 02:03:04 ip-999-99-99-99 ku[1234]: E5678 02:03:04.5678    1111" -> "header"
+ * " Y" -> uncaught string
+ * " Failed" -> uncaught string
+ * @endcode
+ */
+TEST_CASE("multi_capture_two", "[BufferParser]") {
+    constexpr string_view cDelimitersSchema{R"(delimiters: \n\r\[:,)"};
+    constexpr string_view cTime{R"((?<timestamp>[A-Za-z]{3} \d{2} \d{2}:\d{2}:\d{2}))"};
+    constexpr string_view cIp{R"((?<IP>\d{3}\-\d{2}\-\d{2}\-\d{2}))"};
+    constexpr string_view cPid{R"((?<PID>\d{4}))"};
+    constexpr string_view cLogLevel{R"((?<LogLevel>I|D|E|W))"};
+    constexpr string_view cLid{R"((?<LID>\d{4}))"};
+    constexpr string_view cLTime{R"((?<LTime>\d{2}:\d{2}:\d{2}\.\d{4}))"};
+    constexpr string_view cTid{R"((?<TID>\d{4}))"};
+    constexpr string_view cInput{"Jan 01 02:03:04 ip-999-99-99-99 ku[1234]: E5678 02:03:04.5678"
+                                 "    1111 Y failed"};
+
+    string const header_rule{fmt::format(R"(header:{} ip\-{} ku\[{}\]: {}{} {}    {})", cTime, cIp, cPid, cLogLevel, cLid, cLTime, cTid)};
+    ExpectedEvent const expected_event1{
+            .m_logtype{"<timestamp> ip-<IP> ku[<PID>]: <LogLevel><LID> <LTime>    <TID> Y failed"},
+            .m_timestamp_raw{""},
+            .m_tokens{
+                    {{"Jan 01 02:03:04 ip-999-99-99-99 ku[1234]: E5678 02:03:04.5678    1111",
+                      "header",
+                      {{{"timestamp", {{0}, {15}}},
+                        {"IP", {{19}, {31}}},
+                        {"PID", {{35}, {39}}},
+                        {"LogLevel", {{42}, {43}}},
+                        {"LID", {{43}, {47}}},
+                        {"LTime", {{48}, {61}}},
+                        {"TID", {{65}, {69}}}}}},
+                     {" Y", "", {}},
+                     {" failed", "", {}}}
             }
     };
 

--- a/tests/test-buffer-parser.cpp
+++ b/tests/test-buffer-parser.cpp
@@ -865,8 +865,8 @@ TEST_CASE("multi_line_with_delimited_vars", "[BufferParser]") {
  * ### Schema Definition
  * @code
  * delimiters: \n\r\[:,
- * header:(?<timestamp>\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}) (?<PID>\d{4}) (?<TID>\d{4})
- * ... (?<LogLevel>I|D|E|W)
+ * header:(?<timestamp>\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}) (?<PID>\d{4}) (?<TID>\d{4}) \
+ *        (?<LogLevel>I|D|E|W)
  * @endcode
  *
  * ### Input Example

--- a/tests/test-buffer-parser.cpp
+++ b/tests/test-buffer-parser.cpp
@@ -965,7 +965,16 @@ TEST_CASE("multi_capture_two", "[BufferParser]") {
     constexpr string_view cInput{"Jan 01 02:03:04 ip-999-99-99-99 ku[1234]: E5678 02:03:04.5678"
                                  "    1111 Y failed"};
 
-    string const header_rule{fmt::format(R"(header:{} ip\-{} ku\[{}\]: {}{} {}    {})", cTime, cIp, cPid, cLogLevel, cLid, cLTime, cTid)};
+    string const header_rule{fmt::format(
+            R"(header:{} ip\-{} ku\[{}\]: {}{} {}    {})",
+            cTime,
+            cIp,
+            cPid,
+            cLogLevel,
+            cLid,
+            cLTime,
+            cTid
+    )};
     ExpectedEvent const expected_event1{
             .m_logtype{"<timestamp> ip-<IP> ku[<PID>]: <LogLevel><LID> <LTime>    <TID> Y failed"},
             .m_timestamp_raw{""},

--- a/tests/test-buffer-parser.cpp
+++ b/tests/test-buffer-parser.cpp
@@ -895,10 +895,7 @@ TEST_CASE("multi_capture", "[BufferParser]") {
     constexpr string_view cLogLevel{R"((?<LogLevel>I|D|E|W))"};
     constexpr string_view cInput{"1999-12-12T01:02:03.456 1234 5678 I MyService A=TEXT B=1.1"};
 
-    string const header_capture_rule{
-            "header:" + string(cTime) + " " + string(cPid) + " " + string(cTid) + " "
-            + string(cLogLevel)
-    };
+    string const header_rule{fmt::format("header:{} {} {} {}", cTime, cPid, cTid, cLogLevel)};
     ExpectedEvent const expected_event1{
             .m_logtype{"<timestamp> <PID> <TID> <LogLevel> MyService A=TEXT B=1.1"},
             .m_timestamp_raw{""},
@@ -917,7 +914,7 @@ TEST_CASE("multi_capture", "[BufferParser]") {
 
     Schema schema;
     schema.add_delimiters(cDelimitersSchema);
-    schema.add_variable(header_capture_rule, -1);
+    schema.add_variable(header_rule, -1);
     BufferParser buffer_parser{std::move(schema.release_schema_ast_ptr())};
 
     parse_and_validate(buffer_parser, cInput, {expected_event1});

--- a/tests/test-buffer-parser.cpp
+++ b/tests/test-buffer-parser.cpp
@@ -909,8 +909,8 @@ TEST_CASE("multi_capture", "[BufferParser]") {
                         {"PID", {{24}, {28}}},
                         {"TID", {{29}, {33}}},
                         {"LogLevel", {{34}, {35}}}}}},
-                     {" MyService"},
-                     {" A=TEXT"},
+                     {" MyService", "", {}},
+                     {" A=TEXT", "", {}},
                      {" B=1.1", "", {}}}
             }
     };

--- a/tests/test-buffer-parser.cpp
+++ b/tests/test-buffer-parser.cpp
@@ -938,7 +938,7 @@ TEST_CASE("multi_capture_one", "[BufferParser]") {
  *
  * ### Input Example
  * @code
- * "Jan 01 02:03:04 ip-999-99-99-99 ku[1234]: E5678 02:03:04.5678    1111 Y Failed"
+ * "Jan 01 02:03:04 ip-999-99-99-99 ku[1234]: E5678 02:03:04.5678    1111 Y failed"
  * @endcode
  *
  * ### Expected Logtype
@@ -950,7 +950,7 @@ TEST_CASE("multi_capture_one", "[BufferParser]") {
  * @code
  * "Jan 01 02:03:04 ip-999-99-99-99 ku[1234]: E5678 02:03:04.5678    1111" -> "header"
  * " Y" -> uncaught string
- * " Failed" -> uncaught string
+ * " failed" -> uncaught string
  * @endcode
  */
 TEST_CASE("multi_capture_two", "[BufferParser]") {

--- a/tests/test-query.cpp
+++ b/tests/test-query.cpp
@@ -77,6 +77,9 @@ auto make_test_lexer() -> ByteLexer {
     lexer.m_id_symbol[0] = "hasNumber";
 
     auto const schema_ast = schema.release_schema_ast_ptr();
+    REQUIRE(nullptr != schema_ast);
+    REQUIRE(1 == schema_ast->m_schema_vars.size());
+    REQUIRE(nullptr != schema_ast->m_schema_vars[0]);
     auto& capture_rule_ast = dynamic_cast<SchemaVarAST&>(*schema_ast->m_schema_vars[0]);
     lexer.add_rule(lexer.m_symbol_id["hasNumber"], std::move(capture_rule_ast.m_regex_ptr));
 

--- a/tests/test-query.cpp
+++ b/tests/test-query.cpp
@@ -53,7 +53,7 @@ auto test_query(
         string_view const expected_processed_query_string,
         set<string> const& expected_serialized_interpretations
 ) -> void {
-    auto const& lexer{make_test_lexer()};
+    auto const lexer{make_test_lexer()};
 
     Query const query{string(raw_query_string)};
     REQUIRE(expected_processed_query_string == query.get_processed_query_string());

--- a/tests/test-query.cpp
+++ b/tests/test-query.cpp
@@ -28,7 +28,7 @@ using std::string_view;
 namespace {
 /**
  * Creates a query from the given query string and tests that its processed query string and
- * interpretations matche the expeced values.
+ * interpretations match the expeced values.
  *
  * @param raw_query_string The search query.
  * @param expected_processed_query_string The processed search query.

--- a/tests/test-query.cpp
+++ b/tests/test-query.cpp
@@ -43,7 +43,7 @@ auto test_query(
 /**
  * Initializes a `ByteLexer` with delimiters "\n\r\[:" and variable "myVar:userID=(?<uid>123)".
  *
- * @result The initialized `ByteLexer`.
+ * @return The initialized `ByteLexer`.
  */
 auto make_test_lexer() -> ByteLexer;
 

--- a/tests/test-query.cpp
+++ b/tests/test-query.cpp
@@ -41,7 +41,8 @@ auto test_query(
 ) -> void;
 
 /**
- * Initializes a `ByteLexer` with delimiters "\n\r\[:" and variable "myVar:userID=(?<uid>123)".
+ * Initializes a `ByteLexer` with delimiters "\n\r\[:" and variable
+ * "hasNumber:[A-Za-z]*\d+[A-Za-z]*".
  *
  * @return The initialized `ByteLexer`.
  */

--- a/tests/test-query.cpp
+++ b/tests/test-query.cpp
@@ -267,10 +267,10 @@ TEST_CASE("long_non_greedy_wildcard_sequence_query", "[Query]") {
     };
 
     test_query(
-          cRawQueryString,
-          cProcessedQueryString,
-          schema_rules,
-          expected_serialized_interpretations
+            cRawQueryString,
+            cProcessedQueryString,
+            schema_rules,
+            expected_serialized_interpretations
     );
 }
 
@@ -335,10 +335,7 @@ TEST_CASE("non_wildcard_multi_variable_query", "[Query]") {
     constexpr string_view cProcessedQueryString{"abc123 123"};
 
     SECTION("int_priority") {
-        vector<string> const schema_rules{
-                {R"(int:(\d+))"},
-                {R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)"}
-        };
+        vector<string> const schema_rules{{R"(int:(\d+))"}, {R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)"}};
         set<string> const expected_serialized_interpretations{
                 R"(logtype='abc123 123', contains_wildcard='0')",
                 R"(logtype='abc123 <0>(123)', contains_wildcard='00')",
@@ -355,10 +352,7 @@ TEST_CASE("non_wildcard_multi_variable_query", "[Query]") {
     }
 
     SECTION("has_number_priority") {
-        vector<string> const schema_rules{
-                {R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)"},
-                {R"(int:(\d+))"}
-        };
+        vector<string> const schema_rules{{R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)"}, {R"(int:(\d+))"}};
         set<string> const expected_serialized_interpretations{
                 R"(logtype='abc123 123', contains_wildcard='0')",
                 R"(logtype='abc123 <0>(123)', contains_wildcard='00')",
@@ -388,10 +382,7 @@ TEST_CASE("wildcard_multi_variable_query", "[Query]") {
     constexpr string_view cRawQueryString{"abc123* *123"};
     constexpr string_view cProcessedQueryString{"abc123* *123"};
 
-    vector<string> const schema_rules{
-            {R"(int:(\d+))"},
-            {R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)"}
-    };
+    vector<string> const schema_rules{{R"(int:(\d+))"}, {R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)"}};
     set<string> const expected_serialized_interpretations{
             R"(logtype='abc123* *123', contains_wildcard='0')",
             R"(logtype='abc123*** *123', contains_wildcard='0')",

--- a/tests/test-query.cpp
+++ b/tests/test-query.cpp
@@ -2,6 +2,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 #include <log_surgeon/Lexer.hpp>
 #include <log_surgeon/Schema.hpp>
@@ -24,6 +25,7 @@ using log_surgeon::wildcard_query_parser::Query;
 using std::set;
 using std::string;
 using std::string_view;
+using std::vector;
 
 namespace {
 /**
@@ -32,28 +34,31 @@ namespace {
  *
  * @param raw_query_string The search query.
  * @param expected_processed_query_string The processed search query.
+ * @param schema_rules A vector of strings, each string representing a schema rule.
  * @param expected_serialized_interpretations  The expected set of serialized interpretations.
  */
 auto test_query(
         string_view raw_query_string,
         string_view expected_processed_query_string,
+        vector<string> const& schema_rules,
         set<string> const& expected_serialized_interpretations
 ) -> void;
 
 /**
- * Initializes a `ByteLexer` with delimiters "\n\r\[:" and variable
- * "hasNumber:[A-Za-z]*\d+[A-Za-z]*".
+ * Initializes a `ByteLexer` with space as a delimiter and the given `schema_rules`.
  *
+ * @param schema_rules A vector of strings, each string representing a schema rule.
  * @return The initialized `ByteLexer`.
  */
-auto make_test_lexer() -> ByteLexer;
+auto make_test_lexer(vector<string> const& schema_rules) -> ByteLexer;
 
 auto test_query(
         string_view const raw_query_string,
         string_view const expected_processed_query_string,
+        vector<string> const& schema_rules,
         set<string> const& expected_serialized_interpretations
 ) -> void {
-    auto const lexer{make_test_lexer()};
+    auto const lexer{make_test_lexer(schema_rules)};
 
     Query const query{string(raw_query_string)};
     REQUIRE(expected_processed_query_string == query.get_processed_query_string());
@@ -67,21 +72,25 @@ auto test_query(
     REQUIRE(expected_serialized_interpretations == serialized_interpretations);
 }
 
-auto make_test_lexer() -> ByteLexer {
-    Schema schema;
-    schema.add_delimiters(R"(delimiters: \n\r\[:,)");
-    schema.add_variable(R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)", -1);
-
+auto make_test_lexer(vector<string> const& schema_rules) -> ByteLexer {
     ByteLexer lexer;
-    lexer.m_symbol_id["hasNumber"] = 0;
-    lexer.m_id_symbol[0] = "hasNumber";
+    lexer.set_delimiters({' '});
+
+    Schema schema;
+    size_t symbol_id{0};
+    for (auto const& schema_rule : schema_rules) {
+        schema.add_variable(schema_rule, -1);
+        ++symbol_id;
+    }
 
     auto const schema_ast = schema.release_schema_ast_ptr();
     REQUIRE(nullptr != schema_ast);
-    REQUIRE(1 == schema_ast->m_schema_vars.size());
-    REQUIRE(nullptr != schema_ast->m_schema_vars[0]);
-    auto& capture_rule_ast = dynamic_cast<SchemaVarAST&>(*schema_ast->m_schema_vars[0]);
-    lexer.add_rule(lexer.m_symbol_id["hasNumber"], std::move(capture_rule_ast.m_regex_ptr));
+    REQUIRE(schema_rules.size() == schema_ast->m_schema_vars.size());
+    for (size_t i{0}; i < schema_ast->m_schema_vars.size(); ++i) {
+        REQUIRE(nullptr != schema_ast->m_schema_vars[i]);
+        auto& capture_rule_ast{dynamic_cast<SchemaVarAST&>(*schema_ast->m_schema_vars[i])};
+        lexer.add_rule(i, std::move(capture_rule_ast.m_regex_ptr));
+    }
 
     lexer.generate();
     return lexer;
@@ -95,9 +104,15 @@ auto make_test_lexer() -> ByteLexer {
 TEST_CASE("empty_query", "[Query]") {
     constexpr string_view cRawQueryString;
     constexpr string_view cProcessedQueryString;
+    vector<string> const schema_rules{{R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)"}};
     set<string> const expected_serialized_interpretations;
 
-    test_query(cRawQueryString, cProcessedQueryString, expected_serialized_interpretations);
+    test_query(
+            cRawQueryString,
+            cProcessedQueryString,
+            schema_rules,
+            expected_serialized_interpretations
+    );
 }
 
 /**
@@ -107,9 +122,15 @@ TEST_CASE("empty_query", "[Query]") {
 TEST_CASE("greedy_wildcard_query", "[Query]") {
     constexpr string_view cRawQueryString{"*"};
     constexpr string_view cProcessedQueryString{"*"};
+    vector<string> const schema_rules{{R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)"}};
     set<string> const expected_serialized_interpretations{"logtype='*', contains_wildcard='0'"};
 
-    test_query(cRawQueryString, cProcessedQueryString, expected_serialized_interpretations);
+    test_query(
+            cRawQueryString,
+            cProcessedQueryString,
+            schema_rules,
+            expected_serialized_interpretations
+    );
 }
 
 /**
@@ -119,6 +140,7 @@ TEST_CASE("greedy_wildcard_query", "[Query]") {
 TEST_CASE("repeated_greedy_wildcard_query", "[Query]") {
     constexpr string_view cRawQueryString{"a**b"};
     constexpr string_view cProcessedQueryString{"a*b"};
+    vector<string> const schema_rules{{R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)"}};
     set<string> const expected_serialized_interpretations{
             "logtype='a*b', contains_wildcard='0'",
             "logtype='a***b', contains_wildcard='0'",
@@ -128,7 +150,12 @@ TEST_CASE("repeated_greedy_wildcard_query", "[Query]") {
             "logtype='a**<0>(*b)', contains_wildcard='01'"
     };
 
-    test_query(cRawQueryString, cProcessedQueryString, expected_serialized_interpretations);
+    test_query(
+            cRawQueryString,
+            cProcessedQueryString,
+            schema_rules,
+            expected_serialized_interpretations
+    );
 }
 
 /**
@@ -138,6 +165,7 @@ TEST_CASE("repeated_greedy_wildcard_query", "[Query]") {
 TEST_CASE("short_wildcard_sequence_query", "[Query]") {
     constexpr string_view cRawQueryString{"a?*b"};
     constexpr string_view cProcessedQueryString{"a*b"};
+    vector<string> const schema_rules{{R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)"}};
     set<string> const expected_serialized_interpretations{
             "logtype='a*b', contains_wildcard='0'",
             "logtype='a***b', contains_wildcard='0'",
@@ -147,7 +175,12 @@ TEST_CASE("short_wildcard_sequence_query", "[Query]") {
             "logtype='a**<0>(*b)', contains_wildcard='01'"
     };
 
-    test_query(cRawQueryString, cProcessedQueryString, expected_serialized_interpretations);
+    test_query(
+            cRawQueryString,
+            cProcessedQueryString,
+            schema_rules,
+            expected_serialized_interpretations
+    );
 }
 
 /**
@@ -157,6 +190,7 @@ TEST_CASE("short_wildcard_sequence_query", "[Query]") {
 TEST_CASE("long_mixed_wildcard_sequence_query", "[Query]") {
     constexpr string_view cRawQueryString{"a?*?*?*?b"};
     constexpr string_view cProcessedQueryString{"a*b"};
+    vector<string> const schema_rules{{R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)"}};
     set<string> const expected_serialized_interpretations{
             "logtype='a*b', contains_wildcard='0'",
             "logtype='a***b', contains_wildcard='0'",
@@ -166,7 +200,12 @@ TEST_CASE("long_mixed_wildcard_sequence_query", "[Query]") {
             "logtype='a**<0>(*b)', contains_wildcard='01'"
     };
 
-    test_query(cRawQueryString, cProcessedQueryString, expected_serialized_interpretations);
+    test_query(
+            cRawQueryString,
+            cProcessedQueryString,
+            schema_rules,
+            expected_serialized_interpretations
+    );
 }
 
 /**
@@ -176,6 +215,7 @@ TEST_CASE("long_mixed_wildcard_sequence_query", "[Query]") {
 TEST_CASE("long_non_greedy_wildcard_sequence_query", "[Query]") {
     constexpr string_view cRawQueryString{"a????b"};
     constexpr string_view cProcessedQueryString{"a????b"};
+    vector<string> const schema_rules{{R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)"}};
     set<string> const expected_serialized_interpretations{
             R"(logtype='a????b', contains_wildcard='0')",
 
@@ -227,7 +267,12 @@ TEST_CASE("long_non_greedy_wildcard_sequence_query", "[Query]") {
             R"(logtype='<0>(a?)<0>(?)<0>(?)<0>(?b)', contains_wildcard='1111')"
     };
 
-    test_query(cRawQueryString, cProcessedQueryString, expected_serialized_interpretations);
+    test_query(
+          cRawQueryString,
+          cProcessedQueryString,
+          schema_rules,
+          expected_serialized_interpretations
+    );
 }
 
 /**
@@ -237,9 +282,136 @@ TEST_CASE("long_non_greedy_wildcard_sequence_query", "[Query]") {
 TEST_CASE("escaped_star_query", "[Query]") {
     constexpr string_view cRawQueryString{R"(a\*b)"};
     constexpr string_view cProcessedQueryString{R"(a\*b)"};
+    vector<string> const schema_rules{{R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)"}};
     set<string> const expected_serialized_interpretations{
             R"(logtype='a\*b', contains_wildcard='0')"
     };
 
-    test_query(cRawQueryString, cProcessedQueryString, expected_serialized_interpretations);
+    test_query(
+            cRawQueryString,
+            cProcessedQueryString,
+            schema_rules,
+            expected_serialized_interpretations
+    );
+}
+
+/**
+ * @ingroup unit_tests_query
+ * @brief Creates and tests a query with an escaped '*' character.
+ *
+ * NOTE: This has a static-text case as strings "1", "2', and "3" in isolation aren't surrounded by
+ * delimiters. These tokens then build up the interpretation "123". Although additional
+ * interpretations don't impact correctness, they may impact performance. We can optimize these out,
+ * but it'll make the code messy. Instead, we should eventually remove the explicit tracking of
+ * static-tokens, in favor of only tracking variable tokens.
+ */
+TEST_CASE("int_query", "[Query]") {
+    constexpr string_view cRawQueryString{"123"};
+    constexpr string_view cProcessedQueryString{"123"};
+    vector<string> const schema_rules{{R"(int:\d+)"}};
+    set<string> const expected_serialized_interpretations{
+            R"(logtype='123', contains_wildcard='0')",
+            R"(logtype='<0>(123)', contains_wildcard='0')"
+    };
+
+    test_query(
+            cRawQueryString,
+            cProcessedQueryString,
+            schema_rules,
+            expected_serialized_interpretations
+    );
+}
+
+/**
+ * @ingroup unit_tests_query
+ * @brief Creates and tests a query with multiple variable types.
+ *
+ * This test ensures that each non-wildcard token is assigned to the highest priority variable.
+ *
+ * NOTE: Similar to the above `int_query` test there are unneeded intepretations due to aggresively
+ * generating static-text tokens.
+ */
+TEST_CASE("non_wildcard_multi_variable_query", "[Query]") {
+    constexpr string_view cRawQueryString{"abc123 123"};
+    constexpr string_view cProcessedQueryString{"abc123 123"};
+
+    SECTION("int_priority") {
+        vector<string> const schema_rules{
+                {R"(int:(\d+))"},
+                {R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)"}
+        };
+        set<string> const expected_serialized_interpretations{
+                R"(logtype='abc123 123', contains_wildcard='0')",
+                R"(logtype='abc123 <0>(123)', contains_wildcard='00')",
+                R"(logtype='<1>(abc123) 123', contains_wildcard='00')",
+                R"(logtype='<1>(abc123) <0>(123)', contains_wildcard='000')"
+        };
+
+        test_query(
+                cRawQueryString,
+                cProcessedQueryString,
+                schema_rules,
+                expected_serialized_interpretations
+        );
+    }
+
+    SECTION("has_number_priority") {
+        vector<string> const schema_rules{
+                {R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)"},
+                {R"(int:(\d+))"}
+        };
+        set<string> const expected_serialized_interpretations{
+                R"(logtype='abc123 123', contains_wildcard='0')",
+                R"(logtype='abc123 <0>(123)', contains_wildcard='00')",
+                R"(logtype='<0>(abc123) 123', contains_wildcard='00')",
+                R"(logtype='<0>(abc123) <0>(123)', contains_wildcard='000')"
+        };
+
+        test_query(
+                cRawQueryString,
+                cProcessedQueryString,
+                schema_rules,
+                expected_serialized_interpretations
+        );
+    }
+}
+
+/**
+ * @ingroup unit_tests_query
+ * @brief Creates and tests a query with multiple variable types.
+ *
+ * This test ensures that each greedy wildcard token is identified as all correct token types.
+ *
+ * NOTE: Similar to the above `int_query` test there are unneeded intepretations due to aggresively
+ * generating static-text tokens. This same issue causes interpretations with redundant wildcards.
+ */
+TEST_CASE("wildcard_multi_variable_query", "[Query]") {
+    constexpr string_view cRawQueryString{"abc123* *123"};
+    constexpr string_view cProcessedQueryString{"abc123* *123"};
+
+    vector<string> const schema_rules{
+            {R"(int:(\d+))"},
+            {R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)"}
+    };
+    set<string> const expected_serialized_interpretations{
+            R"(logtype='abc123* *123', contains_wildcard='0')",
+            R"(logtype='abc123*** *123', contains_wildcard='0')",
+            R"(logtype='abc123* ***123', contains_wildcard='0')",
+            R"(logtype='abc123*** ***123', contains_wildcard='0')",
+            R"(logtype='abc123* **<0>(*123)', contains_wildcard='01')",
+            R"(logtype='abc123*** **<0>(*123)', contains_wildcard='01')",
+            R"(logtype='abc123* **<1>(*123)', contains_wildcard='01')",
+            R"(logtype='abc123*** **<1>(*123)', contains_wildcard='01')",
+            R"(logtype='<1>(abc123*)** *123', contains_wildcard='10')",
+            R"(logtype='<1>(abc123*)** ***123', contains_wildcard='10')",
+            R"(logtype='<1>(abc123*)** **<0>(*123)', contains_wildcard='101')",
+            R"(logtype='<1>(abc123*)** **<1>(*123)', contains_wildcard='101')"
+    };
+
+    test_query(
+            cRawQueryString,
+            cProcessedQueryString,
+            schema_rules,
+            expected_serialized_interpretations
+    );
 }

--- a/tests/test-query.cpp
+++ b/tests/test-query.cpp
@@ -235,9 +235,9 @@ TEST_CASE("long_non_greedy_wildcard_sequence_query", "[Query]") {
  * @brief Creates and tests a query with an escaped '*' character.
  */
 TEST_CASE("escaped_star_query", "[Query]") {
-    constexpr string_view cRawQueryString{"*"};
-    constexpr string_view cProcessedQueryString{"*"};
-    set<string> const expected_serialized_interpretations{"logtype='*', contains_wildcard='0'"};
+    constexpr string_view cRawQueryString{R"(a\*b)"};
+    constexpr string_view cProcessedQueryString{R"(a\*b)"};
+    set<string> const expected_serialized_interpretations{R"(logtype='a\*b', contains_wildcard='0')"};
 
     test_query(cRawQueryString, cProcessedQueryString, expected_serialized_interpretations);
 }

--- a/tests/test-query.cpp
+++ b/tests/test-query.cpp
@@ -120,12 +120,12 @@ TEST_CASE("repeated_greedy_wildcard_query", "[Query]") {
     constexpr string_view cRawQueryString{"a**b"};
     constexpr string_view cProcessedQueryString{"a*b"};
     set<string> const expected_serialized_interpretations{
-            {"logtype='a*b', contains_wildcard='0'"},
-            {"logtype='a***b', contains_wildcard='0'"},
-            {"logtype='<0>(a*)**b', contains_wildcard='10'"},
-            {"logtype='<0>(a*)*<0>(*b)', contains_wildcard='101'"},
-            {"logtype='<0>(a*b)', contains_wildcard='1'"},
-            {"logtype='a**<0>(*b)', contains_wildcard='01'"}
+            "logtype='a*b', contains_wildcard='0'",
+            "logtype='a***b', contains_wildcard='0'",
+            "logtype='<0>(a*)**b', contains_wildcard='10'",
+            "logtype='<0>(a*)*<0>(*b)', contains_wildcard='101'",
+            "logtype='<0>(a*b)', contains_wildcard='1'",
+            "logtype='a**<0>(*b)', contains_wildcard='01'"
     };
 
     test_query(cRawQueryString, cProcessedQueryString, expected_serialized_interpretations);
@@ -139,12 +139,12 @@ TEST_CASE("short_wildcard_sequence_query", "[Query]") {
     constexpr string_view cRawQueryString{"a?*b"};
     constexpr string_view cProcessedQueryString{"a*b"};
     set<string> const expected_serialized_interpretations{
-            {"logtype='a*b', contains_wildcard='0'"},
-            {"logtype='a***b', contains_wildcard='0'"},
-            {"logtype='<0>(a*)**b', contains_wildcard='10'"},
-            {"logtype='<0>(a*)*<0>(*b)', contains_wildcard='101'"},
-            {"logtype='<0>(a*b)', contains_wildcard='1'"},
-            {"logtype='a**<0>(*b)', contains_wildcard='01'"}
+            "logtype='a*b', contains_wildcard='0'",
+            "logtype='a***b', contains_wildcard='0'",
+            "logtype='<0>(a*)**b', contains_wildcard='10'",
+            "logtype='<0>(a*)*<0>(*b)', contains_wildcard='101'",
+            "logtype='<0>(a*b)', contains_wildcard='1'",
+            "logtype='a**<0>(*b)', contains_wildcard='01'"
     };
 
     test_query(cRawQueryString, cProcessedQueryString, expected_serialized_interpretations);
@@ -158,12 +158,12 @@ TEST_CASE("long_mixed_wildcard_sequence_query", "[Query]") {
     constexpr string_view cRawQueryString{"a?*?*?*?b"};
     constexpr string_view cProcessedQueryString{"a*b"};
     set<string> const expected_serialized_interpretations{
-            {"logtype='a*b', contains_wildcard='0'"},
-            {"logtype='a***b', contains_wildcard='0'"},
-            {"logtype='<0>(a*)**b', contains_wildcard='10'"},
-            {"logtype='<0>(a*)*<0>(*b)', contains_wildcard='101'"},
-            {"logtype='<0>(a*b)', contains_wildcard='1'"},
-            {"logtype='a**<0>(*b)', contains_wildcard='01'"}
+            "logtype='a*b', contains_wildcard='0'",
+            "logtype='a***b', contains_wildcard='0'",
+            "logtype='<0>(a*)**b', contains_wildcard='10'",
+            "logtype='<0>(a*)*<0>(*b)', contains_wildcard='101'",
+            "logtype='<0>(a*b)', contains_wildcard='1'",
+            "logtype='a**<0>(*b)', contains_wildcard='01'"
     };
 
     test_query(cRawQueryString, cProcessedQueryString, expected_serialized_interpretations);
@@ -177,54 +177,54 @@ TEST_CASE("long_non_greedy_wildcard_sequence_query", "[Query]") {
     constexpr string_view cRawQueryString{"a????b"};
     constexpr string_view cProcessedQueryString{"a????b"};
     set<string> const expected_serialized_interpretations{
-            {R"(logtype='a????b', contains_wildcard='0')"},
+            R"(logtype='a????b', contains_wildcard='0')",
 
-            {R"(logtype='<0>(a?)???b', contains_wildcard='10')"},
-            {R"(logtype='<0>(a??)??b', contains_wildcard='10')"},
-            {R"(logtype='<0>(a???)?b', contains_wildcard='10')"},
-            {R"(logtype='<0>(a????b)', contains_wildcard='1')"},
+            R"(logtype='<0>(a?)???b', contains_wildcard='10')",
+            R"(logtype='<0>(a??)??b', contains_wildcard='10')",
+            R"(logtype='<0>(a???)?b', contains_wildcard='10')",
+            R"(logtype='<0>(a????b)', contains_wildcard='1')",
 
-            {R"(logtype='a?<0>(?)??b', contains_wildcard='010')"},
-            {R"(logtype='a?<0>(??)?b', contains_wildcard='010')"},
-            {R"(logtype='a?<0>(???b)', contains_wildcard='01')"},
-            {R"(logtype='a?<0>(?)?<0>(?b)', contains_wildcard='0101')"},
+            R"(logtype='a?<0>(?)??b', contains_wildcard='010')",
+            R"(logtype='a?<0>(??)?b', contains_wildcard='010')",
+            R"(logtype='a?<0>(???b)', contains_wildcard='01')",
+            R"(logtype='a?<0>(?)?<0>(?b)', contains_wildcard='0101')",
 
-            {R"(logtype='a??<0>(?)?b', contains_wildcard='010')"},
-            {R"(logtype='a??<0>(??b)', contains_wildcard='01')"},
+            R"(logtype='a??<0>(?)?b', contains_wildcard='010')",
+            R"(logtype='a??<0>(??b)', contains_wildcard='01')",
 
-            {R"(logtype='a???<0>(?b)', contains_wildcard='01')"},
+            R"(logtype='a???<0>(?b)', contains_wildcard='01')",
 
-            {R"(logtype='<0>(a?)?<0>(?)?b', contains_wildcard='1010')"},
-            {R"(logtype='<0>(a?)?<0>(??b)', contains_wildcard='101')"},
-            {R"(logtype='<0>(a?)??<0>(?b)', contains_wildcard='101')"},
+            R"(logtype='<0>(a?)?<0>(?)?b', contains_wildcard='1010')",
+            R"(logtype='<0>(a?)?<0>(??b)', contains_wildcard='101')",
+            R"(logtype='<0>(a?)??<0>(?b)', contains_wildcard='101')",
 
-            {R"(logtype='<0>(a??)?<0>(?b)', contains_wildcard='101')"},
+            R"(logtype='<0>(a??)?<0>(?b)', contains_wildcard='101')",
 
             // Double dipping on delimiters
-            {R"(logtype='<0>(a?)<0>(?)??b', contains_wildcard='110')"},
-            {R"(logtype='<0>(a?)<0>(??)?b', contains_wildcard='110')"},
-            {R"(logtype='<0>(a?)<0>(???b)', contains_wildcard='11')"},
-            {R"(logtype='<0>(a?)<0>(?)?<0>(?b)', contains_wildcard='1101')"},
-            {R"(logtype='<0>(a?)?<0>(?)<0>(?b)', contains_wildcard='1011')"},
+            R"(logtype='<0>(a?)<0>(?)??b', contains_wildcard='110')",
+            R"(logtype='<0>(a?)<0>(??)?b', contains_wildcard='110')",
+            R"(logtype='<0>(a?)<0>(???b)', contains_wildcard='11')",
+            R"(logtype='<0>(a?)<0>(?)?<0>(?b)', contains_wildcard='1101')",
+            R"(logtype='<0>(a?)?<0>(?)<0>(?b)', contains_wildcard='1011')",
 
-            {R"(logtype='<0>(a??)<0>(?)?b', contains_wildcard='110')"},
-            {R"(logtype='<0>(a??)<0>(??b)', contains_wildcard='11')"},
+            R"(logtype='<0>(a??)<0>(?)?b', contains_wildcard='110')",
+            R"(logtype='<0>(a??)<0>(??b)', contains_wildcard='11')",
 
-            {R"(logtype='<0>(a???)<0>(?b)', contains_wildcard='11')"},
+            R"(logtype='<0>(a???)<0>(?b)', contains_wildcard='11')",
 
-            {R"(logtype='a?<0>(?)<0>(?)?b', contains_wildcard='0110')"},
-            {R"(logtype='a?<0>(?)<0>(??b)', contains_wildcard='011')"},
+            R"(logtype='a?<0>(?)<0>(?)?b', contains_wildcard='0110')",
+            R"(logtype='a?<0>(?)<0>(??b)', contains_wildcard='011')",
 
-            {R"(logtype='a?<0>(??)<0>(?b)', contains_wildcard='011')"},
-            {R"(logtype='a??<0>(?)<0>(?b)', contains_wildcard='011')"},
+            R"(logtype='a?<0>(??)<0>(?b)', contains_wildcard='011')",
+            R"(logtype='a??<0>(?)<0>(?b)', contains_wildcard='011')",
 
-            {R"(logtype='<0>(a?)<0>(?)<0>(?)?b', contains_wildcard='1110')"},
-            {R"(logtype='<0>(a?)<0>(?)<0>(??b)', contains_wildcard='111')"},
-            {R"(logtype='<0>(a?)<0>(??)<0>(?b)', contains_wildcard='111')"},
-            {R"(logtype='<0>(a??)<0>(?)<0>(?b)', contains_wildcard='111')"},
-            {R"(logtype='a?<0>(?)<0>(?)<0>(?b)', contains_wildcard='0111')"},
+            R"(logtype='<0>(a?)<0>(?)<0>(?)?b', contains_wildcard='1110')",
+            R"(logtype='<0>(a?)<0>(?)<0>(??b)', contains_wildcard='111')",
+            R"(logtype='<0>(a?)<0>(??)<0>(?b)', contains_wildcard='111')",
+            R"(logtype='<0>(a??)<0>(?)<0>(?b)', contains_wildcard='111')",
+            R"(logtype='a?<0>(?)<0>(?)<0>(?b)', contains_wildcard='0111')",
 
-            {R"(logtype='<0>(a?)<0>(?)<0>(?)<0>(?b)', contains_wildcard='1111')"}
+            R"(logtype='<0>(a?)<0>(?)<0>(?)<0>(?b)', contains_wildcard='1111')"
     };
 
     test_query(cRawQueryString, cProcessedQueryString, expected_serialized_interpretations);

--- a/tests/test-query.cpp
+++ b/tests/test-query.cpp
@@ -12,7 +12,7 @@
 
 /**
  * @defgroup unit_tests_query `Query` unit tests.
- * @brief Unit tests for `Query` construction, mutation, and comparison.
+ * @brief Unit tests for `Query` construction and interpretation.
 
  * These unit tests contain the `Query` tag.
  */

--- a/tests/test-query.cpp
+++ b/tests/test-query.cpp
@@ -87,8 +87,9 @@ auto make_test_lexer(vector<string> const& schema_rules) -> ByteLexer {
     REQUIRE(schema_rules.size() == schema_ast->m_schema_vars.size());
     for (size_t i{0}; i < schema_ast->m_schema_vars.size(); ++i) {
         REQUIRE(nullptr != schema_ast->m_schema_vars[i]);
-        auto& capture_rule_ast{dynamic_cast<SchemaVarAST&>(*schema_ast->m_schema_vars[i])};
-        lexer.add_rule(i, std::move(capture_rule_ast.m_regex_ptr));
+        auto* capture_rule_ast{dynamic_cast<SchemaVarAST*>(schema_ast->m_schema_vars[i].get())};
+        REQUIRE(nullptr != capture_rule_ast);
+        lexer.add_rule(i, std::move(capture_rule_ast->m_regex_ptr));
     }
 
     lexer.generate();

--- a/tests/test-query.cpp
+++ b/tests/test-query.cpp
@@ -237,7 +237,9 @@ TEST_CASE("long_non_greedy_wildcard_sequence_query", "[Query]") {
 TEST_CASE("escaped_star_query", "[Query]") {
     constexpr string_view cRawQueryString{R"(a\*b)"};
     constexpr string_view cProcessedQueryString{R"(a\*b)"};
-    set<string> const expected_serialized_interpretations{R"(logtype='a\*b', contains_wildcard='0')"};
+    set<string> const expected_serialized_interpretations{
+            R"(logtype='a\*b', contains_wildcard='0')"
+    };
 
     test_query(cRawQueryString, cProcessedQueryString, expected_serialized_interpretations);
 }

--- a/tests/test-query.cpp
+++ b/tests/test-query.cpp
@@ -299,7 +299,7 @@ TEST_CASE("escaped_star_query", "[Query]") {
  * @ingroup unit_tests_query
  * @brief Creates and tests a query with an escaped '*' character.
  *
- * NOTE: This has a static-text case as strings "1", "2', and "3" in isolation aren't surrounded by
+ * NOTE: This has a static-text case as strings "1", "2", and "3" in isolation aren't surrounded by
  * delimiters. These tokens then build up the interpretation "123". Although additional
  * interpretations don't impact correctness, they may impact performance. We can optimize these out,
  * but it'll make the code messy. Instead, we should eventually remove the explicit tracking of
@@ -328,7 +328,7 @@ TEST_CASE("int_query", "[Query]") {
  *
  * This test ensures that each non-wildcard token is assigned to the highest priority variable.
  *
- * NOTE: Similar to the above `int_query` test there are unneeded intepretations due to aggresively
+ * NOTE: Similar to the above `int_query` test there are unneeded interpretations due to aggresively
  * generating static-text tokens.
  */
 TEST_CASE("non_wildcard_multi_variable_query", "[Query]") {
@@ -376,7 +376,7 @@ TEST_CASE("non_wildcard_multi_variable_query", "[Query]") {
  *
  * This test ensures that each greedy wildcard token is identified as all correct token types.
  *
- * NOTE: Similar to the above `int_query` test there are unneeded intepretations due to aggresively
+ * NOTE: Similar to the above `int_query` test there are unneeded interpretations due to aggresively
  * generating static-text tokens. This same issue causes interpretations with redundant wildcards.
  */
 TEST_CASE("wildcard_multi_variable_query", "[Query]") {

--- a/tests/test-query.cpp
+++ b/tests/test-query.cpp
@@ -28,7 +28,7 @@ using std::string_view;
 namespace {
 /**
  * Creates a query from the given query string and tests that its processed query string and
- * interpretations match the expeced values.
+ * interpretations match the expected values.
  *
  * @param raw_query_string The search query.
  * @param expected_processed_query_string The processed search query.

--- a/tests/test-query.cpp
+++ b/tests/test-query.cpp
@@ -1,0 +1,104 @@
+#include <set>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <log_surgeon/BufferParser.hpp>
+#include <log_surgeon/Schema.hpp>
+#include <log_surgeon/wildcard_query_parser/Query.hpp>
+
+#include <catch2/catch_message.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+/**
+ * @defgroup unit_tests_query `Query` unit tests.
+ * @brief Unit tests for `Query` construction, mutation, and comparison.
+
+ * These unit tests contain the `Query` tag.
+ */
+
+using std::set;
+using std::string;
+using std::string_view;
+using std::vector;
+
+using log_surgeon::BufferParser;
+using log_surgeon::Schema;
+using log_surgeon::wildcard_query_parser::Query;
+
+namespace {
+/**
+ * Creates a query from the given query string and tests that its processed query string and
+ * interpretations matche the expeced values.
+ *
+ * @param raw_query_string The search query.
+ * @param expected_processed_query_string The processed search query.
+ * @param expected_serialized_interpretations  The expected set of serialized interpretations.
+ */
+auto test_query(
+        string_view raw_query_string,
+        string_view expected_processed_query_string,
+        set<string> const& expected_serialized_interpretations
+) -> void;
+
+/**
+ * Initializes a `BufferParser` with delimiters "\n\r\[:" and variable "myVar:userID=(?<uid>123)".
+ *
+ * @result The initialized `BufferParser`.
+ */
+auto make_test_buffer() -> BufferParser;
+
+auto test_query(
+        string_view raw_query_string,
+        string_view expected_processed_query_string,
+        set<string> const& expected_serialized_interpretations
+) -> void {
+    auto const& buffer_parser{make_test_buffer()};
+    auto const& lexer{buffer_parser.get_log_parser().m_lexer};
+
+    Query const query{string(raw_query_string)};
+    REQUIRE(expected_processed_query_string == query.get_processed_query_string());
+
+    auto const interpretations{query.get_all_multi_token_interpretations(lexer)};
+    set<string> serialized_interpretations;
+    for (auto const& interpretation : interpretations) {
+        serialized_interpretations.insert(interpretation.serialize());
+    }
+
+    CAPTURE(expected_serialized_interpretations);
+    CAPTURE(serialized_interpretations);
+    REQUIRE(expected_serialized_interpretations.size() == serialized_interpretations.size());
+    REQUIRE(expected_serialized_interpretations == serialized_interpretations);
+}
+
+auto make_test_buffer() -> BufferParser {
+    Schema schema;
+    schema.add_delimiters(R"(delimiters: \n\r\[:,)");
+    schema.add_variable(R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)", -1);
+    return BufferParser(std::move(schema.release_schema_ast_ptr()));
+}
+}  // namespace
+
+/**
+ * @ingroup unit_tests_query
+ * @brief Creates and tests an empty `Query`.
+ */
+TEST_CASE("empty_query", "[Query]") {
+    constexpr string_view raw_query_string{""};
+    constexpr string_view processed_query_string{""};
+    set<string> const expected_serialized_interpretations;
+
+    test_query(raw_query_string, processed_query_string, expected_serialized_interpretations);
+}
+
+/**
+ * @ingroup unit_tests_query
+ * @brief Creates and tests a greedy wildcard `Query`.
+ */
+TEST_CASE("greedy_wildcard_query", "[Query]") {
+    constexpr string_view raw_query_string{"*"};
+    constexpr string_view processed_query_string{"*"};
+    set<string> const expected_serialized_interpretations{"logtype='*', contains_wildcard='0'"};
+
+    test_query(raw_query_string, processed_query_string, expected_serialized_interpretations);
+}

--- a/tests/test-query.cpp
+++ b/tests/test-query.cpp
@@ -1,7 +1,7 @@
 #include <set>
 #include <string>
 #include <string_view>
-#include <vector>
+#include <utility>
 
 #include <log_surgeon/BufferParser.hpp>
 #include <log_surgeon/Schema.hpp>
@@ -20,7 +20,6 @@
 using std::set;
 using std::string;
 using std::string_view;
-using std::vector;
 
 using log_surgeon::BufferParser;
 using log_surgeon::Schema;
@@ -84,11 +83,11 @@ auto make_test_buffer() -> BufferParser {
  * @brief Creates and tests an empty `Query`.
  */
 TEST_CASE("empty_query", "[Query]") {
-    constexpr string_view raw_query_string{""};
-    constexpr string_view processed_query_string{""};
+    constexpr string_view cRawQueryString;
+    constexpr string_view cProcessedQueryString;
     set<string> const expected_serialized_interpretations;
 
-    test_query(raw_query_string, processed_query_string, expected_serialized_interpretations);
+    test_query(cRawQueryString, cProcessedQueryString, expected_serialized_interpretations);
 }
 
 /**
@@ -96,9 +95,9 @@ TEST_CASE("empty_query", "[Query]") {
  * @brief Creates and tests a greedy wildcard `Query`.
  */
 TEST_CASE("greedy_wildcard_query", "[Query]") {
-    constexpr string_view raw_query_string{"*"};
-    constexpr string_view processed_query_string{"*"};
+    constexpr string_view cRawQueryString{"*"};
+    constexpr string_view cProcessedQueryString{"*"};
     set<string> const expected_serialized_interpretations{"logtype='*', contains_wildcard='0'"};
 
-    test_query(raw_query_string, processed_query_string, expected_serialized_interpretations);
+    test_query(cRawQueryString, cProcessedQueryString, expected_serialized_interpretations);
 }

--- a/tests/test-query.cpp
+++ b/tests/test-query.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <set>
 #include <string>
 #include <string_view>
@@ -77,10 +78,8 @@ auto make_test_lexer(vector<string> const& schema_rules) -> ByteLexer {
     lexer.set_delimiters({' '});
 
     Schema schema;
-    size_t symbol_id{0};
     for (auto const& schema_rule : schema_rules) {
         schema.add_variable(schema_rule, -1);
-        ++symbol_id;
     }
 
     auto const schema_ast = schema.release_schema_ast_ptr();

--- a/tests/test-query.cpp
+++ b/tests/test-query.cpp
@@ -3,11 +3,11 @@
 #include <string_view>
 #include <utility>
 
-#include <log_surgeon/BufferParser.hpp>
+#include <log_surgeon/Lexer.hpp>
 #include <log_surgeon/Schema.hpp>
+#include <log_surgeon/SchemaParser.hpp>
 #include <log_surgeon/wildcard_query_parser/Query.hpp>
 
-#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 /**
@@ -17,13 +17,13 @@
  * These unit tests contain the `Query` tag.
  */
 
+using log_surgeon::lexers::ByteLexer;
+using log_surgeon::Schema;
+using log_surgeon::SchemaVarAST;
+using log_surgeon::wildcard_query_parser::Query;
 using std::set;
 using std::string;
 using std::string_view;
-
-using log_surgeon::BufferParser;
-using log_surgeon::Schema;
-using log_surgeon::wildcard_query_parser::Query;
 
 namespace {
 /**
@@ -41,19 +41,18 @@ auto test_query(
 ) -> void;
 
 /**
- * Initializes a `BufferParser` with delimiters "\n\r\[:" and variable "myVar:userID=(?<uid>123)".
+ * Initializes a `ByteLexer` with delimiters "\n\r\[:" and variable "myVar:userID=(?<uid>123)".
  *
- * @result The initialized `BufferParser`.
+ * @result The initialized `ByteLexer`.
  */
-auto make_test_buffer() -> BufferParser;
+auto make_test_lexer() -> ByteLexer;
 
 auto test_query(
-        string_view raw_query_string,
-        string_view expected_processed_query_string,
+        string_view const raw_query_string,
+        string_view const expected_processed_query_string,
         set<string> const& expected_serialized_interpretations
 ) -> void {
-    auto const& buffer_parser{make_test_buffer()};
-    auto const& lexer{buffer_parser.get_log_parser().m_lexer};
+    auto const& lexer{make_test_lexer()};
 
     Query const query{string(raw_query_string)};
     REQUIRE(expected_processed_query_string == query.get_processed_query_string());
@@ -64,17 +63,24 @@ auto test_query(
         serialized_interpretations.insert(interpretation.serialize());
     }
 
-    CAPTURE(expected_serialized_interpretations);
-    CAPTURE(serialized_interpretations);
-    REQUIRE(expected_serialized_interpretations.size() == serialized_interpretations.size());
     REQUIRE(expected_serialized_interpretations == serialized_interpretations);
 }
 
-auto make_test_buffer() -> BufferParser {
+auto make_test_lexer() -> ByteLexer {
     Schema schema;
     schema.add_delimiters(R"(delimiters: \n\r\[:,)");
     schema.add_variable(R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)", -1);
-    return BufferParser(std::move(schema.release_schema_ast_ptr()));
+
+    ByteLexer lexer;
+    lexer.m_symbol_id["hasNumber"] = 0;
+    lexer.m_id_symbol[0] = "hasNumber";
+
+    auto const schema_ast = schema.release_schema_ast_ptr();
+    auto& capture_rule_ast = dynamic_cast<SchemaVarAST&>(*schema_ast->m_schema_vars[0]);
+    lexer.add_rule(lexer.m_symbol_id["hasNumber"], std::move(capture_rule_ast.m_regex_ptr));
+
+    lexer.generate();
+    return lexer;
 }
 }  // namespace
 
@@ -95,6 +101,136 @@ TEST_CASE("empty_query", "[Query]") {
  * @brief Creates and tests a greedy wildcard `Query`.
  */
 TEST_CASE("greedy_wildcard_query", "[Query]") {
+    constexpr string_view cRawQueryString{"*"};
+    constexpr string_view cProcessedQueryString{"*"};
+    set<string> const expected_serialized_interpretations{"logtype='*', contains_wildcard='0'"};
+
+    test_query(cRawQueryString, cProcessedQueryString, expected_serialized_interpretations);
+}
+
+/**
+ * @ingroup unit_tests_query
+ * @brief Creates and tests a query with repeated greedy wildcards.
+ */
+TEST_CASE("repeated_greedy_wildcard_query", "[Query]") {
+    constexpr string_view cRawQueryString{"a**b"};
+    constexpr string_view cProcessedQueryString{"a*b"};
+    set<string> const expected_serialized_interpretations{
+            {"logtype='a*b', contains_wildcard='0'"},
+            {"logtype='a***b', contains_wildcard='0'"},
+            {"logtype='<0>(a*)**b', contains_wildcard='10'"},
+            {"logtype='<0>(a*)*<0>(*b)', contains_wildcard='101'"},
+            {"logtype='<0>(a*b)', contains_wildcard='1'"},
+            {"logtype='a**<0>(*b)', contains_wildcard='01'"}
+    };
+
+    test_query(cRawQueryString, cProcessedQueryString, expected_serialized_interpretations);
+}
+
+/**
+ * @ingroup unit_tests_query
+ * @brief Creates and tests a query with a non-greedy wildcard followed by a greedy wildcard.
+ */
+TEST_CASE("short_wildcard_sequence_query", "[Query]") {
+    constexpr string_view cRawQueryString{"a?*b"};
+    constexpr string_view cProcessedQueryString{"a*b"};
+    set<string> const expected_serialized_interpretations{
+            {"logtype='a*b', contains_wildcard='0'"},
+            {"logtype='a***b', contains_wildcard='0'"},
+            {"logtype='<0>(a*)**b', contains_wildcard='10'"},
+            {"logtype='<0>(a*)*<0>(*b)', contains_wildcard='101'"},
+            {"logtype='<0>(a*b)', contains_wildcard='1'"},
+            {"logtype='a**<0>(*b)', contains_wildcard='01'"}
+    };
+
+    test_query(cRawQueryString, cProcessedQueryString, expected_serialized_interpretations);
+}
+
+/**
+ * @ingroup unit_tests_query
+ * @brief Creates and tests a query with a long mixed wildcard sequence.
+ */
+TEST_CASE("long_mixed_wildcard_sequence_query", "[Query]") {
+    constexpr string_view cRawQueryString{"a?*?*?*?b"};
+    constexpr string_view cProcessedQueryString{"a*b"};
+    set<string> const expected_serialized_interpretations{
+            {"logtype='a*b', contains_wildcard='0'"},
+            {"logtype='a***b', contains_wildcard='0'"},
+            {"logtype='<0>(a*)**b', contains_wildcard='10'"},
+            {"logtype='<0>(a*)*<0>(*b)', contains_wildcard='101'"},
+            {"logtype='<0>(a*b)', contains_wildcard='1'"},
+            {"logtype='a**<0>(*b)', contains_wildcard='01'"}
+    };
+
+    test_query(cRawQueryString, cProcessedQueryString, expected_serialized_interpretations);
+}
+
+/**
+ * @ingroup unit_tests_query
+ * @brief Creates and tests a query with a long non-greedy wildcard sequence.
+ */
+TEST_CASE("long_non_greedy_wildcard_sequence_query", "[Query]") {
+    constexpr string_view cRawQueryString{"a????b"};
+    constexpr string_view cProcessedQueryString{"a????b"};
+    set<string> const expected_serialized_interpretations{
+            {R"(logtype='a????b', contains_wildcard='0')"},
+
+            {R"(logtype='<0>(a?)???b', contains_wildcard='10')"},
+            {R"(logtype='<0>(a??)??b', contains_wildcard='10')"},
+            {R"(logtype='<0>(a???)?b', contains_wildcard='10')"},
+            {R"(logtype='<0>(a????b)', contains_wildcard='1')"},
+
+            {R"(logtype='a?<0>(?)??b', contains_wildcard='010')"},
+            {R"(logtype='a?<0>(??)?b', contains_wildcard='010')"},
+            {R"(logtype='a?<0>(???b)', contains_wildcard='01')"},
+            {R"(logtype='a?<0>(?)?<0>(?b)', contains_wildcard='0101')"},
+
+            {R"(logtype='a??<0>(?)?b', contains_wildcard='010')"},
+            {R"(logtype='a??<0>(??b)', contains_wildcard='01')"},
+
+            {R"(logtype='a???<0>(?b)', contains_wildcard='01')"},
+
+            {R"(logtype='<0>(a?)?<0>(?)?b', contains_wildcard='1010')"},
+            {R"(logtype='<0>(a?)?<0>(??b)', contains_wildcard='101')"},
+            {R"(logtype='<0>(a?)??<0>(?b)', contains_wildcard='101')"},
+
+            {R"(logtype='<0>(a??)?<0>(?b)', contains_wildcard='101')"},
+
+            // Double dipping on delimiters
+            {R"(logtype='<0>(a?)<0>(?)??b', contains_wildcard='110')"},
+            {R"(logtype='<0>(a?)<0>(??)?b', contains_wildcard='110')"},
+            {R"(logtype='<0>(a?)<0>(???b)', contains_wildcard='11')"},
+            {R"(logtype='<0>(a?)<0>(?)?<0>(?b)', contains_wildcard='1101')"},
+            {R"(logtype='<0>(a?)?<0>(?)<0>(?b)', contains_wildcard='1011')"},
+
+            {R"(logtype='<0>(a??)<0>(?)?b', contains_wildcard='110')"},
+            {R"(logtype='<0>(a??)<0>(??b)', contains_wildcard='11')"},
+
+            {R"(logtype='<0>(a???)<0>(?b)', contains_wildcard='11')"},
+
+            {R"(logtype='a?<0>(?)<0>(?)?b', contains_wildcard='0110')"},
+            {R"(logtype='a?<0>(?)<0>(??b)', contains_wildcard='011')"},
+
+            {R"(logtype='a?<0>(??)<0>(?b)', contains_wildcard='011')"},
+            {R"(logtype='a??<0>(?)<0>(?b)', contains_wildcard='011')"},
+
+            {R"(logtype='<0>(a?)<0>(?)<0>(?)?b', contains_wildcard='1110')"},
+            {R"(logtype='<0>(a?)<0>(?)<0>(??b)', contains_wildcard='111')"},
+            {R"(logtype='<0>(a?)<0>(??)<0>(?b)', contains_wildcard='111')"},
+            {R"(logtype='<0>(a??)<0>(?)<0>(?b)', contains_wildcard='111')"},
+            {R"(logtype='a?<0>(?)<0>(?)<0>(?b)', contains_wildcard='0111')"},
+
+            {R"(logtype='<0>(a?)<0>(?)<0>(?)<0>(?b)', contains_wildcard='1111')"}
+    };
+
+    test_query(cRawQueryString, cProcessedQueryString, expected_serialized_interpretations);
+}
+
+/**
+ * @ingroup unit_tests_query
+ * @brief Creates and tests a query with an escaped '*' character.
+ */
+TEST_CASE("escaped_star_query", "[Query]") {
     constexpr string_view cRawQueryString{"*"};
     constexpr string_view cProcessedQueryString{"*"};
     set<string> const expected_serialized_interpretations{"logtype='*', contains_wildcard='0'"};

--- a/tests/test-query.cpp
+++ b/tests/test-query.cpp
@@ -138,7 +138,7 @@ TEST_CASE("greedy_wildcard_query", "[Query]") {
  * @brief Creates and tests a query with repeated greedy wildcards.
  */
 TEST_CASE("repeated_greedy_wildcard_query", "[Query]") {
-    constexpr string_view cRawQueryString{"a**b"};
+    constexpr string_view cRawQueryString{"a*****b"};
     constexpr string_view cProcessedQueryString{"a*b"};
     vector<string> const schema_rules{{R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)"}};
     set<string> const expected_serialized_interpretations{
@@ -164,40 +164,15 @@ TEST_CASE("repeated_greedy_wildcard_query", "[Query]") {
  */
 TEST_CASE("short_wildcard_sequence_query", "[Query]") {
     constexpr string_view cRawQueryString{"a?*b"};
-    constexpr string_view cProcessedQueryString{"a*b"};
+    constexpr string_view cProcessedQueryString{"a?*b"};
     vector<string> const schema_rules{{R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)"}};
     set<string> const expected_serialized_interpretations{
-            "logtype='a*b', contains_wildcard='0'",
-            "logtype='a***b', contains_wildcard='0'",
-            "logtype='<0>(a*)**b', contains_wildcard='10'",
-            "logtype='<0>(a*)*<0>(*b)', contains_wildcard='101'",
-            "logtype='<0>(a*b)', contains_wildcard='1'",
-            "logtype='a**<0>(*b)', contains_wildcard='01'"
-    };
-
-    test_query(
-            cRawQueryString,
-            cProcessedQueryString,
-            schema_rules,
-            expected_serialized_interpretations
-    );
-}
-
-/**
- * @ingroup unit_tests_query
- * @brief Creates and tests a query with a long mixed wildcard sequence.
- */
-TEST_CASE("long_mixed_wildcard_sequence_query", "[Query]") {
-    constexpr string_view cRawQueryString{"a?*?*?*?b"};
-    constexpr string_view cProcessedQueryString{"a*b"};
-    vector<string> const schema_rules{{R"(hasNumber:[A-Za-z]*\d+[A-Za-z]*)"}};
-    set<string> const expected_serialized_interpretations{
-            "logtype='a*b', contains_wildcard='0'",
-            "logtype='a***b', contains_wildcard='0'",
-            "logtype='<0>(a*)**b', contains_wildcard='10'",
-            "logtype='<0>(a*)*<0>(*b)', contains_wildcard='101'",
-            "logtype='<0>(a*b)', contains_wildcard='1'",
-            "logtype='a**<0>(*b)', contains_wildcard='01'"
+            "logtype='a?*b', contains_wildcard='0'",
+            "logtype='a?***b', contains_wildcard='0'",
+            "logtype='<0>(a?*)**b', contains_wildcard='10'",
+            "logtype='<0>(a?*)*<0>(*b)', contains_wildcard='101'",
+            "logtype='<0>(a?*b)', contains_wildcard='1'",
+            "logtype='a?**<0>(*b)', contains_wildcard='01'"
     };
 
     test_query(


### PR DESCRIPTION
# Description
The Query constructor previously collapsed any sequence of wildcards that contained a greedy wildcard:
- "a*****b" -> "a*b"
- "a?*b" -> "a*b"
- "a?*?*b" -> "a*b"
- "a???b" -> "a???b"

However, removing any non-greedy wildcards (`?`) will result in a more general search query. This is not correct as the resulting interpretation will can match against logtypes the user does not want to match against. For example:

"a?*b" converted to "a*b" can match "ab". "ab" is not valid under "a?*b".

We now only collapse sequences of greedy wildcards, while any sequence with a non-greedy wildcard is preserved.
- "a*****b" -> "a*b"
- "a?*b" -> "a?*b"
- "a?*?*b" -> "a?*?*b"
- "a???b" -> "a???b"

# Validation performed
Updated unit-tests to reflect this change:
- "a**b" unit-test extended to "a*****b" to test longer sequences of greed ywildcards.
- "a?*b" unit-test now checks for the processed string to be "a?*b" and check that the logtypes contain the `?` wildcard.
- longer mixed wildcard sequences are no longer tested as they don't need to be collapsed.