### PR TITLE
docs: Correct `get_all_multi_token_interpretations` docstring; Correct `int_query` docstring.

### DIFF
--- a/src/log_surgeon/wildcard_query_parser/Query.hpp
+++ b/src/log_surgeon/wildcard_query_parser/Query.hpp
@@ -16,7 +16,7 @@ public:
     explicit Query(std::string const& query_string);
 
     /**
-     * Generates all k-token interpretations of the n-character query string, where 1 <= k < n.
+     * Generates all k-token interpretations of the n-character query string, where 1 <= k <= n.
      *
      * 1. Interpret each substring [a,b) as a single token (k=1).
      *    - Substrings adjacent to greedy wildcards must be interpreted as if they include them. To
@@ -47,7 +47,7 @@ public:
      *      - Note: The length >= 2 requirement avoids skipping 1-length greedy substrings ("*") as
      *        they are never redundant (i.e., no 0-length substring exists to extend).
      *
-     * 2. Let I(a) be the set of all k-token interpretations of substring [0,a), where 1 <= k < a.
+     * 2. Let I(a) be the set of all k-token interpretations of substring [0,a), where 1 <= k <= a.
      *    - Let T(a,b) be the set of all valid single-token interpretations of substring [a,b).
      *    - We can then compute I(a) recursively:
      *

--- a/tests/test-query.cpp
+++ b/tests/test-query.cpp
@@ -297,7 +297,7 @@ TEST_CASE("escaped_star_query", "[Query]") {
 
 /**
  * @ingroup unit_tests_query
- * @brief Creates and tests a query with an escaped '*' character.
+ * @brief Creates and tests a numeric-only query.
  *
  * NOTE: This has a static-text case as strings "1", "2", and "3" in isolation aren't surrounded by
  * delimiters. These tokens then build up the interpretation "123". Although additional


### PR DESCRIPTION
# Description
Fix `get_all_multi_token_interpretations` docstring:
- Include k == n case in the `Query` class dynamic programming documentation. Previously it stated that the # of tokens, k, is strictly less than the # of characters in a query, n, and substring, a. However, if n == 1 then k == n is trivially true. Similarly, if a == 1 then k == n.

Fix `int_query` docstring:
- Specify that the query is numeric not an escaped wildcard character.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Clarified k bounds in Query documentation (from 1 ≤ k < n/a to 1 ≤ k ≤ n/a) to improve accuracy for multi-token interpretation guidance.
  - Updated a unit test brief from “escaped ‘*’ query” to “numeric-only query” for clearer intent.
  - No behavioural or functional changes.
  - No changes to public APIs or interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->