### PR TITLE
feat: Improve regex schema shorthand support (fixes #182):

### DIFF
--- a/src/log_surgeon/Constants.hpp
+++ b/src/log_surgeon/Constants.hpp
@@ -11,7 +11,7 @@ constexpr uint32_t cSizeOfUnicode = cUnicodeMax + 1;
 constexpr uint32_t cSizeOfByte = 256;
 constexpr uint32_t cNullSymbol = 10'000'000;
 constexpr std::pair<uint32_t, uint32_t> cPrintableAsciiRange{32, 125};
-constexpr std::array<uint32_t, 5> cControlWhitespaceChars{'\t', '\n', '\r', '\f', '\v'};
+constexpr std::array<uint32_t, 5> cControlWhiteSpaceChars{'\t', '\n', '\r', '\f', '\v'};
 
 enum class ErrorCode {
     Success,

--- a/src/log_surgeon/SchemaParser.cpp
+++ b/src/log_surgeon/SchemaParser.cpp
@@ -13,6 +13,7 @@
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 #include <log_surgeon/Constants.hpp>
 #include <log_surgeon/FileReader.hpp>
@@ -52,6 +53,7 @@ using std::make_unique;
 using std::string;
 using std::string_view;
 using std::unique_ptr;
+using std::vector;
 
 namespace log_surgeon {
 SchemaParser::SchemaParser() {
@@ -408,7 +410,13 @@ static auto regex_newline_rule(NonTerminal* /* m */) -> unique_ptr<ParserAST> {
 }
 
 static auto make_white_space_group() -> unique_ptr<RegexASTGroupByte> {
-    return make_unique<RegexASTGroupByte>(RegexASTGroupByte({' ', '\t', '\r', '\n', '\v', '\f'}));
+    vector<uint32_t> white_space_chars{' '};
+    white_space_chars.insert(
+            white_space_chars.end(),
+            cControlWhiteSpaceChars.begin(),
+            cControlWhiteSpaceChars.end()
+    );
+    return make_unique<RegexASTGroupByte>(RegexASTGroupByte(white_space_chars));
 }
 
 static auto regex_white_space_rule(NonTerminal* /* m */) -> unique_ptr<ParserAST> {

--- a/src/log_surgeon/finite_automata/RegexAST.hpp
+++ b/src/log_surgeon/finite_automata/RegexAST.hpp
@@ -1179,9 +1179,9 @@ template <typename TypedNfaState>
             }
         };
 
-        std::set<uint32_t> const control_whitespace_set{
-                cControlWhitespaceChars.begin(),
-                cControlWhitespaceChars.end()
+        std::set<uint32_t> const control_white_space_set{
+                cControlWhiteSpaceChars.begin(),
+                cControlWhiteSpaceChars.end()
         };
 
         auto const transformed_ranges
@@ -1189,17 +1189,17 @@ template <typename TypedNfaState>
                   | std::ranges::views::transform([&](std::pair<uint32_t, uint32_t> const& range) {
                         auto const [begin, end]{range};
 
-                        auto begin_esc{control_whitespace_set.contains(begin) ? U"\\" : U""};
-                        auto end_esc{control_whitespace_set.contains(end) ? U"\\" : U""};
+                        auto begin_esc{control_white_space_set.contains(begin) ? U"\\" : U""};
+                        auto end_esc{control_white_space_set.contains(end) ? U"\\" : U""};
                         auto const begin_printable{
                                 (cPrintableAsciiRange.first <= begin
                                 && cPrintableAsciiRange.second >= begin)
-                                || control_whitespace_set.contains(begin)
+                                || control_white_space_set.contains(begin)
                         };
                         auto const end_printable{
                                 (cPrintableAsciiRange.first <= end
                                 && cPrintableAsciiRange.second >= end)
-                                || control_whitespace_set.contains(end)
+                                || control_white_space_set.contains(end)
                         };
 
                         if (begin == end) {

--- a/tests/test-regex-ast.cpp
+++ b/tests/test-regex-ast.cpp
@@ -198,10 +198,10 @@ TEST_CASE("regex_shorthands", "[Regex]") {
     test_regex_ast("var:[1\\D]", UR"([1,\u0-\u47,\u58-\u1114111])");
     test_regex_ast("var:[\\D1]", UR"([\u0-\u47,\u58-\u1114111,1])");
 
-    test_regex_ast("var:\\s", UR"([ ,\t,\r,\n,\v,\f])");
-    test_regex_ast("var:[\\s]", UR"([ ,\t,\r,\n,\v,\f])");
-    test_regex_ast("var:[a-z\\s]", UR"([a-z, ,\t,\r,\n,\v,\f])");
-    test_regex_ast("var:[\\sa-z]", UR"([ ,\t,\r,\n,\v,\f,a-z])");
+    test_regex_ast("var:\\s", UR"([ ,\t,\n,\r,\f,\v])");
+    test_regex_ast("var:[\\s]", UR"([ ,\t,\n,\r,\f,\v])");
+    test_regex_ast("var:[a-z\\s]", UR"([a-z, ,\t,\n,\r,\f,\v])");
+    test_regex_ast("var:[\\sa-z]", UR"([ ,\t,\n,\r,\f,\v,a-z])");
     test_regex_ast("var:\\S", UR"([\u0-\u8,\u14-\u31,\u33-\u1114111])");
     test_regex_ast("var:[\\S]", UR"([\u0-\u8,\u14-\u31,\u33-\u1114111])");
     test_regex_ast("var:[\\t\\S]", UR"([\t,\u0-\u8,\u14-\u31,\u33-\u1114111])");


### PR DESCRIPTION
- Add regex shorthands for `\w`, `\D`, `\S`, and `\W`.
- Add `?` multiplication regex.
- Handle negative shorthands in `RegexASTGroup`.
- Serialize whitespace characters in `RegexASTGroup`. 

# Reference
Addresses issue #182.

# Description
Regex updates:
- Adds `\w` to refer to word (i.e., string containing 0-9, a-z, A-Z, or _).
- Adds using capitalization as a complementary set.
  - \D is any non-digit.
  - \S is any non-whitespace character
  - \W is any non-word.
- Adds `?` regex to indicate a {0,1} multiplication.

`RegexASTGroup` handling negative shortands:
- The constructor from a single group now takes the negate field of that group and use all ranges.
- The constructor from 2 groups now uses all the ranges from the RHS.
- These constructors now enforce the requirements by throwing instead of asserting.

`RegexASTGroup` serialization updates:
- Display non-printable whitespace characters '\t', '\n', '\r', '\v', and '\f'.
- Display other non-printable characters as \x<ascii-code>.
- For single characters ranges, such as `\t-\t`, serialize it as just '\t'.

# Verification Performed
- Add unit-test for creating an AST with every supported shorthand and every supported multiplication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for regex shorthands: \d, \D, \s, \S, \w, \W (including bracketed and negated forms).
  * Public ability to negate character groups.

* **Behavior Changes**
  * Expanded quantifier support: ?, *, + with refined grouping and shorthand integration.
  * Improved character-class serialization with clearer escaping and comma-separated ranges.

* **Bug Fixes**
  * Stricter runtime validations for group construction.

* **Tests**
  * New unit tests covering shorthands, quantifiers and serialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->