### PR TITLE
fix!: Set precedence for concatenation above alternation; Support alternations of all regex expressions (fixes #181).

### DIFF
--- a/src/log_surgeon/SchemaParser.cpp
+++ b/src/log_surgeon/SchemaParser.cpp
@@ -538,15 +538,16 @@ auto SchemaParser::add_productions() -> void {
     add_production("Identifier", {"IdentifierCharacters"}, new_identifier_rule);
     add_production("WhitespaceStar", {"WhitespaceStar", "Space"}, nullptr);
     add_production("WhitespaceStar", {}, nullptr);
-    add_production("Regex", {"Concat"}, regex_identity_rule);
-    add_production("Concat", {"Concat", "Or"}, regex_cat_rule);
-    add_production("Concat", {"Or"}, regex_identity_rule);
-    add_production("Or", {"Or", "Vbar", "Literal"}, regex_or_rule);
-    add_production("Or", {"MatchStar"}, regex_identity_rule);
-    add_production("Or", {"MatchPlus"}, regex_identity_rule);
-    add_production("Or", {"MatchExact"}, regex_identity_rule);
-    add_production("Or", {"MatchRange"}, regex_identity_rule);
-    add_production("Or", {"CompleteGroup"}, regex_identity_rule);
+    add_production("Regex", {"Or"}, regex_identity_rule);
+    add_production("Or", {"Or", "Vbar", "Concat"}, regex_or_rule);
+    add_production("Or", {"Concat"}, regex_identity_rule);
+    add_production("Concat", {"Concat", "Quantity"}, regex_cat_rule);
+    add_production("Concat", {"Quantity"}, regex_identity_rule);
+    add_production("Quantity", {"MatchStar"}, regex_identity_rule);
+    add_production("Quantity", {"MatchPlus"}, regex_identity_rule);
+    add_production("Quantity", {"MatchExact"}, regex_identity_rule);
+    add_production("Quantity", {"MatchRange"}, regex_identity_rule);
+    add_production("Quantity", {"CompleteGroup"}, regex_identity_rule);
     add_production("MatchStar", {"CompleteGroup", "Star"}, regex_match_zero_or_more_rule);
     add_production("MatchPlus", {"CompleteGroup", "Plus"}, regex_match_one_or_more_rule);
     add_production(

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -822,7 +822,7 @@ void RegexASTOr<TypedNfaState>::add_to_nfa(
 template <typename TypedNfaState>
 [[nodiscard]] auto RegexASTOr<TypedNfaState>::serialize() const -> std::u32string {
     return fmt::format(
-            U"({})|({}){}",
+            U"(({})|({}){})",
             nullptr != m_left ? m_left->serialize() : U"null",
             nullptr != m_right ? m_right->serialize() : U"null",
             RegexAST<TypedNfaState>::serialize_negative_captures()


### PR DESCRIPTION
# Reference
Addresses #181.

# Description
Fixes precedence:
- Simplifies productions in schema parser slightly by introducing a `quantifier` symbol.
- Corrects productions such that alternation now builds from concatenation.
- Corrects serialization of alternation ASTs.

Fixes previously unknown bug:
- Expressions such as `a|\d+` or `abc|[def]` would previously fail as the alternations production was only using `literal` on the RHS.
- We now use `quantifier` on the RHS to ensure all types of patterns can be used on the RHS of concatenations (fix is applied to concatenations not alternations as the order of operations is now flipped).

# Validation Performed
- Updated existing unit-tests with new alternation AST serialization.
- Created new unit-tests for testing various regex orders of operations by inspecting the resulting AST.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized regex parsing grammar structure for improved clarity and maintainability.

* **Tests**
  * Enhanced test coverage with new cases validating operator precedence and grouping in regex expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->