### PR TITLE
ci: Add build workflow for documentation-only changes

### DIFF
--- a/.github/workflows/build-lightweight.yaml
+++ b/.github/workflows/build-lightweight.yaml
@@ -1,0 +1,26 @@
+name: "build"
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/build-lightweight.yaml"
+      - "README.md"
+      - "docs/**/*"
+      - "*.md"
+  push:
+    paths:
+      - ".github/workflows/build-lightweight.yaml"
+      - "README.md"
+      - "docs/**/*"
+      - "*.md"
+
+concurrency:
+  group: "build-lightweight-${{github.ref}}"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Non-code changes only"
+        run: echo "Only non-code changes detected, skipping build"


### PR DESCRIPTION
# Description
This PR adds a lightweight build workflow that allows PRs with non-code changes to pass the required "build" check without running the full build and test suite.

## Problem
Currently, PRs that only modify documentation files (like README.md or files in docs/) or workflow configurations don't trigger the main `build.yaml` workflow due to its path filters. However, if branch protection rules require the "build" check to pass, these PRs get stuck waiting indefinitely for a status that never gets reported.

## Solution
Create a new workflow (`build-lightweight.yaml`) that:
  - Triggers only when non-code files are modified:
    - Documentation files: `README.md`, `docs/**/*`, `*.md`
    - The workflow file itself: `.github/workflows/build-lightweight.yaml`
  - Shares the same workflow name ("build") as the main build workflow to satisfy branch protection requirements
  - Quickly reports success without running expensive build/test steps
  - Uses a distinct concurrency group ("build-lightweight") to prevent conflicts

## Technical Details
The workflow uses a hardcoded concurrency group (`build-lightweight-${{github.ref}}`) instead of `${{github.workflow}}` to avoid concurrency conflicts. Without this, both the main build and lightweight workflows would share the same concurrency group (both resolve to "build") when a PR contains mixed changes (docs + code), potentially causing one workflow to cancel the other with `cancel-in-progress: true`.

## Behavior
  - **Non-code changes only**: lightweight workflow runs quickly and reports success
  - **Code changes only**: main build workflow runs with full tests
  - **Mixed changes**: both workflows run independently without interfering

# Checklist

  * [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
  * [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a breaking change.
  * [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
  - Verified the workflow YAML syntax is valid
  - Confirmed path filters target appropriate non-code files (documentation and workflow itself)
  - Tested that the concurrency group name is unique to prevent conflicts with the main build workflow
  - Validated that using the same workflow name ("build") allows both workflows to satisfy branch protection requirements

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build workflow with intelligent change detection to optimize pull request and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->